### PR TITLE
Added GitHub workflow to build and test Go code.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,85 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build and Test
+
+on: ["push"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1.19", "1.20"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.version }}
+          cache: true
+
+      - name: Cache linter
+        uses: actions/cache@v3
+        with:
+          path: ~/go/bin/golangci-lint
+          key: golangci-lint-v1.51.0
+
+      - name: Cache protoc-gen-go
+        uses: actions/cache@v3
+        with:
+          path: ~/go/bin/protoc-gen-go
+          key: protoc-gen-go-v1.26
+
+      - name: Cache addlicense
+        uses: actions/cache@v3
+        with:
+          path: ~/go/bin/addlicense
+          key: addlicense-v1.1.1
+
+      - name: Install linter
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
+
+      - name: Install protoc
+        run: sudo apt install -y protobuf-compiler
+
+      - name: Install protoc-gen-go
+        run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
+
+      - name: Install addlicense
+        run: go install github.com/google/addlicense@v1.1.1
+
+      - name: Tidy
+        run: ./dev/allmodules tidy
+
+      - name: Generate
+        run: ./dev/allmodules generate
+
+      - name: Build
+        run: ./dev/allmodules build
+
+      - name: Vet
+        run: ./dev/allmodules vet
+
+      - name: Lint
+        run: ./dev/allmodules lint
+
+      - name: Test
+        run: ./dev/allmodules test
+
+      - name: Test Race
+        run: ./dev/allmodules testrace

--- a/dev/allmodules
+++ b/dev/allmodules
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Run various build steps on every Go module
 #

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/ServiceWeaver/weaver/examples
 
-go 1.18
+go 1.19
 
 replace github.com/ServiceWeaver/weaver => ../
 


### PR DESCRIPTION
This CL adds a GitHub workflow [1] that builds and tests our code every time it is pushed. I mostly copied the instructions in [2] and made some slight modifications.

Some interesting features:

- We build and test with three go versions: 1.18, 1.19, and 1.20.
- We cache golangci-lint, so it installs very quickly.

[1]: https://docs.github.com/en/actions
[2]: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go