### PR TITLE
Added "weaver help" subcommand.

### DIFF
--- a/runtime/tool/command.go
+++ b/runtime/tool/command.go
@@ -45,7 +45,7 @@ func Run(tool string, commands map[string]*Command) {
 			Description: "Print help for a sub-command",
 			Fn: func(_ context.Context, args []string) error {
 				if len(args) == 0 {
-					fmt.Fprintln(os.Stderr, mainHelp(tool, commands))
+					fmt.Fprintln(os.Stderr, MainHelp(tool, commands))
 					return nil
 				}
 				if len(args) != 1 {
@@ -64,7 +64,7 @@ func Run(tool string, commands map[string]*Command) {
 	// Catch -h or --help.
 	flags := flag.NewFlagSet(tool, flag.ContinueOnError)
 	flags.Usage = func() {
-		fmt.Fprintln(os.Stderr, mainHelp(tool, commands))
+		fmt.Fprintln(os.Stderr, MainHelp(tool, commands))
 	}
 	if err := flags.Parse(os.Args[1:]); err == flag.ErrHelp {
 		os.Exit(0)
@@ -76,7 +76,7 @@ func Run(tool string, commands map[string]*Command) {
 	// Get sub-command.
 	cmd, ok := commands[flags.Arg(0)]
 	if !ok {
-		fmt.Fprintln(os.Stderr, mainHelp(tool, commands))
+		fmt.Fprintln(os.Stderr, MainHelp(tool, commands))
 		os.Exit(1)
 	}
 
@@ -103,7 +103,8 @@ func Run(tool string, commands map[string]*Command) {
 	}
 }
 
-func mainHelp(tool string, commands map[string]*Command) string {
+// MainHelp returns the help message for the provided set of commands.
+func MainHelp(tool string, commands map[string]*Command) string {
 	var sorted []string
 	for name, cmd := range commands {
 		if !cmd.Hidden {
@@ -131,6 +132,7 @@ Flags:
 Use "%s help <command>" for more information about a command.`, tool, cmds.String(), tool)
 }
 
+// commandHelp returns the help message for the provided command.
 func commandHelp(cmd *Command) string {
 	if cmd.Help == "" {
 		return cmd.Description


### PR DESCRIPTION
This PR adds a `weaver help` subcommand. For example, `weaver help generate` shows a help message for the `weaver generate command`. The help command takes one of the following forms:

    weaver help
    weaver help generate
    weaver help <single|multi|ssh>
    weaver help <single|multi|ssh> <subcommand>
    weaver help <external>

It does not handle more complex help queries like

    // Flags aren't supported.
    weaver help multi profile --type=cpu

    // Deeper nested subcommands aren't supported.
    weaver help multi store list

    // External subcommands aren't supported.
    weaver help gke profile

In the future, we can improve the help command to support these things if we find it useful.