### PR TITLE
Made website more tutorial-like.

### DIFF
--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -1,5 +1,9 @@
 # Hello
 
-This directory contains the "Hello, World!" application from the Getting Started
-section of the Service Weaver documentation. To run the application, run `go run .`.
-Then, curl the `/hello` endpoint, like `curl localhost:12345/hello?name=Alice`.
+This directory contains the "Hello, World!" application from the ["Step by Step
+Tutorial"][tutorial] section of the [Service Weaver documentation][docs]. To run
+the application, run `go run .`.  Then, curl the `/hello` endpoint (e.g., `curl
+localhost:12345/hello?name=Alice`).
+
+[docs]: https://serviceweaver.dev/docs.html
+[tutorial]: https://serviceweaver.dev/docs.html#step-by-step-tutorial


### PR DESCRIPTION
This PR makes the website more tutorial-like, in the sense that it should be easy for people to follow along a given section from top to bottom.

Specifically, I revamped all OVERVIEW and FUNDAMENTALS sections.

- I mentioned that Go 1.18+ needs to be installed.
- I renamed "Getting Started" to "Step by Step Tutorial", inspired by https://jekyllrb.com.
- I added links to the example source code.
- I expanded code snippets to be more stand alone.
- I avoided back referencing to the "Step by Step Tutorial" section unless needed.
- I added a Config subsection to the Components section.
- I fixed various stale things.

In a future PR, I'll update the DEPLOYERS sections to be more standalone as well.