### PR TITLE
Enable errcheck linter on production files

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 linters:
-  disable:
-    - errcheck # Currently too many places are ignoring errors
   enable:
     - nolintlint
+issues:
+  exclude-rules:
+    - path: '_test\.go'
+      linters: [errcheck] # Currently too many places are ignoring errors
 linters-settings:
   staticcheck:
     checks:

--- a/internal/envelope/conn/envelope_conn.go
+++ b/internal/envelope/conn/envelope_conn.go
@@ -147,10 +147,12 @@ func (e *EnvelopeConn) handleMessage(msg *protos.WeaveletMsg) error {
 			info, err := e.handler.GetRoutingInfo(request)
 			if err != nil {
 				// Reply with error.
+				//nolint:errcheck // error will be returned on next send
 				e.send(&protos.EnvelopeMsg{Id: -id, Error: err.Error()})
 				return
 			}
 			// Reply with routing info.
+			//nolint:errcheck // error will be returned on next send
 			e.send(&protos.EnvelopeMsg{Id: -id, RoutingInfo: info})
 		}()
 		return nil
@@ -164,10 +166,12 @@ func (e *EnvelopeConn) handleMessage(msg *protos.WeaveletMsg) error {
 			components, err := e.handler.GetComponentsToStart(request)
 			if err != nil {
 				// Reply with error.
+				//nolint:errcheck // error will be returned on next send
 				e.send(&protos.EnvelopeMsg{Id: -id, Error: err.Error()})
 				return
 			}
 			// Reply with components info.
+			//nolint:errcheck // error will be returned on next send
 			e.send(&protos.EnvelopeMsg{Id: -id, ComponentsToStart: components})
 		}()
 		return nil

--- a/internal/envelope/conn/weavelet_conn.go
+++ b/internal/envelope/conn/weavelet_conn.go
@@ -110,10 +110,12 @@ func (d *WeaveletConn) handleMessage(msg *protos.EnvelopeMsg) error {
 			data, err := Profile(req)
 			if err != nil {
 				// Reply with error.
+				//nolint:errcheck // error will be returned on next send
 				d.send(&protos.WeaveletMsg{Id: -id, Error: err.Error()})
 				return
 			}
 			// Reply with profile data.
+			//nolint:errcheck // error will be returned on next send
 			d.send(&protos.WeaveletMsg{Id: -id, Profile: &protos.Profile{
 				AppName:   req.AppName,
 				VersionId: req.VersionId,
@@ -226,8 +228,9 @@ func (d *WeaveletConn) send(msg *protos.WeaveletMsg) error {
 }
 
 // SendLogEntry sends a log entry to the envelope, without waiting for a reply.
-func (d *WeaveletConn) SendLogEntry(entry *protos.LogEntry) error {
-	return d.send(&protos.WeaveletMsg{LogEntry: entry})
+func (d *WeaveletConn) SendLogEntry(entry *protos.LogEntry) {
+	//nolint:errcheck // error will be returned on next send
+	d.send(&protos.WeaveletMsg{LogEntry: entry})
 }
 
 // SendTraceSpans sends a set of trace spans to the envelope, without waiting


### PR DESCRIPTION
Closes #90

This PR completes the work to enable the `errcheck` linter on non-test files. There are two changes:

1. handle and print errors related to serving the perfetto backend
2. ignore errors from async calls to `conn.send`. `conn.send` captures the error as `conn.failure`, and any subsequent calls to `send` will return the first error. Ignoring the `send` error is these cases should be safe because  because the error will be related a bit later, not completely lost.