### PR TITLE
Fix usage of Roboto font

### DIFF
--- a/website/assets/css/common.css
+++ b/website/assets/css/common.css
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 body {
-  font-family: "Roboto";
+  font-family: "Roboto", sans-serif;
   padding: 0;
   margin: 0;
 }

--- a/website/templates/head.html
+++ b/website/templates/head.html
@@ -17,3 +17,6 @@
 {{template "analytics.html" .}}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, minimum-scale=1">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">


### PR DESCRIPTION
I noticed that this website uses the Roboto font without importing it as a web font. This causes it to show up as the default serif font on my system. To remedy this, I've added the code from https://fonts.google.com/specimen/Roboto to import the web font, and I've also modified the CSS to have a sans-serif fallback in case the font fails to load.