### PR TITLE
Add padding on blog post left and right

### DIFF
--- a/website/assets/css/blog.css
+++ b/website/assets/css/blog.css
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-div {
-  text-align: justify;
-  text-justify: inter-word;
-}
-
 /* Limit the page content width to keep lines readable. */
 .page_blog {
+  padding-left: 20px;
+  padding-right: 20px;
   max-width: 60em;
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
It is a subjective opinion, but I find the blog post is hard to read on the mobile 🤔 so I just add the padding and remove the [text-align.](text-align: justify;)

**Before the change:**
![image](https://user-images.githubusercontent.com/1687930/223653607-b805b123-eb89-4401-ae56-c5b2146d54eb.png)

**After the change:**
![image](https://user-images.githubusercontent.com/1687930/223653657-b17f21fa-99c6-4102-aa46-9afac2b3d8e9.png)

