### PR TITLE
Don't treat colocation group replica ids as UUIDs.

### DIFF
--- a/runtime/protos/runtime.pb.go
+++ b/runtime/protos/runtime.pb.go
@@ -991,10 +991,10 @@ type WeaveletInfo struct {
 	unknownFields protoimpl.UnknownFields
 
 	App          string           `protobuf:"bytes,1,opt,name=app,proto3" json:"app,omitempty"`                                       // app name
-	DeploymentId string           `protobuf:"bytes,2,opt,name=deployment_id,json=deploymentId,proto3" json:"deployment_id,omitempty"` // deployment id
+	DeploymentId string           `protobuf:"bytes,2,opt,name=deployment_id,json=deploymentId,proto3" json:"deployment_id,omitempty"` // deployment id, in UUID format
 	Group        *ColocationGroup `protobuf:"bytes,3,opt,name=group,proto3" json:"group,omitempty"`                                   // colocation group
 	GroupId      string           `protobuf:"bytes,4,opt,name=group_id,json=groupId,proto3" json:"group_id,omitempty"`                // colocation group replica id
-	Id           string           `protobuf:"bytes,5,opt,name=id,proto3" json:"id,omitempty"`                                         // weavelet id
+	Id           string           `protobuf:"bytes,5,opt,name=id,proto3" json:"id,omitempty"`                                         // weavelet id, in UUID format
 	// TODO(spetrovic): Rename to same_group.
 	SameProcess        []*ComponentGroup `protobuf:"bytes,6,rep,name=same_process,json=sameProcess,proto3" json:"same_process,omitempty"`                                                                // See AppConfig.SameProcess.
 	Sections           map[string]string `protobuf:"bytes,7,rep,name=sections,proto3" json:"sections,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"` // See AppConfig.Sections.

--- a/runtime/protos/runtime.proto
+++ b/runtime/protos/runtime.proto
@@ -199,10 +199,10 @@ message ColocationGroup {
 // WeaveletInfo contains information provided to a weavelet from its deployer.
 message WeaveletInfo {
   string app = 1;                            // app name
-  string deployment_id = 2;                  // deployment id
+  string deployment_id = 2;                  // deployment id, in UUID format
   ColocationGroup group = 3;                 // colocation group
   string group_id = 4;                       // colocation group replica id
-  string id = 5;                             // weavelet id
+  string id = 5;                             // weavelet id, in UUID format
   // TODO(spetrovic): Rename to same_group.
   repeated ComponentGroup same_process = 6;  // See AppConfig.SameProcess.
   map<string, string> sections = 7;          // See AppConfig.Sections.

--- a/runtime/weavelet.go
+++ b/runtime/weavelet.go
@@ -38,8 +38,8 @@ func CheckWeaveletInfo(w *protos.WeaveletInfo) error {
 	if w.Group.Name == "" {
 		return fmt.Errorf("WeaveletInfo: missing colocation group name")
 	}
-	if _, err := uuid.Parse(w.GroupId); err != nil {
-		return fmt.Errorf("WeaveletInfo: invalid group id: %w", err)
+	if w.GroupId == "" {
+		return fmt.Errorf("WeaveletInfo: missing colocation group replica id")
 	}
 	if _, err := uuid.Parse(w.Id); err != nil {
 		return fmt.Errorf("WeaveletInfo: invalid weavelet id: %w", err)


### PR DESCRIPTION
GKE deployer uses pod names as replica ids, mostly to be able to quickly determine the set of replicas by reading pod information using Kubernetes APIs.