### PR TITLE
Added a skeleton blog to the website.

### DIFF
--- a/dev/docgen/docgen.go
+++ b/dev/docgen/docgen.go
@@ -39,6 +39,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/styles"
@@ -48,8 +49,14 @@ import (
 )
 
 var files = []file{
-	{dst: "index.html", html: "index.html", template: "home.html", title: "Service Weaver", license: true},
+	{dst: "index.html", html: "index.html", template: "basic.html", title: "Service Weaver", license: true},
 	{dst: "docs.html", markdown: "docs.md", template: "guide.html", license: true},
+
+	{dst: "blog/index.html", html: "blog/index.html", template: "basic.html", license: true},
+	{dst: "blog/hello_world.html", markdown: "blog/hello_world.md", template: "basic.html", license: true},
+	{dst: "blog/deployers.html", markdown: "blog/deployers.md", template: "basic.html", license: true},
+
+	staticFile("assets/css/blog.css"),
 	staticFile("assets/css/common.css"),
 	staticFile("assets/css/guide.css"),
 	staticFile("assets/css/home.css"),
@@ -102,7 +109,10 @@ func main() {
 }
 
 func build(dstDir, templateGlob string, files []file) error {
-	t, err := template.ParseGlob(templateGlob)
+	t, err := template.
+		New("docgen").
+		Funcs(template.FuncMap{"prefix": strings.HasPrefix}).
+		ParseGlob(templateGlob)
 	if err != nil {
 		return err
 	}

--- a/godeps.txt
+++ b/godeps.txt
@@ -71,6 +71,7 @@ github.com/ServiceWeaver/weaver/dev/docgen
     os/exec
     path/filepath
     regexp
+    strings
 github.com/ServiceWeaver/weaver/internal/babysitter
     context
     crypto/sha256

--- a/website/README.md
+++ b/website/README.md
@@ -23,3 +23,10 @@ And to preview the resulting structure:
 | public       | Generated website (DO NOT EDIT!) |
 | templates    | Go templates that define generated document structure |
 
+## Adding a Blog Post
+
+To add a blog post:
+
+1. Write the blog as a markdown file in `blog/`.
+2. Update `blog/index.html` with a link to the blog.
+2. Update `dev/docgen/docgen.go` with the markdown file.

--- a/website/assets/css/blog.css
+++ b/website/assets/css/blog.css
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.blog-listing {
+  margin-bottom: 12pt;
+}
+
+.blog-title {
+  font-size: 16pt;
+}
+
+.blog-date {
+  color: gray;
+}
+
+.blog-author {
+  font-style: italic;
+}

--- a/website/blog/deployers.md
+++ b/website/blog/deployers.md
@@ -1,0 +1,9 @@
+# Hello, World!
+
+*Alonzo Church*
+
+*February 7, 2023*
+
+## Introduction
+
+In this article, we show you how to implement deployers.

--- a/website/blog/hello_world.md
+++ b/website/blog/hello_world.md
@@ -1,0 +1,9 @@
+# Hello, World!
+
+*Alan Turing*
+
+*February 7, 2023*
+
+## Introduction
+
+This is a blog post.

--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -1,0 +1,35 @@
+<!--
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- TODO: Avoid boilerplate. -->
+<!-- TODO: Remove these fake blogs. -->
+<div class="blog-listing">
+  <div>
+    <a class="blog-title" href="deployers.html">Implementing a Deployer</a>
+    <span class="blog-date">February 7, 2023</span>
+  </div>
+  <div class="blog-author">Alonzo Church</div>
+  <div>How to implement a Service Weaver deployer</div>
+</div>
+
+<div class="blog-listing">
+  <div>
+    <a class="blog-title" href="hello_world.html">Hello, World!</a>
+    <span class="blog-date">February 7, 2023</span>
+  </div>
+  <div class="blog-author">Alan Turing</div>
+  <div>The first blog post!</div>
+</div>

--- a/website/templates/basic.html
+++ b/website/templates/basic.html
@@ -20,8 +20,9 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1">
     <title>{{.Title}}</title>
     <!-- <meta http-equiv="refresh" content="1"> -->
-    <link rel="stylesheet" href="assets/css/common.css">
-    <link rel="stylesheet" href="assets/css/home.css">
+    <link rel="stylesheet" href="/assets/css/common.css">
+    <link rel="stylesheet" href="/assets/css/home.css">
+    <link rel="stylesheet" href="/assets/css/blog.css">
   </head>
   <body>
     <div class="page">

--- a/website/templates/guide.html
+++ b/website/templates/guide.html
@@ -20,8 +20,8 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1">
     <title>Service Weaver User Guide</title>
     <!-- <meta http-equiv="refresh" content="1"> -->
-    <link rel="stylesheet" href="assets/css/common.css">
-    <link rel="stylesheet" href="assets/css/guide.css">
+    <link rel="stylesheet" href="/assets/css/common.css">
+    <link rel="stylesheet" href="/assets/css/guide.css">
   </head>
   <body>
     <div class="page">
@@ -36,6 +36,6 @@
       </div>
     </div>
   </body>
-  <script src="assets/js/toc.js"></script>
-  <script src="assets/js/copy.js"></script>
+  <script src="/assets/js/toc.js"></script>
+  <script src="/assets/js/copy.js"></script>
 </html>

--- a/website/templates/header.html
+++ b/website/templates/header.html
@@ -16,16 +16,17 @@
 
 <header>
   <div class="header-menu">
-    <a href="./" class="logo">
+    <a href="/" class="logo">
       <span>Service Weaver</span>
     </a>
     <ul>
-      <li><a href="./" class="{{if eq .Path "index.html"}}active{{end}}">Home</a></li>
-      <li><a href="./docs.html" class="{{if eq .Path "docs.html"}}active{{end}}">Docs</a></li>
+      <li><a href="/" class="{{if eq .Path "index.html"}}active{{end}}">Home</a></li>
+      <li><a href="/docs.html" class="{{if eq .Path "docs.html"}}active{{end}}">Docs</a></li>
+      <li><a href="/blog" class="{{if prefix .Path "blog/"}}active{{end}}">Blog</a></li>
       <li><a href="/yyy" class="{{if eq .Path "TODO"}}active{{end}}">API</a></li>
     </ul>
   </div>
   <a class="icon" href="https://github.com/TODO">
-    <img src="assets/images/github_logo.svg" alt="GitHub">
+    <img src="/assets/images/github_logo.svg" alt="GitHub">
   </a>
 </header>


### PR DESCRIPTION
This PR adds a very, very minimal blog section to the website. For now, it contains two fake blogs just to exercise the code. I took a lot of inspiration from [Go's blog][1].

For now, there's a lot of boilerplate and repetition in writing blogs. We could augment `docgen.go` to automate some of this, similar to [what Jekyll has][2]. But, since I don't anticipate us writing a ton of blog posts really quickly, I'll defer this until we actually need it.

[1]: https://go.dev/blog/all
[2]: https://jekyllrb.com/docs/step-by-step/08-blogging/