### PR TITLE
Added prototype of "weaver metrics" command.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -223,6 +223,8 @@ github.com/ServiceWeaver/weaver/internal/status
     github.com/ServiceWeaver/weaver/runtime/tool
     github.com/google/pprof/profile
     github.com/pkg/browser
+    golang.org/x/exp/maps
+    golang.org/x/exp/slices
     google.golang.org/protobuf/reflect/protoreflect
     google.golang.org/protobuf/runtime/protoimpl
     google.golang.org/protobuf/types/known/timestamppb

--- a/internal/status/metrics.go
+++ b/internal/status/metrics.go
@@ -1,0 +1,200 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/ServiceWeaver/weaver/runtime/colors"
+	"github.com/ServiceWeaver/weaver/runtime/logging"
+	"github.com/ServiceWeaver/weaver/runtime/protos"
+	dtool "github.com/ServiceWeaver/weaver/runtime/tool"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+// MetricsCommand returns a "metrics" subcommand that pretty prints the metrics
+// of all active applications registered with the provided registry. tool is
+// the name of the command-line tool the returned subcommand runs as (e.g.,
+// "weaver single").
+func MetricsCommand(tool string, registry func(context.Context) (*Registry, error)) *dtool.Command {
+	return &dtool.Command{
+		Name:        "metrics",
+		Description: "Show application metrics",
+		Help: fmt.Sprintf(`Usage:
+  %s metrics [metric]...
+
+Flags:
+  -h, --help	Print this help message.`, tool),
+		Flags: flag.NewFlagSet("metrics", flag.ContinueOnError),
+		Fn: func(ctx context.Context, args []string) error {
+			r, err := registry(ctx)
+			if err != nil {
+				return err
+			}
+			regs, err := r.List(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Only show the metrics provided on the command line, or if there
+			// are no command line arguments, show all metrics.
+			filters := map[string]bool{}
+			for _, arg := range args {
+				filters[arg] = true
+			}
+
+			var metrics []*protos.MetricSnapshot
+			for _, reg := range regs {
+				reply, err := NewClient(reg.Addr).Metrics(ctx)
+				if err != nil {
+					return err
+				}
+				for _, metric := range reply.Metrics {
+					if len(filters) == 0 || filters[metric.Name] {
+						metrics = append(metrics, metric)
+					}
+				}
+			}
+			formatMetrics(metrics)
+			return nil
+		},
+	}
+}
+
+// formatMetrics pretty prints metrics to stdout.
+func formatMetrics(metrics []*protos.MetricSnapshot) {
+	// Group metrics by name.
+	grouped := map[string][]*protos.MetricSnapshot{}
+	for _, metric := range metrics {
+		if strings.HasPrefix(metric.Name, "serviceweaver_system") {
+			// Ignore Service Weaver internal metrics.
+			continue
+		}
+		grouped[metric.Name] = append(grouped[metric.Name], metric)
+	}
+
+	// Sort metrics by name, sorting internal metrics after user metrics.
+	names := maps.Keys(grouped)
+	internal := func(name string) bool {
+		return strings.HasPrefix(name, "serviceweaver")
+	}
+	sort.Slice(names, func(i, j int) bool {
+		ni, nj := names[i], names[j]
+		switch {
+		case internal(ni) && !internal(nj):
+			return false
+		case !internal(ni) && internal(nj):
+			return true
+		case internal(ni) && internal(nj), !internal(ni) && !internal(nj):
+			return ni < nj
+		}
+		return false
+	})
+	groups := make([][]*protos.MetricSnapshot, 0, len(names))
+	for _, name := range names {
+		groups = append(groups, grouped[name])
+	}
+
+	// Sort each metric by label.
+	sortedValues := func(m map[string]string) []string {
+		keys := maps.Keys(m)
+		sort.Strings(keys)
+		values := make([]string, len(keys))
+		for i, key := range keys {
+			values[i] = m[key]
+		}
+		return values
+	}
+	for _, group := range groups {
+		sort.Slice(group, func(i, j int) bool {
+			li, lj := group[i].Labels, group[j].Labels
+			return slices.Compare(sortedValues(li), sortedValues(lj)) < 0
+		})
+	}
+
+	// Pretty print the metrics.
+	for _, group := range groups {
+		name := group[0].Name
+		typ := group[0].Typ
+		help := group[0].Help
+		keys := maps.Keys(group[0].Labels)
+		sort.Strings(keys)
+
+		title := []colors.Text{
+			{
+				{S: fmt.Sprintf("// %s", help), Color: colors.Color256(249)},
+			},
+			{
+				{S: name, Color: colors.Color256(141), Bold: true},
+				{S: ": "},
+				{S: fmt.Sprint(typ), Color: colors.Color256(214)},
+			},
+		}
+		t := colors.NewTabularizer(os.Stdout, title, colors.NoDim)
+
+		// Write the header.
+		var header []any
+		for _, key := range keys {
+			header = append(header, key)
+		}
+		if typ == protos.MetricType_HISTOGRAM {
+			header = append(header, "Average")
+		} else {
+			header = append(header, "Value")
+		}
+		t.Row(header...)
+
+		// Write the rows.
+		dim := colors.Color256(245)
+		for _, m := range group {
+			var row []any
+			for _, key := range keys {
+				entry := colors.Atom{S: m.Labels[key]}
+
+				// Abbreviate long labels.
+				switch {
+				case internal(name) && key == "component":
+					entry.S = logging.ShortenComponent(entry.S)
+				case key == "serviceweaver_node":
+					entry.S = logging.Shorten(entry.S)
+				case key == "serviceweaver_version":
+					entry.Color = colors.ColorHash(entry.S)
+					entry.S = logging.Shorten(entry.S)
+					entry.Underline = true
+				}
+
+				// Dim zero-valued metrics.
+				if m.Value == 0 {
+					entry.Color = dim
+				}
+
+				row = append(row, entry)
+			}
+			entry := colors.Atom{S: fmt.Sprint(m.Value)}
+			if m.Value == 0 {
+				entry.Color = dim
+			}
+			row = append(row, entry)
+			t.Row(row...)
+		}
+		t.Flush()
+	}
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -95,7 +95,8 @@ func formatId(id string) (prefix, suffix colors.Atom) {
 
 // formatDeployments pretty-prints the set of deployments.
 func formatDeployments(w io.Writer, statuses []*Status) {
-	t := colors.NewTabularizer(w, colors.Atom{S: "DEPLOYMENTS", Bold: true}, colors.PrefixDim)
+	title := []colors.Text{{{S: "DEPLOYMENTS", Bold: true}}}
+	t := colors.NewTabularizer(w, title, colors.PrefixDim)
 	defer t.Flush()
 	t.Row("APP", "DEPLOYMENT", "AGE")
 	for _, status := range statuses {
@@ -107,7 +108,8 @@ func formatDeployments(w io.Writer, statuses []*Status) {
 
 // formatDeployments pretty-prints the set of components.
 func formatComponents(w io.Writer, statuses []*Status) {
-	t := colors.NewTabularizer(w, colors.Atom{S: "COMPONENTS", Bold: true}, colors.PrefixDim)
+	title := []colors.Text{{{S: "COMPONENTS", Bold: true}}}
+	t := colors.NewTabularizer(w, title, colors.PrefixDim)
 	defer t.Flush()
 	t.Row("APP", "DEPLOYMENT", "COMPONENT", "REPLICA PIDS")
 	for _, status := range statuses {
@@ -131,7 +133,8 @@ func formatComponents(w io.Writer, statuses []*Status) {
 
 // formatDeployments pretty-prints the set of listeners.
 func formatListeners(w io.Writer, statuses []*Status) {
-	t := colors.NewTabularizer(w, colors.Atom{S: "LISTENERS", Bold: true}, colors.PrefixDim)
+	title := []colors.Text{{{S: "LISTENERS", Bold: true}}}
+	t := colors.NewTabularizer(w, title, colors.PrefixDim)
 	defer t.Flush()
 	t.Row("APP", "DEPLOYMENT", "LISTENER", "ADDRESS")
 	for _, status := range statuses {

--- a/internal/tool/multi/multi.go
+++ b/internal/tool/multi/multi.go
@@ -51,6 +51,7 @@ var (
 		}),
 		"dashboard": status.DashboardCommand(dashboardSpec),
 		"status":    status.StatusCommand("weaver multi", defaultRegistry),
+		"metrics":   status.MetricsCommand("weaver multi", defaultRegistry),
 		"profile":   status.ProfileCommand("weaver multi", defaultRegistry),
 	}
 )

--- a/internal/tool/single/single.go
+++ b/internal/tool/single/single.go
@@ -38,6 +38,7 @@ var (
 	Commands = map[string]*tool.Command{
 		"status":    status.StatusCommand("weaver single", defaultRegistry),
 		"dashboard": status.DashboardCommand(dashboardSpec),
+		"metrics":   status.MetricsCommand("weaver single", defaultRegistry),
 		"profile":   status.ProfileCommand("weaver single", defaultRegistry),
 	}
 )

--- a/runtime/colors/tabularizer_test.go
+++ b/runtime/colors/tabularizer_test.go
@@ -24,7 +24,11 @@ func TestTabularizer(t *testing.T) {
 	blue := Color256(27)
 	green := Color256(40)
 
-	tab := NewTabularizer(os.Stdout, Atom{S: "CATS", Bold: true}, NoDim)
+	title := []Text{
+		{{S: "CATS", Bold: true}},
+		{{S: "felis catus", Color: Color256(254)}},
+	}
+	tab := NewTabularizer(os.Stdout, title, NoDim)
 	defer tab.Flush()
 	tab.Row("NAME", "AGE", "COLOR")
 	tab.Row("belle", "1y", Atom{S: "tortie", Color: red})


### PR DESCRIPTION
This PR introduces `weaver single metrics` and `weaver multi metrics` commands that pretty print the current value of all metrics.

![metrics](https://user-images.githubusercontent.com/3654277/218223755-6c9bd1c0-8199-460f-a495-77ac9c2aa657.png)

## Motivation

Currently, we don't have a convenient way to view the metrics of a singleprocess or multiprocess app. You have to run `weaver dashboard` and go to the `/metrics` page. This page exports metrics in prometheus format, which is not intended to be read by humans. Good luck reading this:

    # HELP serviceweaver_http_request_bytes_received Number of bytes received by HTTP request handlers
    # TYPE serviceweaver_http_request_bytes_received histogram
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="1"} 0
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="2"} 0
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="5"} 0
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="10"} 0
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="20"} 0
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="50"} 0
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="100"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="200"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="500"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="1000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="2000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="5000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="10000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="20000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="50000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="100000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="200000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="500000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="1000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="2000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="5000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="10000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="20000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="50000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="100000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="200000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="500000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="1000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="2000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="5000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="10000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="20000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="50000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="100000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="200000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="500000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="1000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="2000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="5000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="10000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="20000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="50000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="100000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="200000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="500000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="1000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="2000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="5000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="10000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="20000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="50000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="100000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="200000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="500000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="1000000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="2000000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="5000000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="10000000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="20000000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="50000000000000000000"} 5
    serviceweaver_http_request_bytes_received_bucket{host="localhost:9000",label="collatz",serviceweaver_node="66263124",le="+Inf"} 5
    serviceweaver_http_request_bytes_received_sum{host="localhost:9000",label="collatz",serviceweaver_node="66263124"} 445
    serviceweaver_http_request_bytes_received_count{host="localhost:9000",label="collatz",serviceweaver_node="66263124"} 5

You can hook up the metrics to prometheus, but when tinkering with something locally or debugging something simple, this can be overkill.

This inspired me to add a `weaver metrics` command to make it easier to view metrics. The command is not perfect. In fact, it's arguably not that useful (there's no history, for example), but it is significantly better than the current prometheus formatted metrics.

## Details

This PR also fixes a bug in `singleprocess.go`. Recall that when metrics are exported over the pipe, the pipe injects three labels into every metric: the app name, the version id, and the weavelet id. For single process deployments, metrics do not traverse a pipe, and these labels were not being injected. This made single process metrics diverge from all other metrics. I changed `singleprocess.go` to also inject these metrics.