### PR TITLE
Allow raw HTML in markdown for website.

### DIFF
--- a/dev/docgen/docgen.go
+++ b/dev/docgen/docgen.go
@@ -48,6 +48,7 @@ import (
 	"github.com/yuin/goldmark"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
 	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/renderer/html"
 )
 
 var watch = flag.Bool("watch", false, "Automatically rebuild website on change")
@@ -188,6 +189,8 @@ func build(dstDir, templateGlob string, files []file) error {
 			),
 			extension.Table,
 		),
+		// Render raw HTML tags.
+		goldmark.WithRendererOptions(html.WithUnsafe()),
 	)
 	for _, f := range files {
 		var err error


### PR DESCRIPTION
Recently, we've been writing blog posts. It's convenient to write them in markdown, but we sometimes need to add some custom styling. Allowing raw HTML in the markdown makes this possible. Jekyll supports this by default as well.