### PR TITLE
Removed examples/ dependency on gorilla mux.

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
-	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/mattn/go-sqlite3 v1.14.16
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.39.0

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -31,8 +31,6 @@ github.com/google/pprof v0.0.0-20221010195024-131d412537ea h1:R3VfsTXMMK4JCWZDdx
 github.com/google/pprof v0.0.0-20221010195024-131d412537ea/go.mod h1:dDKJzRmX4S37WGHujM7tX//fmj1uioxKzKxz3lo4HJo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/lightstep/varopt v1.3.0 h1:H7OhtEBhYyDhoMu+wJGl4mTqM9TrYYdThG+xLGU3fZQ=


### PR DESCRIPTION
This PR removes the `examples/` directory's dependecy on the [gorilla mux module][1]. We replace `gorilla.Router` with `http.ServeMux`. The replacement is mostly straightforward, but there were two small hiccups:

1. Both a `gorilla.Router` and an `http.ServeMux` allow you to dispatch requests based on the path of the request (e.g., `"/"`, `"/foo"`). A `gorilla.Router` additionally allows you to dispatch based on the HTTP method (e.g., POST, GET). I implemented this logic manually (it's just a small helper function).
2. A `gorilla.Router` allows you to pattern match paths and extract components of them. Specifically, we had a `"/product/{id}"` pattern that extracted the id of a product. Again, I implemented this logic manually.

This PR is part of an effort to merge the examples module with the core weaver module without blowing up the number of dependencies.

[1]: https://github.com/gorilla/mux