### PR TITLE
Added Google Analytics to website.

### DIFF
--- a/website/templates/analytics.html
+++ b/website/templates/analytics.html
@@ -1,0 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-GWZW7L8C6L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-GWZW7L8C6L');
+</script>

--- a/website/templates/basic.html
+++ b/website/templates/basic.html
@@ -16,6 +16,7 @@
 
 <html>
   <head>
+    {{template "analytics.html" .}}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1">
     <title>{{.Title}}</title>

--- a/website/templates/blog.html
+++ b/website/templates/blog.html
@@ -16,6 +16,7 @@
 
 <html>
   <head>
+    {{template "analytics.html" .}}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1">
     <title>{{.Title}}</title>

--- a/website/templates/guide.html
+++ b/website/templates/guide.html
@@ -17,6 +17,7 @@
 <html>
   <!--TODO(rgrandl): the top menu is changing the position when you click on the blog. Fix it -->
   <head>
+    {{template "analytics.html" .}}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1">
     <title>Service Weaver User Guide</title>


### PR DESCRIPTION
Google Analytics lets you track visits to your website. It lets you monitor things like the number of views every page is getting, how long people spend on each page, etc.

Mechanistically, you copy and paste a little snippet of javascript into your pages, and the code exports metrics to the Google Analytics service. This PR sets up Google Analytics for serviceweaver.dev.

In the future, we should disable metrics when viewing the website locally, but for now, they are always enabled.