### PR TITLE
add documentation about registry store folder environment variable XD…

### DIFF
--- a/website/docs.md
+++ b/website/docs.md
@@ -51,6 +51,12 @@ running `source ~/.bashrc`:
 $ export PATH="$PATH:$GOPATH/bin"
 ```
 
+**Note** If you're a Windows user, you should set an environment variable that points to writable directory:
+
+```console
+$ export XDG_DATA_HOME=C:\\serviceweaver
+```
+
 If the installation was successful, you should be able to run `weaver --help`:
 
 ```console


### PR DESCRIPTION
add documentation about the registry store folder environment variable XDG_DATA_HOME.
Otherwise, Windows won't be able to find registry data and all `weaver` commands won't see any deployments