### PR TITLE
Polished "weaver generator" output.

### DIFF
--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -68,7 +68,7 @@ func main() {
 		}
 		generateFlags.Parse(flag.Args()[1:])
 		if err := generate.Generate(".", flag.Args()[1:]); err != nil {
-			fmt.Fprintln(os.Stderr, err)
+			fmt.Fprint(os.Stderr, err)
 			os.Exit(1)
 		}
 		return

--- a/godeps.txt
+++ b/godeps.txt
@@ -243,6 +243,7 @@ github.com/ServiceWeaver/weaver/internal/tool/generate
     crypto/sha256
     fmt
     github.com/ServiceWeaver/weaver/internal/files
+    github.com/ServiceWeaver/weaver/runtime/colors
     go/ast
     go/format
     go/parser


### PR DESCRIPTION
This PR polishes `weaver generate` output in two ways. First, it abbreviates filenames in error messages. Before, we were printing absolute paths, and (for me, at least) the paths were taking up 100+ characters, making almost every error message span multiple lines on my terminal. This PR relativizes the paths to the current working directory, shortening them quite a bit.

Second, I colored the paths red. I think it makes the errors a bit easier to parse, but happy to revert the change if others disagree.

![colored_errors](https://user-images.githubusercontent.com/3654277/217968986-d009d302-2df0-4aca-b23f-c37be30b19c9.png)