### PR TITLE
Use Roboto Mono for code blocks

### DIFF
--- a/website/assets/css/common.css
+++ b/website/assets/css/common.css
@@ -39,6 +39,11 @@ pre {
   border-radius: 6px;
 }
 
+code {
+  font-family: "Roboto Mono", monospace;
+  font-size: 0.8em;
+}
+
 /* Limit the page content width to keep lines readable. */
 .page {
   max-width: 80em;

--- a/website/templates/head.html
+++ b/website/templates/head.html
@@ -19,4 +19,4 @@
 <meta name="viewport" content="width=device-width, minimum-scale=1">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto&family=Roboto+Mono&display=swap" rel="stylesheet">


### PR DESCRIPTION
Per @mwhittaker in #135, it would be better for the code blocks to use Roboto Mono as opposed to the default monospace font chosen by the browser. I've changed the code to use Roboto Mono at an appropriate size accordingly (with a fallback to the default monotspace font if needed).