### PR TITLE
Fixed some visual bugs on mobile website.

### DIFF
--- a/website/assets/css/common.css
+++ b/website/assets/css/common.css
@@ -69,9 +69,7 @@ header .active {
 header a {
   text-decoration: none;
   color: black;
-  padding: 0.75ch;
-  padding-left: 1ch;
-  padding-right: 1ch;
+  padding: 0.5ch;
 }
 header .navlink {
   color: #363434;
@@ -90,6 +88,8 @@ header ul {
 header li {
   display: inline-block;
   margin-left: 1ch;
+  padding-top: 0.5ch;
+  padding-bottom: 0.5ch;
 }
 
 .icon img {

--- a/website/assets/css/home.css
+++ b/website/assets/css/home.css
@@ -31,6 +31,13 @@
   overflow-wrap: anywhere;
 }
 
+@media (max-width: 800px) {
+  #serviceweaver-jumbotron {
+    margin-left: 0pt;
+    margin-right: 0pt;
+  }
+}
+
 #serviceweaver-jumbotron h1 {
   font-size: 2em;
 }


### PR DESCRIPTION

This PR fixes two bugs that appeared when the website was viewed on mobile. First, the jumbotron on the landing page was squeezed very thin. I fixed this by removing the left and right margins on small pages. Second, the top navigation header had elements overlapping vertically. I fixed this by adjusting padding.

| Before | After |
| --- | --- |
| ![3KtjtCAcCaUrmME](https://user-images.githubusercontent.com/3654277/223296303-f75972b6-a46f-4463-8b33-3d88ac210305.png) | ![5hrdzVnRDefiM7D](https://user-images.githubusercontent.com/3654277/223296301-0d1d338d-8a84-4d83-b793-63591291527c.png) |