### PR TITLE
Fix the copy button in the dashboard

### DIFF
--- a/internal/status/assets/copy.js
+++ b/internal/status/assets/copy.js
@@ -22,7 +22,7 @@
 // successfully copied.
 function addCopyButtons() {
   for (let e of document.querySelectorAll('.copyable')) {
-    const text = e.innerText;
+    const text = e.textContent;
     const button = document.createElement('button');
     button.innerText = '📋';
     button.classList.add('copy-button');

--- a/internal/status/assets/main.css
+++ b/internal/status/assets/main.css
@@ -107,7 +107,7 @@ details[open] .card-title {
   cursor: pointer;
   border: 0pt;
   background: white;
-  padding: 2pt;
+  padding: 0 2pt;
   border-radius: 4pt;
 }
 


### PR DESCRIPTION
I was playing with the dashboard and I noticed the copy button under the "Commands" section was copying an empty string to the clipboard instead of the command (Chrome v109.0.5414.119). 

Reading over [these docs](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext) I believe the problem is that `addCopyButtons` runs when the page is first loaded, and at that time the contents  of the "Commands" section is hidden, so `innerText` returns the empty string. `textContent` returns the correct value even when the element is hidden from the page.

Another option to fix this would be to lookup the text from the sibling element in the closure passed to `addEventListener('click', ...)`, instead of capturing it when the page loads.

I also noticed that the text of the commands were shifting by a pixel or two on mouseover. By removing the top and bottom padding from the button the text stays in place.

I can squash these commits if you are interested in accepting both and would like them in a single commit.