### PR TITLE
Handle or ignore many unhandled errors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,11 +40,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/go/bin/golangci-lint
-          key: golangci-lint-v1.51.0
+          key: golangci-lint-v1.51.2
         if: ${{ matrix.command == 'lint' }}
 
       - name: Install linter
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
         if: ${{ matrix.command == 'lint' }}
 
       - name: ${{ matrix.command }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,8 @@
 linters:
   disable:
     - errcheck # Currently too many places are ignoring errors
+  enable:
+    - nolintlint
 linters-settings:
   staticcheck:
     checks:

--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -72,7 +72,7 @@ func main() {
 		generateFlags.Usage = func() {
 			fmt.Fprintln(os.Stderr, generate.Usage)
 		}
-		generateFlags.Parse(flag.Args()[1:])
+		generateFlags.Parse(flag.Args()[1:]) //nolint:errcheck // does os.Exit on error
 		if err := generate.Generate(".", flag.Args()[1:]); err != nil {
 			fmt.Fprint(os.Stderr, err)
 			os.Exit(1)

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -22,10 +22,10 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/exp/maps"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
+	"golang.org/x/exp/maps"
 )
 
 // escaper is used to format the labels according to [1]. Prometheus labels can
@@ -213,7 +213,7 @@ func writeLabels(w *bytes.Buffer, labels map[string]string,
 	separator := "{"
 	for _, l := range sortedLabels {
 		w.WriteString(separator + l + `="`)
-		escaper.WriteString(w, labels[l])
+		escaper.WriteString(w, labels[l]) //nolint:errcheck // bytes.Buffer.Write does not error
 		w.WriteByte('"')
 		separator = ","
 	}

--- a/internal/net/call/call.go
+++ b/internal/net/call/call.go
@@ -280,7 +280,9 @@ func Connect(ctx context.Context, resolver Resolver, opts ClientOptions) (Connec
 	if !resolver.IsConstant() && version == nil {
 		return nil, errors.New("non-constant resolver returned a nil version")
 	}
-	conn.updateEndpoints(endpoints)
+	if err := conn.updateEndpoints(endpoints); err != nil {
+		return nil, err
+	}
 
 	// If the resolver is non-constant, then we start a goroutine to watch for
 	// updates to the set of endpoints. If the resolver is constant, then we
@@ -417,7 +419,8 @@ func (rc *reconnectingConnection) watchResolver(ctx context.Context, version *Ve
 			// Resolver wishes to be called again after an appropriate delay.
 			continue
 		}
-		rc.updateEndpoints(endpoints)
+		err = rc.updateEndpoints(endpoints)
+		logError(rc.opts.Logger, "watchResolver", err)
 		version = newVersion
 		r.Reset()
 	}

--- a/internal/status/dashboard.go
+++ b/internal/status/dashboard.go
@@ -134,12 +134,12 @@ Flags:
 
 			traceDB, err := perfetto.Open(ctx)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, "cannot open Perfetto database: %w", err)
+				fmt.Fprintf(os.Stderr, "cannot open Perfetto database: %v\n", err)
 			}
 			go traceDB.Serve(ctx)
 
 			fmt.Fprintln(os.Stderr, "Dashboard available at:", url)
-			go browser.OpenURL(url)
+			go browser.OpenURL(url) //nolint:errcheck // browser open is optional
 			return http.Serve(lis, nil)
 		},
 	}
@@ -174,7 +174,9 @@ func (d *dashboard) handleIndex(w http.ResponseWriter, r *http.Request) {
 		Tool:     d.spec.Tool,
 		Statuses: statuses,
 	}
-	indexTemplate.Execute(w, content)
+	if err := indexTemplate.Execute(w, content); err != nil {
+		panic(err)
+	}
 }
 
 // handleDeployment handles requests to /deployment?id=<deployment id>
@@ -305,5 +307,5 @@ func (d *dashboard) handleMetrics(w http.ResponseWriter, r *http.Request) {
 
 	var b bytes.Buffer
 	imetrics.TranslateMetricsToPrometheusTextFormat(&b, snapshots, reg.Addr, prometheusEndpoint)
-	w.Write(b.Bytes())
+	w.Write(b.Bytes()) //nolint:errcheck // response write error
 }

