### PR TITLE
Add the always-OK healthz handler to the default ServeMux.

### DIFF
--- a/examples/factors/server.go
+++ b/examples/factors/server.go
@@ -35,7 +35,6 @@ func serve(ctx context.Context, root weaver.Instance, addr string) error {
 
 	s := &server{factorer}
 	http.Handle("/", weaver.InstrumentHandlerFunc("/", s.handleFactors))
-	http.Handle("/healthz", weaver.InstrumentHandlerFunc("/healthz", s.handleHealthz))
 
 	lis, err := root.Listener("factors", weaver.ListenerOptions{LocalAddress: addr})
 	if err != nil {
@@ -64,9 +63,4 @@ func (s *server) handleFactors(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	fmt.Fprintln(w, factors)
-}
-
-// handleHealthz handles the /healthz endpoint.
-func (s *server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
-	fmt.Fprintln(w, "ok")
 }

--- a/weaver.go
+++ b/weaver.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"reflect"
 
@@ -75,6 +76,11 @@ func init() {
 		LocalStubFn:  func(any, trace.Tracer) any { return nil },
 		ClientStubFn: func(codegen.Stub, string) any { return nil },
 		ServerStubFn: func(any, func(uint64, float64)) codegen.Server { return nil },
+	})
+
+	// Add a trivial /healthz handler to the default mux.
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("ok"))
 	})
 }
 


### PR DESCRIPTION
This prevents applications like the Hello example from forgetting to add the /healthz handler explicitly.

Alternatives:
  * We could expect health checks on /debug/weaver/healthz, but that means the user has to use a more complex path to add their own (i.e., whenever they use a custom ServeMux).
  * Somehow inject ourselves into the user-created HTTP server. We explored this and it's tricky, since the only thing in our control is the net.Listener, and that's too low level to inspect the HTTP traffic and take over the handling for health checks.