### PR TITLE
Move the Perfetto code to runtime/, to make it accessible to deployers.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -19,6 +19,7 @@ github.com/ServiceWeaver/weaver
     github.com/ServiceWeaver/weaver/runtime/colors
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/metrics
+    github.com/ServiceWeaver/weaver/runtime/perfetto
     github.com/ServiceWeaver/weaver/runtime/protomsg
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/retry
@@ -328,11 +329,11 @@ github.com/ServiceWeaver/weaver/internal/babysitter
     github.com/ServiceWeaver/weaver/internal/net/call
     github.com/ServiceWeaver/weaver/internal/proxy
     github.com/ServiceWeaver/weaver/internal/status
-    github.com/ServiceWeaver/weaver/internal/traceio
     github.com/ServiceWeaver/weaver/internal/versioned
     github.com/ServiceWeaver/weaver/runtime/envelope
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/metrics
+    github.com/ServiceWeaver/weaver/runtime/perfetto
     github.com/ServiceWeaver/weaver/runtime/protomsg
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/retry
@@ -512,11 +513,11 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     fmt
     github.com/ServiceWeaver/weaver/internal/babysitter
     github.com/ServiceWeaver/weaver/internal/status
-    github.com/ServiceWeaver/weaver/internal/traceio
     github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/codegen
     github.com/ServiceWeaver/weaver/runtime/colors
     github.com/ServiceWeaver/weaver/runtime/logging
+    github.com/ServiceWeaver/weaver/runtime/perfetto
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/retry
     github.com/ServiceWeaver/weaver/runtime/tool
@@ -573,6 +574,7 @@ github.com/ServiceWeaver/weaver/internal/tool/ssh/impl
     github.com/ServiceWeaver/weaver/runtime/envelope
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/metrics
+    github.com/ServiceWeaver/weaver/runtime/perfetto
     github.com/ServiceWeaver/weaver/runtime/protomsg
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/retry
@@ -595,11 +597,6 @@ github.com/ServiceWeaver/weaver/internal/tool/ssh/impl
     time
 github.com/ServiceWeaver/weaver/internal/traceio
     context
-    crypto/sha256
-    encoding/binary
-    encoding/json
-    fmt
-    github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/protos
     go.opentelemetry.io/otel/attribute
     go.opentelemetry.io/otel/codes
@@ -607,14 +604,8 @@ github.com/ServiceWeaver/weaver/internal/traceio
     go.opentelemetry.io/otel/sdk/instrumentation
     go.opentelemetry.io/otel/sdk/resource
     go.opentelemetry.io/otel/sdk/trace
-    go.opentelemetry.io/otel/semconv/v1.4.0
     go.opentelemetry.io/otel/trace
     math
-    net
-    net/http
-    os
-    strconv
-    strings
     sync
     time
 github.com/ServiceWeaver/weaver/internal/versioned
@@ -727,6 +718,23 @@ github.com/ServiceWeaver/weaver/runtime/metrics
     sync/atomic
     unicode
     unicode/utf8
+github.com/ServiceWeaver/weaver/runtime/perfetto
+    context
+    crypto/sha256
+    encoding/binary
+    encoding/json
+    fmt
+    github.com/ServiceWeaver/weaver/runtime/logging
+    go.opentelemetry.io/otel/sdk/trace
+    go.opentelemetry.io/otel/semconv/v1.4.0
+    go.opentelemetry.io/otel/trace
+    net
+    net/http
+    os
+    strconv
+    strings
+    sync
+    time
 github.com/ServiceWeaver/weaver/runtime/protomsg
     bytes
     context

--- a/internal/babysitter/babysitter.go
+++ b/internal/babysitter/babysitter.go
@@ -28,24 +28,24 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/google/uuid"
-	"go.opentelemetry.io/otel/sdk/trace"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
 	"github.com/ServiceWeaver/weaver/internal/logtype"
 	imetrics "github.com/ServiceWeaver/weaver/internal/metrics"
 	"github.com/ServiceWeaver/weaver/internal/net/call"
 	"github.com/ServiceWeaver/weaver/internal/proxy"
 	"github.com/ServiceWeaver/weaver/internal/status"
-	"github.com/ServiceWeaver/weaver/internal/traceio"
 	"github.com/ServiceWeaver/weaver/internal/versioned"
 	"github.com/ServiceWeaver/weaver/runtime/envelope"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
