### PR TITLE
Attach app and version attributes to our traces.

### DIFF
--- a/internal/traceio/trace.go
+++ b/internal/traceio/trace.go
@@ -25,6 +25,8 @@ const (
 	// Trace attribute keys for various Service Weaver identifiers. These
 	// are attached to all exported traces by the weavelet, and displayed
 	// in the UI by the Service Weaver visualization tools (e.g., dashboard).
+	AppNameTraceKey             = attribute.Key("serviceweaver.app")
+	VersionTraceKey             = attribute.Key("serviceweaver.version")
 	ColocationGroupNameTraceKey = attribute.Key("serviceweaver.coloc_group")
 	GroupReplicaIDTraceKey      = attribute.Key("serviceweaver.group_replica_id")
 )

--- a/weavelet.go
+++ b/weavelet.go
@@ -145,8 +145,10 @@ func newWeavelet(ctx context.Context, componentInfos []*codegen.Registration) (*
 			semconv.SchemaURL,
 			semconv.ServiceNameKey.String(fmt.Sprintf("serviceweaver/%s/%s", wletInfo.Process, wletInfo.Id[:4])),
 			semconv.ProcessPIDKey.Int(os.Getpid()),
-			traceio.GroupReplicaIDTraceKey.String(wletInfo.GroupReplicaId),
+			traceio.AppNameTraceKey.String(wletInfo.Dep.App.Name),
+			traceio.VersionTraceKey.String(wletInfo.Dep.Id),
 			traceio.ColocationGroupNameTraceKey.String(wletInfo.Group.Name),
+			traceio.GroupReplicaIDTraceKey.String(wletInfo.GroupReplicaId),
 		)),
 		// TODO(spetrovic): Allow the user to create new TracerProviders where
 		// they can control trace sampling and other options.


### PR DESCRIPTION
Google Cloud Tracing allows filtering based on the attributes/labels, and so it's a good idea to allow them to filter based on the Service Weaver app/version.