### PR TITLE
Attempted to fix conn_test.go flake.

### DIFF
--- a/internal/envelope/conn/conn_test.go
+++ b/internal/envelope/conn/conn_test.go
@@ -20,11 +20,11 @@ import (
 	sync "sync"
 	"testing"
 
-	"github.com/google/uuid"
-	"go.opentelemetry.io/otel/sdk/trace"
 	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
 	"github.com/ServiceWeaver/weaver/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/sdk/trace"
 )
 
 // We test the combination of conn, EnvelopeConn, WeaveletConn here.
@@ -92,7 +92,7 @@ func makeConnections(t *testing.T) *conn.EnvelopeConn {
 	go func() {
 		defer wait.Done()
 		err := e.Run()
-		if err != nil && !errors.Is(err, io.ErrClosedPipe) {
+		if err != nil && !errors.Is(err, io.ErrClosedPipe) && !errors.Is(err, io.EOF) {
 			t.Errorf("envelope failed: %v", err)
 		}
 	}()
@@ -102,7 +102,7 @@ func makeConnections(t *testing.T) *conn.EnvelopeConn {
 			t.Errorf("weavelet failed: %v", err)
 		}
 		err := d.Run()
-		if err != nil && !errors.Is(err, io.ErrClosedPipe) {
+		if err != nil && !errors.Is(err, io.ErrClosedPipe) && !errors.Is(err, io.EOF) {
 			t.Errorf("weavelet failed: %v", err)
 		}
 	}()


### PR DESCRIPTION
The `TestMetricPropagation` test inside `conn_test.go` was flaking on GitHub Actions (e.g., [1] and [2]). I wasn't able to reproduce the error locally, but looking through the code, I think I might understand the flake. This PR attempts to fix it.

`TestMetricPropagation` (and other similar tests) sets up an `EnvelopeConn` and a `WeaveletConn`. These two communicate over a set of OS pipes. They both repeatedly read a message from the pipe (blocking if needed), handle the message, and reply on the pipe.

At the end of the test, the pipes are closed. The tests were failing because the `Conn`s were receiving `io.EOF`s. Playing around with pipes, however, I think this is expected. If you block reading on a pipe and the other end of pipe is closed, you get an `io.EOF`. The tests were checking for `io.ErrClosedPipe`, but from my experimenting, it seems you get that error only when you close *your* end of the pipe, not the other end.

This PR checks for and ignores `io.EOF`s.

[1]: https://github.com/ServiceWeaver/weaver/actions/runs/4168933069
[2]: https://github.com/ServiceWeaver/weaver/actions/runs/4168814674