+	"github.com/ServiceWeaver/weaver/runtime/perfetto"
 	"github.com/ServiceWeaver/weaver/runtime/protomsg"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/ServiceWeaver/weaver/runtime/retry"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -128,7 +128,7 @@ func NewBabysitter(ctx context.Context, dep *protos.Deployment, logSaver func(*p
 		routingInfo:    versioned.NewMap[*protos.RoutingInfo](),
 		proxies:        map[string]*proxyInfo{},
 	}
-	go traceio.RunTracerProvider(b.ctx)
+	go perfetto.ServeLocalTraces(b.ctx)
 	go b.statsProcessor.CollectMetrics(b.ctx, b.readMetrics)
 	return b, nil
 }

--- a/internal/status/dashboard.go
+++ b/internal/status/dashboard.go
@@ -29,14 +29,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/browser"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	imetrics "github.com/ServiceWeaver/weaver/internal/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
 	protos "github.com/ServiceWeaver/weaver/runtime/protos"
 	dtool "github.com/ServiceWeaver/weaver/runtime/tool"
+	"github.com/pkg/browser"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var (
@@ -66,7 +66,7 @@ var (
 			return x - 1
 		},
 		"traceurl": func(file string) string {
-			// See metrics.RunTracerProvider for an explanation of the URLs.
+			// See perfetto.ServeLocalTraces for an explanation of the URLs.
 			tracerURL := url.QueryEscape("http://127.0.0.1:9001" + file)
 			return "https://ui.perfetto.dev/#!/?url=" + tracerURL
 		},

--- a/runtime/perfetto/perfetto.go
+++ b/runtime/perfetto/perfetto.go
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package traceio
+// Package perfetto contains libraries for displaying trace information in the
+// Perfetto UI and Chrome Tracer.
+package perfetto
 
 import (
 	"context"
@@ -25,32 +27,35 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/ServiceWeaver/weaver/runtime/logging"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"go.opentelemetry.io/otel/trace"
-	"github.com/ServiceWeaver/weaver/runtime/logging"
 )
 
-// This file contains event tracing information to be rendered by the Perfetto UI[1].
+var (
+	// Maps (colocation group, process id) to a readable replica number (e.g.,
+	// Replica 1, Replica 2, etc.)
+	mu   sync.Mutex
+	pids map[string]map[int]int = map[string]map[int]int{}
+)
+
+// This file contains event tracing information to be rendered by the
+// Perfetto UI [1] and Chrome tracer [3]
 //
-// The events are represented in JSON format as specified in [2], format compatible
-// both with Perfetto UI and Chrome tracing[3].
-//
-// Each event contains information exported by an OTEL read span[4]. There are
-// multiple types of JSON events[2]. However, for rendering read only spans, we
-// picked two types of events:
-// * Complete events - they are duration events but in a more compact format
-// * Metadata events - to associate extra information, in our case read span events
+// The events are represented in JSON format as specified in [2]. This format
+// is compatible with both Perfetto UI and Chrome tracer.
 //
 // [1] https://ui.perfetto.dev/
 // [2] https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#
 // [3] https://sites.google.com/a/chromium.org/dev/developers/how-tos/trace-event-profiling-tool/frame-viewer
 // [4] https://github.com/open-telemetry/opentelemetry-go/blob/main/sdk/trace/span.go
 
-// CompleteEvent renders an event that contains a start time and a duration.
-type CompleteEvent struct {
+// completeEvent renders an event that contains a start time and a duration.
+type completeEvent struct {
 	Ph   string                       `json:"ph"`   // the event type
 	Name string                       `json:"name"` // name of the event
 	Cat  string                       `json:"cat"`  // category of the event
@@ -61,8 +66,8 @@ type CompleteEvent struct {
 	Args map[string]map[string]string `json:"args"` // arguments provided for the event
 }
 
-// MetadataEvent renders an event that contains metadata information for a CompleteEvent.
-type MetadataEvent struct {
+// metadataEvent renders an event that contains metadata information for a completeEvent.
+type metadataEvent struct {
 	Ph   string            `json:"ph"`   // the event type
 	Name string            `json:"name"` // name of the event
 	Cat  string            `json:"cat"`  // category of the event
@@ -71,35 +76,32 @@ type MetadataEvent struct {
 	Args map[string]string `json:"args"` // arguments provided for the event
 }
 
-// ChromeTraceEncoder encodes read spans into JSON events that can be rendered by
-// Chrome tracer and Perfetto UI.
-type ChromeTraceEncoder struct {
-	encoded []byte // encoded traces in JSON format
-
-	// Needed to map colocation group process ids to more readable numbers (e.g.,
-	// Replica 1, Replica 2, etc.)
-	mapping map[string]map[int]int // keyed by colocation group and process id
-}
-
-func NewChromeTraceEncoder() *ChromeTraceEncoder {
-	return &ChromeTraceEncoder{mapping: map[string]map[int]int{}}
-}
-
-// Encode converts a slice of read span events to events that can be rendered by
-// chrome tracer and Perfetto UI.
+// Encode converts a slice of span events into a JSON string that can be
+// rendered by the Perfetto UI and Chrome Tracer.
 //
-// For each span event we generate the following:
-//   - a complete event for each colocation group and corresponding metadata events to label
-//     the process/replica name
-//   - a metadata event for each event in the span, encapsulated in a context event
-func (c *ChromeTraceEncoder) Encode(spans []sdktrace.ReadOnlySpan) []byte {
+// For each span, the following Perfetto events are generated:
+//   - A complete event, which encapsulates the span duration.
+//   - A number of metadata events, which correspond to span events.
+func Encode(spans []sdktrace.ReadOnlySpan) ([]byte, error) {
 	if len(spans) == 0 {
+		return nil, nil
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	var encoded []byte
+	appendEvent := func(event any) error {
+		b, err := json.Marshal(event)
+		if err != nil {
+			return err
+		}
+		encoded = append(encoded, b...)
+		encoded = append(encoded, ',')
 		return nil
 	}
-	c.encoded = c.encoded[:0] // clear any previous state
 
 	for _, span := range spans {
-		// Get the pid of the process that output the span, and the corresponding colocation group.
+		// Get the pid of the process that output the span, and the
+		// corresponding colocation group.
 		var pid int
 		var colocGroup string
 		for _, a := range span.Resource().Attributes() {
@@ -109,19 +111,23 @@ func (c *ChromeTraceEncoder) Encode(spans []sdktrace.ReadOnlySpan) []byte {
 				colocGroup = a.Value.AsString()
 			}
 		}
-		if _, found := c.mapping[colocGroup]; !found {
-			c.mapping[colocGroup] = map[int]int{}
-			c.mapping[colocGroup][0] = 1 // special entry to track the last replica id for this colocation group
+		cg, found := pids[colocGroup]
+		if !found {
+			// Special entry to track the last replica id for this colocation
+			// group.
+			cg = map[int]int{0: 1}
+			pids[colocGroup] = cg
 		}
-		if _, found := c.mapping[colocGroup][pid]; !found {
-			c.mapping[colocGroup][pid] = c.mapping[colocGroup][0]
-			c.mapping[colocGroup][0]++
+		replicaID, found := cg[pid]
+		if !found {
+			replicaID = cg[0]
+			cg[pid] = replicaID
+			cg[0]++
 		}
-		replicaId := c.mapping[colocGroup][pid]
 
-		// The span name contains the name of the method that is called. Based on the
-		// span kind, we attach an additional label to identify whether the event
-		// happened at the client, server, or local.
+		// The span name contains the name of the method that is called. Based
+		// on the span kind, we attach an additional label to identify whether
+		// the event happened at the client, server, or locally.
 		eventName := span.Name()
 		switch span.SpanKind() {
 		case trace.SpanKindServer:
@@ -150,42 +156,44 @@ func (c *ChromeTraceEncoder) Encode(spans []sdktrace.ReadOnlySpan) []byte {
 			"attributes": attrs,
 		}
 
-		// Generate a complete event, and a series of metadata events.
+		// Generate a complete event and a series of metadata events.
 		colocGroupFP := fp(colocGroup)
 
 		// Build two metadata events for each colocation group (one to replace the process
 		// name label and one for the thread name).
-		c.encodeEvent(&MetadataEvent{
+		if err := appendEvent(&metadataEvent{
 			Ph:   "M", // make it a metadata event
 			Name: "process_name",
 			Cat:  span.SpanKind().String(),
 			Pid:  colocGroupFP,
-			Tid:  replicaId,
+			Tid:  replicaID,
 			Args: map[string]string{"name": fmt.Sprintf("%s+", logging.ShortenComponent(colocGroup))},
-		})
-		c.encodeEvent(&MetadataEvent{
+		}); err != nil {
+			return nil, err
+		}
+		if err := appendEvent(&metadataEvent{
 			Ph:   "M", // make it a metadata event
 			Name: "thread_name",
 			Cat:  span.SpanKind().String(),
 			Pid:  colocGroupFP,
-			Tid:  replicaId,
+			Tid:  replicaID,
 			Args: map[string]string{"name": "Replica"},
-		})
+		}); err != nil {
+			return nil, err
+		}
 
 		// Build a complete event.
-		c.encodeEvent(&CompleteEvent{
+		if err := appendEvent(&completeEvent{
 			Ph:   "X", // make it a complete event
 			Name: eventName,
 			Cat:  span.SpanKind().String(),
 			Pid:  colocGroupFP,
-			Tid:  replicaId,
+			Tid:  replicaID,
 			Args: args,
 			Ts:   span.StartTime().UnixMicro(),
 			Dur:  span.EndTime().UnixMicro() - span.StartTime().UnixMicro(),
-		})
-
-		if len(span.Events()) == 0 {
-			continue
+		}); err != nil {
+			return nil, err
 		}
 
 		// For each span event, create a corresponding metadata event.
@@ -194,23 +202,19 @@ func (c *ChromeTraceEncoder) Encode(spans []sdktrace.ReadOnlySpan) []byte {
 			for _, a := range e.Attributes {
 				attrs[string(a.Key)] = a.Value.Emit()
 			}
-			c.encodeEvent(&MetadataEvent{
+			if err := appendEvent(&metadataEvent{
 				Ph:   "M", // make it a metadata event
 				Name: e.Name,
 				Cat:  span.SpanKind().String(),
 				Pid:  colocGroupFP,
-				Tid:  replicaId,
+				Tid:  replicaID,
 				Args: attrs,
-			})
+			}); err != nil {
+				return nil, err
+			}
 		}
 	}
-	return c.encoded
-}
-
-func (c *ChromeTraceEncoder) encodeEvent(ev any) {
-	b, _ := json.Marshal(ev)
-	c.encoded = append(c.encoded, b...)
-	c.encoded = append(c.encoded, []byte(",")...)
+	return encoded, nil
 }
 
 func fp(name string) int {
@@ -219,20 +223,16 @@ func fp(name string) int {
 	return int(binary.LittleEndian.Uint32(hasher.Sum(nil)))
 }
 
-// RunTracerProvider runs an HTTP server that handles trace requests for all the
-// active deployments.
+// ServeLocalTraces runs an HTTP server that serves traces stored on the
+// local file system.
 //
-// Periodically, it attempts to listen on port 9001, if not able to listen yet.
-// I.e., among all active deployments on a single machine, only a single instance
-// will run the trace provider server. Because trace files are stored on disk, any
-// active server will serve all the files, so if this server can't start, some
-// other server will be able to serve its file.
-//
-// It has to listen on port 9001 because it is the only port from which Perfetto UI
-// can read the trace file.
-func RunTracerProvider(ctx context.Context) {
+// Perfetto UI requires that the server runs on the local port 9001. For that
+// reason, this method will block until port 9001 becomes available. Because the
+// server handles *all* traces stored on the local machine, as long as some
+// other server has successfully started, local trace data will be served.
+func ServeLocalTraces(ctx context.Context) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", tracePage)
+	mux.HandleFunc("/", handler)
 	server := http.Server{Handler: mux}
 
 	ticker := time.NewTicker(time.Second)
@@ -251,19 +251,23 @@ func RunTracerProvider(ctx context.Context) {
 	}
 }
 
-func tracePage(w http.ResponseWriter, r *http.Request) {
-	if strings.Contains(r.RequestURI, ".trace") {
-		// Set access control according to https://perfetto.dev/docs/visualization/deep-linking-to-perfetto-ui.
-		w.Header().Set("Access-Control-Allow-Origin", "https://ui.perfetto.dev")
-		data, _ := os.ReadFile(r.RequestURI)
-		if len(data) == 0 {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		traces := make([]byte, len(data)+2)
-		traces[0] = '['
-		copy(traces[1:], data)
-		traces[len(data)+1] = ']'
-		w.Write(traces)
+// handler is an HTTP handler that serves locally-stored trace files
+// for trace requests from the Perfetto UI.
+func handler(w http.ResponseWriter, r *http.Request) {
+	if !strings.Contains(r.RequestURI, ".trace") {
+		return
 	}
+	// Set access control according to:
+	//   https://perfetto.dev/docs/visualization/deep-linking-to-perfetto-ui.
+	w.Header().Set("Access-Control-Allow-Origin", "https://ui.perfetto.dev")
+	data, err := os.ReadFile(r.RequestURI)
+	if err != nil || len(data) == 0 {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	traces := make([]byte, len(data)+2)
+	traces[0] = '['
+	copy(traces[1:], data)
+	traces[len(data)+1] = ']'
+	w.Write(traces)
 }


### PR DESCRIPTION
In particular, we're migrating the GKE local deployer to Perfetto.

Clean up the code somewhat now that it is in a public API.