### PR TITLE
Added --watch flag to docgen.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -60,9 +60,11 @@ github.com/ServiceWeaver/weaver/cmd/weaver
     strings
 github.com/ServiceWeaver/weaver/dev/docgen
     bytes
+    flag
     fmt
     github.com/alecthomas/chroma/v2
     github.com/alecthomas/chroma/v2/styles
+    github.com/fsnotify/fsnotify
     github.com/yuin/goldmark
     github.com/yuin/goldmark-highlighting/v2
     github.com/yuin/goldmark/extension

--- a/website/README.md
+++ b/website/README.md
@@ -13,6 +13,9 @@ And to preview the resulting structure:
 (cd website/public && python3 -m http.server)
 ```
 
+You can also run `go run dev/docgen/docgen.go --watch` to automatically rebuild
+the website whenever the source files change.
+
 ## Directory structure
 
 | Name         | Description |


### PR DESCRIPTION
This PR adds a `--watch` flag to the website generator. When the `--watch` flag is provided, the generator automatically rebuilds the website whenever the source files are changed. This makes it much much more convenient to the edit the website and see your changes. Before this PR, you had to rerun the generator every time you made a change.