### PR TITLE
Switched from pink code to GitHub-style gray code.

### DIFF
--- a/website/assets/css/common.css
+++ b/website/assets/css/common.css
@@ -31,16 +31,12 @@ pre {
   padding: 1ch;
 }
 
-code {
-  color: #d63384;
-}
-
-pre code {
-  color: inherit;
-}
-
-a code {
-  color: inherit;
+:not(pre) > code {
+  padding: 0.2em 0.4em;
+  margin: 0;
+  white-space: break-spaces;
+  background-color: rgba(175,184,193,0.2);
+  border-radius: 6px;
 }
 
 /* Limit the page content width to keep lines readable. */


### PR DESCRIPTION
Before this PR, `<code>` elements on the website were rendered in pink. This PR changes `<code>` to be rendered in gray boxes, similar to how GitHub renders markdown.

![BQeymvngbccQ2Xw](https://user-images.githubusercontent.com/3654277/217685742-fbb733da-b570-4acc-b590-6a88e9faec09.png)