--- a/internal/status/registry.go
+++ b/internal/status/registry.go
@@ -201,7 +201,9 @@ func (r *Registry) List(ctx context.Context) ([]Registration, error) {
 		// the server is dead, we consider the deployment dead, and we garbage
 		// collect its registration.
 		if r.dead(ctx, reg) {
-			r.Unregister(ctx, reg.DeploymentId)
+			if err := r.Unregister(ctx, reg.DeploymentId); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to unregister deployment: %v", err)
+			}
 			continue
 		}
 		alive = append(alive, reg)

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -63,6 +63,6 @@ func RegisterServer(mux *http.ServeMux, server Server, logger logtype.Logger) {
 		}
 		var b bytes.Buffer
 		imetrics.TranslateMetricsToPrometheusTextFormat(&b, snapshots, r.Host, prometheusEndpoint)
-		w.Write(b.Bytes())
+		w.Write(b.Bytes()) //nolint:errcheck // response write error
 	})
 }

--- a/internal/tool/ssh/deploy.go
+++ b/internal/tool/ssh/deploy.go
@@ -28,9 +28,9 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/ServiceWeaver/weaver/internal/tool/ssh/impl"
 	"github.com/google/uuid"
 
+	"github.com/ServiceWeaver/weaver/internal/tool/ssh/impl"
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"github.com/ServiceWeaver/weaver/runtime/colors"
@@ -102,7 +102,9 @@ func deploy(ctx context.Context, args []string) error {
 	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-done // Will block here until user hits ctrl+c
-		terminateDeployment(locs, dep)
+		if err := terminateDeployment(locs, dep); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to terminate deployment: %v\n", err)
+		}
 		fmt.Fprintf(os.Stderr, "Application %s terminated\n", app.Name)
 		if err := stopFn(); err != nil {
 			fmt.Fprintf(os.Stderr, "stop the manager: %v\n", err)

--- a/internal/tool/ssh/impl/babysitter.go
+++ b/internal/tool/ssh/impl/babysitter.go
@@ -237,12 +237,15 @@ func (b *babysitter) GetComponentsToStart(req *protos.GetComponentsToStart) (*pr
 
 // RecvLogEntry implements the protos.EnvelopeHandler interface.
 func (b *babysitter) RecvLogEntry(req *protos.LogEntry) {
-	protomsg.Call(b.ctx, protomsg.CallArgs{
+	err := protomsg.Call(b.ctx, protomsg.CallArgs{
 		Client:  http.DefaultClient,
 		Addr:    b.mgrAddr,
 		URLPath: recvLogEntryURL,
 		Request: req,
 	})
+	if err != nil {
+		b.logger.Error("Error receiving logs", err, "fromAddr", b.mgrAddr)
+	}
 }
 
 // RecvTraceSpans implements the protos.EnvelopeHandler interface.

--- a/routing.go
+++ b/routing.go
@@ -108,7 +108,7 @@ func (r *routelet) onChange(callback func(*protos.RoutingInfo)) {
 // manager to track the latest routing info. Whenever the routing info changes,
 // any resolvers and balancers returned by the Resolver() and Balancer()
 // methods are updated.
-func (r *routelet) watchRoutingInfo(ctx context.Context, env env, group string) error {
+func (r *routelet) watchRoutingInfo(ctx context.Context, env env, group string) {
 	var version *call.Version
 	for re := retry.Begin(); re.Continue(ctx); {
 		routingInfo, newVersion, err := env.GetRoutingInfo(ctx, group, version)
@@ -125,7 +125,6 @@ func (r *routelet) watchRoutingInfo(ctx context.Context, env env, group string) 
 		}
 		re.Reset()
 	}
-	return ctx.Err()
 }
 
 // update updates the state of a routelet with the latest routing info.

--- a/runtime/logging/query.go
+++ b/runtime/logging/query.go
@@ -367,8 +367,7 @@ func formatExpr(w io.Writer, e *exprpb.Expr) error {
 		fmt.Fprint(w, e.GetIdentExpr().Name)
 		return nil
 	case *exprpb.Expr_ConstExpr:
-		formatConst(w, e.GetConstExpr())
-		return nil
+		return formatConst(w, e.GetConstExpr())
 	case *exprpb.Expr_CallExpr:
 		// Note that CEL represents operators like || and ! as calls.
 		return formatCall(w, e.GetCallExpr())

--- a/runtime/perfetto/db.go
+++ b/runtime/perfetto/db.go
@@ -353,7 +353,7 @@ func (d *DB) getReplicaNumber(ctx context.Context, app, version, cgroup, replica
 	if err != nil {
 		return
 	}
-	defer tx.Rollback()
+	defer tx.Rollback() //nolint:errcheck // rollback errors can be ignored
 
 	// See if the replica number is already associated.
 	const query = `
@@ -498,7 +498,7 @@ func (d *DB) execDB(ctx context.Context, query string, args ...any) (sql.Result,
 func (d *DB) Serve(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte("OK"))
+		w.Write([]byte("OK")) //nolint:errcheck // response write error
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		app := r.URL.Query().Get("app")
@@ -517,7 +517,7 @@ func (d *DB) Serve(ctx context.Context) error {
 		traces[0] = '['
 		copy(traces[1:], data)
 		traces[len(data)+1] = ']'
-		w.Write(traces)
+		w.Write(traces) //nolint:errcheck // response write error
 	})
 	server := http.Server{Handler: mux}
 	ticker := time.NewTicker(time.Second)

--- a/runtime/protomsg/handler.go
+++ b/runtime/protomsg/handler.go
@@ -181,23 +181,22 @@ func metricHandler(handler http.HandlerFunc) http.HandlerFunc {
 }
 
 // toHTTP writes msgs into a given response.  On error, it writes the
-// error into the response instead. Returns the status of the write.
-func toHTTP(w http.ResponseWriter, r *http.Request, msgs ...proto.Message) error {
+// error into the response instead.
+func toHTTP(w http.ResponseWriter, r *http.Request, msgs ...proto.Message) {
 	out, err := toWire(msgs...)
 	if err != nil {
 		httpRequestErrorCounts.Get(errorLabels{r.URL.Path, "marshal response"}).Add(1.0)
 		msg := fmt.Sprintf("cannot marshal response protos: %v", err)
 		http.Error(w, msg, http.StatusBadRequest)
-		return errors.New(msg)
+		return
 	}
 	httpRequestBytesReturned.Get(handlerLabels{r.URL.Path}).Put(float64(len(out)))
 	if _, err = w.Write(out); err != nil {
 		httpRequestErrorCounts.Get(errorLabels{r.URL.Path, "write response"}).Add(1.0)
 		msg := fmt.Sprintf("cannot write responses: %v", err)
 		http.Error(w, msg, http.StatusBadRequest)
-		return errors.New(msg)
+		return
 	}
-	return nil
 }
 
 // fromHTTP fills msgs from a given request body.

--- a/weaver.go
+++ b/weaver.go
@@ -80,7 +80,7 @@ func init() {
 
 	// Add a trivial /healthz handler to the default mux.
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte("ok"))
+		w.Write([]byte("ok")) //nolint:errcheck // response write error
 	})
 }
 


### PR DESCRIPTION
Related to #90 

This PR addresses many of the unhandled errors, there are two common cases not handled here that will be done in a separate PR. This gets us closer to enabling the `errcheck` linter.

I've split up the changes into multiple commits. Each commit groups related changes by how the error is handled (ignored, removed, logged, or returned). Changes may be best viewed by individual commit. I'll leave some comments and questions inline. The last commit has some TODOs. I can remove that commit if we don't have any easy way of addressing those TODOs.

My IDE has sorted some of the import blocks alphabetically. I attempted to turn off that feature, but it was still sorting them. I hope that's not a problem, but I can revert those changes if necessary.