### PR TITLE
Added section headers to table of contents.

### DIFF
--- a/website/assets/css/guide.css
+++ b/website/assets/css/guide.css
@@ -93,6 +93,13 @@
 .toc .toc-active {
   color: #e84393;
 }
+.toc-section {
+  font-weight: 400;
+  color: #e74c3c;
+}
+.toc-section:nth-child(n+2) {
+  padding-top: 12pt;
+}
 
 .contents {
   flex: 1 0 auto;

--- a/website/assets/js/toc.js
+++ b/website/assets/js/toc.js
@@ -31,6 +31,13 @@ init_toc();
 bind();
 
 function init_toc() {
+  const sections = {
+    'what-is-service-weaver': 'OVERVIEW',
+    'components': 'FUNDAMENTALS',
+    'single-process': 'DEPLOYERS',
+    'serializable-types': 'REFERENCE',
+  }
+
   // Process all headings.
   let hs = document.querySelectorAll('h1, h2');
   const toc_list = document.createElement('ul');
@@ -59,6 +66,12 @@ function init_toc() {
     toc_entries.set(h, item);
     if (h.tagName == 'H1') {
       children.set(h, []);
+      if (id in sections) {
+        const section = document.createElement('li');
+        section.innerText = sections[id];
+        section.classList.add('toc-section');
+        toc_list.appendChild(section);
+      }
       toc_list.appendChild(item);
       current_h1 = h;
       current_h1_list = null;


### PR DESCRIPTION
This PR adds section headers to the table of contents on the left side of the user guide on the website. The section headers help divide the long list of sections into OVERVIEW, FUNDAMENTALS, DEPLOYERS, and REFERENCE.

![C57kuzxuwxRgEoH](https://user-images.githubusercontent.com/3654277/217663684-9a54a35a-3a47-46bf-bf89-4254f0dbf8b5.png)