### PR TITLE
Simplify the Service Weaver main README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,8 @@
 # Service Weaver
 
--   **TODO**: Link to user guide.
--   **TODO**: Link to homepage.
-
-## What is Service Weaver?
-
 Service Weaver is a programming framework for writing, deploying, and managing
 distributed applications. You can run, test, and debug a Service Weaver
-application locally on your machine, and then deploy the application to the
+application locally on your machine, and then deploy it to the
 cloud with a single command.
 
 ```bash
@@ -15,17 +10,16 @@ $ go run .                      # Run locally.
 $ weaver gke deploy weaver.toml # Run in the cloud.
 ```
 
-A Service Weaver application is composed of a number **components**. A component
-is represented as a regular Go interface, and components interact with each
-other by calling the methods defined by these interfaces. This makes writing
-Service Weaver applications easy. You don't have to write any networking or
-serialization code; you just write Go. Service Weaver also provides libraries
-for logging, metrics, tracing, routing, testing, and more.
+Visit [https://serviceweaver.dev][website] to learn more about Service Weaver.
 
-You can deploy a Service Weaver application as easily as running a single
-command. Under the covers, Service Weaver will dissect your binary along
-component boundaries, allowing different components to run on different
-machines. Service Weaver will replicate, autoscale, and co-locate these
-distributed components for you. It will also manage all the networking details
-on your behalf, ensuring that different components can communicate with each
-other and that clients can communicate with your application.
+## Installation and Getting Started
+
+Visit [https://serviceweaver.dev/docs.html][docs] for installation
+instructions and information on getting started.
+
+## Contributing
+
+Please read our [contribution guide](./CONTRIBUTING.md) for details on how
+to contribute.
+
+[docs]: https://serviceweaver.dev/docs.html


### PR DESCRIPTION
Since we have the website, we can point people there, rather than duplicate a lot of material in the README.