### PR TITLE
Added InstrumentHandlerFunc function.

### DIFF
--- a/examples/collatz/server.go
+++ b/examples/collatz/server.go
@@ -41,8 +41,8 @@ func newServer(root weaver.Instance) (*server, error) {
 		return nil, err
 	}
 	s := &server{root: root, odd: odd, even: even}
-	s.mux.Handle("/", weaver.InstrumentHandler("collatz", http.HandlerFunc(s.handle)))
-	s.mux.Handle("/healthz", weaver.InstrumentHandler("/healthz", http.HandlerFunc(s.handleHealthz)))
+	s.mux.Handle("/", weaver.InstrumentHandlerFunc("collatz", s.handle))
+	s.mux.Handle("/healthz", weaver.InstrumentHandlerFunc("/healthz", s.handleHealthz))
 	return s, nil
 }
 

--- a/examples/factors/server.go
+++ b/examples/factors/server.go
@@ -34,8 +34,8 @@ func serve(ctx context.Context, root weaver.Instance, addr string) error {
 	}
 
 	s := &server{factorer}
-	http.Handle("/", weaver.InstrumentHandler("/", http.HandlerFunc(s.handleFactors)))
-	http.Handle("/healthz", weaver.InstrumentHandler("/healthz", http.HandlerFunc(s.handleHealthz)))
+	http.Handle("/", weaver.InstrumentHandlerFunc("/", s.handleFactors))
+	http.Handle("/healthz", weaver.InstrumentHandlerFunc("/healthz", s.handleHealthz))
 
 	lis, err := root.Listener("factors", weaver.ListenerOptions{LocalAddress: addr})
 	if err != nil {

--- a/examples/onlineboutique/frontend/frontend.go
+++ b/examples/onlineboutique/frontend/frontend.go
@@ -171,7 +171,7 @@ func NewServer(root weaver.Instance) (*Server, error) {
 			}
 			fn(w, r)
 		}
-		return weaver.InstrumentHandler(label, http.HandlerFunc(handler))
+		return weaver.InstrumentHandlerFunc(label, handler)
 	}
 
 	const get = http.MethodGet

--- a/http.go
+++ b/http.go
@@ -100,6 +100,12 @@ func InstrumentHandler(label string, handler http.Handler) http.Handler {
 	})
 }
 
+// InstrumentHandlerFunc is identical to [InstrumentHandler] but takes a
+// function instead of an http.Handler.
+func InstrumentHandlerFunc(label string, f func(http.ResponseWriter, *http.Request)) http.Handler {
+	return InstrumentHandler(label, http.HandlerFunc(f))
+}
+
 // responseWriterInstrumenter is a wrapper around an http.ResponseWriter that
 // records the status code of the response.
 type responseWriterInstrumenter struct {

--- a/weavertest/internal/simple/simple_test.go
+++ b/weavertest/internal/simple/simple_test.go
@@ -141,9 +141,9 @@ func TestListener(t *testing.T) {
 			// Run server on listener.
 			const response = "hello world"
 			srv := &http.Server{
-				Handler: weaver.InstrumentHandler("test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Handler: weaver.InstrumentHandlerFunc("test", func(w http.ResponseWriter, r *http.Request) {
 					fmt.Fprint(w, response)
-				})),
+				}),
 			}
 			go srv.Serve(lis)
 			defer srv.Shutdown(ctx)


### PR DESCRIPTION
This PR adds an `InstrumentHandlerFunc` function that is pretty much identical to `InstrumentHandler`, but takes a `func(http.ResponseWriter, *http.Request)` instead of an `http.Handler`.