### PR TITLE
Made website header fixed width across all pages.

### DIFF
--- a/website/assets/css/common.css
+++ b/website/assets/css/common.css
@@ -55,6 +55,9 @@ header {
   padding-bottom: 1ch;
   padding-left: 2ch;
   padding-right: 2ch;
+  max-width: 80em;
+  margin-left: auto;
+  margin-right: auto;
 }
 header .logo {
   font-size: 1.5em;

--- a/website/templates/blog.html
+++ b/website/templates/blog.html
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="/assets/css/blog.css">
   </head>
   <body>
+    {{template "header.html" .}}
     <div class="page">
-      {{template "header.html" .}}
       <div class="contents">
         {{.Contents}}
       </div>

--- a/website/templates/blog_entry.html
+++ b/website/templates/blog_entry.html
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="/assets/css/blog.css">
   </head>
   <body>
+    {{template "header.html" .}}
     <div class="page_blog">
-      {{template "header.html" .}}
       <div class="contents">
         {{.Contents}}
       </div>

--- a/website/templates/docs.html
+++ b/website/templates/docs.html
@@ -23,8 +23,8 @@
     <link rel="stylesheet" href="/assets/css/docs.css">
   </head>
   <body>
+    {{template "header.html" .}}
     <div class="page">
-      {{template "header.html" .}}
       <div class="holder">
         <input type="checkbox" id="toc-toggle" checked/>
         <label id="toc-button" for="toc-toggle" title="Click to toggle table of contents">☰</label>

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="/assets/css/home.css">
   </head>
   <body>
+    {{template "header.html" .}}
     <div class="page">
-      {{template "header.html" .}}
       <div class="contents">
         {{.Contents}}
       </div>


### PR DESCRIPTION
Before this PR, the header at the top of the website, represented as a `<header>` HTML element, was nested inside a `<div class="page">` element where the "page" CSS class defined the width of the page. In PR #37, we narrowed the page width for blog posts. This lead to an inconsistent header width.

This PR fixes the problem by hoisting the `<header>` element out of the "page" div. In the future, we might want to nest it again and pick a fixed width for all pages.

Note that there's still a weird bug where the header is slightly nudged on the blog page. I can't figure out why it's doing that, but we should fix it in the future too.