### PR TITLE
fix: weavelet cpu consumption

### DIFF
--- a/singleprocess.go
+++ b/singleprocess.go
@@ -160,7 +160,7 @@ func (e *singleprocessEnv) RegisterComponentToStart(_ context.Context, _ string,
 	return nil
 }
 
-func (e *singleprocessEnv) GetComponentsToStart(ctx context.Context, _*call.Version) ([]string, *call.Version, error) {
+func (e *singleprocessEnv) GetComponentsToStart(ctx context.Context, _ *call.Version) ([]string, *call.Version, error) {
 	// Block forever since there's not going to be anything to start.
 	<-ctx.Done()
 	return []string{}, nil, nil

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -161,6 +161,8 @@ func (e *singleprocessEnv) RegisterComponentToStart(_ context.Context, _ string,
 }
 
 func (e *singleprocessEnv) GetComponentsToStart(context.Context, *call.Version) ([]string, *call.Version, error) {
+	// blocks forever to avoid excessive CPU consumption in weavelet.watchComponentsToStart
+	<-make(chan struct{})
 	return []string{}, nil, nil
 }
 

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -160,9 +160,9 @@ func (e *singleprocessEnv) RegisterComponentToStart(_ context.Context, _ string,
 	return nil
 }
 
-func (e *singleprocessEnv) GetComponentsToStart(context.Context, *call.Version) ([]string, *call.Version, error) {
-	// blocks forever to avoid excessive CPU consumption in weavelet.watchComponentsToStart
-	<-make(chan struct{})
+func (e *singleprocessEnv) GetComponentsToStart(ctx context.Context, _*call.Version) ([]string, *call.Version, error) {
+	// Block forever since there's not going to be anything to start.
+	<-ctx.Done()
 	return []string{}, nil, nil
 }
 


### PR DESCRIPTION
After to run the hello example with `go run .` the cpu consumption was at 100%, this change adds a blocking feature to `getcomponentstostart` in `singleprocess.go`, this prevents the excessive CPU consumption


Before:
```
(pprof) top
Showing nodes accounting for 29.98s, 100% of 29.99s total
Dropped 7 nodes (cum <= 0.15s)
      flat  flat%   sum%        cum   cum%
    15.66s 52.22% 52.22%     29.98s   100%  github.com/ServiceWeaver/weaver.(*weavelet).watchComponentsToStart
     9.71s 32.38% 84.59%     11.14s 37.15%  github.com/ServiceWeaver/weaver/runtime/retry.(*Retry).Continue
     3.18s 10.60% 95.20%      3.18s 10.60%  github.com/ServiceWeaver/weaver.(*singleprocessEnv).GetComponentsToStart
     1.43s  4.77%   100%      1.43s  4.77%  context.(*emptyCtx).Err
         0     0%   100%     29.98s   100%  github.com/ServiceWeaver/weaver.startWork.func1
```

After:
```
(pprof) top
Showing nodes accounting for 90ms, 100% of 90ms total
Showing top 10 nodes out of 27
      flat  flat%   sum%        cum   cum%
      30ms 33.33% 33.33%       30ms 33.33%  runtime/internal/syscall.Syscall6
      10ms 11.11% 44.44%       10ms 11.11%  runtime.(*limiterEvent).stop
      10ms 11.11% 55.56%       50ms 55.56%  runtime.findRunnable
      10ms 11.11% 66.67%       10ms 11.11%  runtime.futex
      10ms 11.11% 77.78%       10ms 11.11%  runtime.nextFreeFast (inline)
      10ms 11.11% 88.89%       10ms 11.11%  runtime.runqget
      10ms 11.11%   100%       10ms 11.11%  time.startTimer
         0     0%   100%       20ms 22.22%  github.com/ServiceWeaver/weaver.(*weavelet).watchComponentsToStart
         0     0%   100%       20ms 22.22%  github.com/ServiceWeaver/weaver.startWork.func1
         0     0%   100%       10ms 11.11%  runtime.futexwakeup
```

fixes #92 