### PR TITLE
Only run cloud build when pushing to main.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,8 @@ name: Build and Test
 
 on:
  push:
+   branches:
+     - 'main'
  pull_request:
 
 jobs:


### PR DESCRIPTION
Before this PR, a GitHub action built the code whenever it was pushed or whenever a pull request was created. If you pushed a branch and opened a pull request for it, all the checks would run twice. This PR changes the GitHub action to run when pushed to main or when a pull request is opened. This should prevent the actions from running twice.

See [here][1] for more information.

[1]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push