### PR TITLE
Error out for generics with emebedded automarshal.

### DIFF
--- a/internal/tool/generate/testdata/errors/generic_automarshaler.go
+++ b/internal/tool/generate/testdata/errors/generic_automarshaler.go
@@ -12,22 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ERROR: not serializable
+// ERROR: cannot embed weaver.AutoMarshal
 package foo
 
-import (
-	"context"
-
-	"github.com/ServiceWeaver/weaver"
-)
+import "github.com/ServiceWeaver/weaver"
 
 type option[T any] struct {
+	x int
 	weaver.AutoMarshal
-	x T
+	y bool
 }
-
-type Foo interface {
-	M(context.Context, option[int]) error
-}
-
-type foo struct{ weaver.Implements[Foo] }


### PR DESCRIPTION
Recall that named structs are not serializable by default. Instead, developers can embed `weaver.AutoMarshal` inside a struct to indicate that `weaver generate` should generate serialization code for it. For example:

```go
type Pair struct {
    weaver.AutoMarshal
    x int
    y int
}
```

Also recall that `weaver.AutoMarshal` does not work with generic types. See `generator.go` for details.

Before this PR, `weaver generate` would ignore `weaver.AutoMarshal`s embedded in generic structs. This silent ignoring was not user friendly. This PR changes `weaver generate` to error out when it encounters a `weaver.AutoMarshal` embedded in a generic struct.