### PR TITLE
Fixed "weaver generate" varargs bug.

### DIFF
--- a/internal/tool/generate/testdata/varargs.go
+++ b/internal/tool/generate/testdata/varargs.go
@@ -1,0 +1,37 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package foo
+
+import (
+	"context"
+
+	"github.com/ServiceWeaver/weaver"
+)
+
+type foo interface {
+	A(context.Context, ...int) error
+	B(context.Context, bool, ...int) error
+	C(context.Context, bool, string, ...int) error
+	D(context.Context, bool, string, ...[]int) error
+}
+
+type impl struct {
+	weaver.Implements[foo]
+}
+
+func (l *impl) A(context.Context, ...int) error                 { return nil }
+func (l *impl) B(context.Context, bool, ...int) error           { return nil }
+func (l *impl) C(context.Context, bool, string, ...int) error   { return nil }
+func (l *impl) D(context.Context, bool, string, ...[]int) error { return nil }


### PR DESCRIPTION
Before this PR, `weaver generate` was not properly handling component methods with variadic arguments. For example:

```go
type MyComponent interface {
    Foo(context.Context, ...int) error
}
```

`weaver generate` would generate code that does not compile. Specifically, it was treating the variadic argument `...t` as a slice `[]t`. They're similar but not quite the same. This PR fixes the bug. `weaver generate` now handles variadic arguments correctly.