### PR TITLE
Reworked internal/conn handshake abstractions.

### DIFF
--- a/runtime/envelope/envelope_test.go
+++ b/runtime/envelope/envelope_test.go
@@ -348,9 +348,7 @@ func createWeaveletConn() (*conn.WeaveletConn, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable make weavelet<->envelope pipes: %w", err)
 	}
-	conn := conn.NewWeaveletConn(toWeavelet, toEnvelope)
-	conn.GetWeaveletInfo() // ensures the connection is established
-	return conn, nil
+	return conn.NewWeaveletConn(toWeavelet, toEnvelope)
 }
 
 func writeTraces(conn *conn.WeaveletConn) error {


### PR DESCRIPTION
Recall that when an envelope and a weavelet establish a connection to one another, they perform a simple handshake. The envelope sends a `protos.Weavelet`, and the weavelet acks it.

Before this PR, the abstractions to perform this handshake were a bit shaky. You would construct an envelope conn and then call `SendWeaveletInfoRPC`:

```go
e := conn.NewEnvelopeConn(...)
e.SendWeaveletInfoRPC(...)
```

However, this wouldn't work because the RPC depends on `e.Run()` having been called. So you need to spawn a goroutine to run `e.Run()`. On the weavelet side, you have to call `GetWeaveletInfo` before you call `w.Run()`:

```go
w := conn.NewWeaveletConn(...)
w.GetWeaveletInfo()
```

If you forgot any of these calls or did them in the wrong order, things would hang or fail.

This PR reworks the abstractions so that you can't forget to perform the handshake. Now, `conn.NewWeaveletConn` automatically sends the `protos.Weavelet` and does not wait for an ack. Similarly, `conn.NewWeaveletConn` blocks until it receives the `protos.Weavelet`. This makes it much harder to forget or mess up the handshake.

This PR is part of a larger effort to clean up the runtime protos and pipe API. There is still a lot of cruft. For example, the `EnvelopeConn` methods will hang unless you call `Run()`. A lot of the protos also pass redundant information. I'll try to clean a lot of this up in future PRs.