### PR TITLE
remove duplicates of default registry dir implementations

### DIFF
--- a/internal/files/file.go
+++ b/internal/files/file.go
@@ -100,3 +100,24 @@ func (w *Writer) Cleanup() {
 	w.tmp = nil
 	os.Remove(w.tmpName)
 }
+
+// DefaultDataDir returns the default directory for Service Weaver files:
+// $XDG_DATA_HOME/serviceweaver, or ~/.local/share/serviceweaver if
+// XDG_DATA_HOME is not set.
+func DefaultDataDir() (string, error) {
+	dataDir := os.Getenv("XDG_DATA_HOME")
+	if dataDir == "" {
+		// Default to ~/.local/share
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dataDir = filepath.Join(home, ".local", "share")
+	}
+	regDir := filepath.Join(dataDir, "serviceweaver")
+	if err := os.MkdirAll(regDir, 0700); err != nil {
+		return "", err
+	}
+
+	return regDir, nil
+}

--- a/internal/status/registry.go
+++ b/internal/status/registry.go
@@ -112,26 +112,6 @@ func NewRegistry(_ context.Context, dir string) (*Registry, error) {
 	return &Registry{dir, newClient}, err
 }
 
-// DefaultRegistryDir returns the default registry directory
-// $XDG_DATA_HOME/serviceweaver, or ~/.local/share/serviceweaver if
-// XDG_DATA_HOME is not set.
-func DefaultRegistryDir() (string, error) {
-	dataDir := os.Getenv("XDG_DATA_HOME")
-	if dataDir == "" {
-		// Default to ~/.local/share
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		dataDir = filepath.Join(home, ".local", "share")
-	}
-	regDir := filepath.Join(dataDir, "serviceweaver")
-	if err := os.MkdirAll(regDir, 0700); err != nil {
-		return "", err
-	}
-	return regDir, nil
-}
-
 // Register adds a registration to the registry.
 func (r *Registry) Register(ctx context.Context, reg Registration) error {
 	bytes, err := json.Marshal(reg)

--- a/internal/tool/multi/deploy.go
+++ b/internal/tool/multi/deploy.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 
 	"github.com/ServiceWeaver/weaver/internal/babysitter"
+	"github.com/ServiceWeaver/weaver/internal/files"
 	"github.com/ServiceWeaver/weaver/internal/status"
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
@@ -178,7 +179,7 @@ func deploy(ctx context.Context, args []string) error {
 // $XDG_DATA_HOME/serviceweaver/multi_registry, or
 // ~/.local/share/serviceweaver/multi_registry if XDG_DATA_HOME is not set.
 func defaultRegistry(ctx context.Context) (*status.Registry, error) {
-	dir, err := status.DefaultRegistryDir()
+	dir, err := files.DefaultDataDir()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tool/single/single.go
+++ b/internal/tool/single/single.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/ServiceWeaver/weaver/internal/files"
 	"github.com/ServiceWeaver/weaver/internal/status"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
@@ -44,7 +45,7 @@ var (
 )
 
 func defaultRegistry(ctx context.Context) (*status.Registry, error) {
-	dir, err := status.DefaultRegistryDir()
+	dir, err := files.DefaultDataDir()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tool/ssh/impl/manager.go
+++ b/internal/tool/ssh/impl/manager.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/ServiceWeaver/weaver/internal/files"
 	imetrics "github.com/ServiceWeaver/weaver/internal/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/perfetto"
@@ -740,7 +741,7 @@ func serveHTTP(ctx context.Context, lis net.Listener, handler http.Handler) erro
 // $XDG_DATA_HOME/serviceweaver/ssh_registry, or
 // ~/.local/share/serviceweaver/ssh_registry if XDG_DATA_HOME is not set.
 func DefaultRegistry(ctx context.Context) (*status.Registry, error) {
-	dir, err := status.DefaultRegistryDir()
+	dir, err := files.DefaultDataDir()
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/perfetto/db.go
+++ b/runtime/perfetto/db.go
@@ -27,11 +27,11 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strconv"
 	"time"
 
+	"github.com/ServiceWeaver/weaver/internal/files"
 	"github.com/ServiceWeaver/weaver/internal/traceio"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/retry"
@@ -96,19 +96,11 @@ type DB struct {
 
 // Open opens the default trace database on the local machine.
 func Open(ctx context.Context) (*DB, error) {
-	dataDir := os.Getenv("XDG_DATA_HOME")
-	if dataDir == "" {
-		// Default to ~/.local/share
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-		dataDir = filepath.Join(home, ".local", "share")
-	}
-	dataDir = filepath.Join(dataDir, "serviceweaver")
-	if err := os.MkdirAll(dataDir, 0700); err != nil {
+	dataDir, err := files.DefaultDataDir()
+	if err != nil {
 		return nil, err
 	}
+
 	fname := filepath.Join(dataDir, "perfetto.db")
 	return open(ctx, fname)
 }

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
+	"github.com/ServiceWeaver/weaver/internal/files"
 	"github.com/ServiceWeaver/weaver/internal/logtype"
 	imetrics "github.com/ServiceWeaver/weaver/internal/metrics"
 	"github.com/ServiceWeaver/weaver/internal/net/call"
@@ -207,7 +208,7 @@ func (e *singleprocessEnv) serveStatus(ctx context.Context) error {
 	}
 
 	// Register the deployment.
-	dir, err := status.DefaultRegistryDir()
+	dir, err := files.DefaultDataDir()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
extract `DefaultRegistryDir` into the separate package, so that it could be used `/runtime/perfetto` 
btw, there is a possible bug if the storage folder has not cleaned up registry files, then `status` `metrics` and `dashboard` commands will fail to attempt to connect to not accepting port with the error:

```console
Get "http://127.0.0.1:56018/debug/serviceweaver/status": dial tcp 127.0.0.1:56018: connectex: No connection could be made because the target machine actively refused it.
```

and won't continue to the next service running

P.S. naming is hard, so open to suggestions of package names. Separate package due to import loop.
