### PR TITLE
Remove from runtime/envelope

### DIFF
--- a/internal/tool/ssh/impl/babysitter.go
+++ b/internal/tool/ssh/impl/babysitter.go
@@ -65,6 +65,7 @@ func RunBabysitter(ctx context.Context) error {
 	}
 	logSaver := fs.Add
 
+	id := uuid.New().String()
 	b := &babysitter{
 		ctx:       ctx,
 		dep:       info.Deployment,
@@ -77,7 +78,7 @@ func RunBabysitter(ctx context.Context) error {
 				Deployment: info.Deployment.Id,
 				Component:  "Babysitter",
 				Weavelet:   uuid.NewString(),
-				Attrs:      []string{"serviceweaver/system", ""},
+				Attrs:      []string{"serviceweaver/system", "", "weavelet", id},
 			},
 			Write: logSaver,
 		},
@@ -93,7 +94,6 @@ func RunBabysitter(ctx context.Context) error {
 	}
 
 	// Start the envelope.
-	id := uuid.New().String()
 	wlet := &protos.WeaveletInfo{
 		App:           b.dep.App.Name,
 		DeploymentId:  b.dep.Id,
@@ -121,7 +121,7 @@ func (b *babysitter) collectMetrics() {
 		case <-tickerCollectMetrics.C:
 			ms, err := b.envelope.ReadMetrics()
 			if err != nil {
-				b.logger.Error("Unable to collect metrics", err, "weavelet", b.envelope.Weavelet().Id)
+				b.logger.Error("Unable to collect metrics", err)
 				continue
 			}
 			ms = append(ms, metrics.Snapshot()...)

--- a/runtime/envelope/envelope.go
+++ b/runtime/envelope/envelope.go
@@ -388,10 +388,6 @@ func (e *Envelope) copyLines(component string, src io.Reader) error {
 	}
 }
 
-func (e *Envelope) Weavelet() *protos.WeaveletInfo {
-	return e.weavelet
-}
-
 func dropNewline(line []byte) []byte {
 	if len(line) > 0 && line[len(line)-1] == '\n' {
 		line = line[:len(line)-1]

--- a/runtime/envelope/envelope.go
+++ b/runtime/envelope/envelope.go
@@ -374,7 +374,7 @@ func (e *Envelope) ReadMetrics() ([]*metrics.MetricSnapshot, error) {
 	if conn == nil {
 		return nil, fmt.Errorf("cannot read metrics: weavelet pipe is down")
 	}
-	return e.conn.GetMetricsRPC()
+	return conn.GetMetricsRPC()
 }
 
 func (e *Envelope) isStopped() bool {

--- a/runtime/envelope/envelope_test.go
+++ b/runtime/envelope/envelope_test.go
@@ -272,7 +272,6 @@ func TestBigPrints(t *testing.T) {
 	ctx := context.Background()
 	var entries []*protos.LogEntry
 	var m sync.Mutex
-	opts := Options{Restart: Never}
 	h := &handlerForTest{logSaver: func(entry *protos.LogEntry) {
 		m.Lock()
 		defer m.Unlock()
@@ -281,7 +280,7 @@ func TestBigPrints(t *testing.T) {
 
 	n := 10000
 	wlet, config := wlet(executable, "bigprint", strconv.Itoa(n))
-	e, err := NewEnvelope(wlet, config, h, opts)
+	e, err := NewEnvelope(wlet, config, h, Options{Restart: Never})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,10 +308,9 @@ func TestCancel(t *testing.T) {
 		name := fmt.Sprintf("%v", restart)
 		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
-			opts := Options{}
 			wlet, config := wlet(executable, "loop")
 			e, err := NewEnvelope(wlet, config,
-				&handlerForTest{logSaver: testSaver(t)}, opts)
+				&handlerForTest{logSaver: testSaver(t)}, Options{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/weavertest/multi.go
+++ b/weavertest/multi.go
@@ -30,10 +30,8 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"github.com/ServiceWeaver/weaver/runtime/colors"
-	"github.com/ServiceWeaver/weaver/runtime/envelope"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
-	"github.com/ServiceWeaver/weaver/runtime/retry"
 	"github.com/google/uuid"
 )
 
@@ -115,24 +113,8 @@ func initMultiProcess(ctx context.Context, t testing.TB, config string) weaver.I
 		t.Fatal(fmt.Errorf("cannot create envelope conn: %v", err))
 	}
 
-	// Create and run an envelope for the main process.
-	options := envelope.Options{
-		Restart:         envelope.Never,
-		Retry:           retry.DefaultOptions,
-		GetEnvelopeConn: func() *conn.EnvelopeConn { return econn },
-	}
-	e, err := envelope.NewEnvelope(weaveletInfo, dep.App, b, options)
-	if err != nil {
-		t.Fatal(fmt.Errorf("cannot create envelope: %v", err))
-	}
-
 	go func() {
 		if err := econn.Run(); err != nil {
-			t.Error(err)
-		}
-	}()
-	go func() {
-		if err := e.Run(ctx); err != nil {
 			t.Error(err)
 		}
 	}()


### PR DESCRIPTION
This PR is a small collection of cleanups in the `runtime/envelope` package for your consideration. There may be good reasons not to make these changes. I'm happy to remove any of the commits in this PR.  

I've made each change in a separate commit, and provided more detail in the commit messages, so may be best viewed by individual commit. Two of the changes are very small, the the larger changes are:

1. Use `type EnvelopeHandler conn.EnvelopeHandler` to remove the duplicate definition of `EnvelopeHandler`.
2. Replace `Options.GetEnvelopeConn` with an exported `SetConn`.