### PR TITLE
fix multi deploy on Windows

### DIFF
--- a/internal/pipe/inherited.go
+++ b/internal/pipe/inherited.go
@@ -1,0 +1,31 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package pipe
+
+import (
+	"os"
+	"os/exec"
+)
+
+// addInheritedFile add a file that will be inherited by the new process.
+func addInheritedFile(cmd *exec.Cmd, file *os.File) uintptr {
+	// From https://pkg.go.dev/os/exec#Cmd.ExtraFiles: "entry i becomes file
+	// descriptor 3+i".
+	fd := 3 + len(cmd.ExtraFiles)
+	cmd.ExtraFiles = append(cmd.ExtraFiles, file)
+	return uintptr(fd)
+}

--- a/internal/pipe/inherited_windows.go
+++ b/internal/pipe/inherited_windows.go
@@ -1,0 +1,32 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipe
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// addInheritedFile add a file that will be inherited by the new process.
+// Note that the file must be marked as inheritable.
+func addInheritedFile(cmd *exec.Cmd, file *os.File) uintptr {
+	fd := file.Fd()
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.AdditionalInheritedHandles = append(cmd.SysProcAttr.AdditionalInheritedHandles, syscall.Handle(fd))
+	return fd
+}

--- a/runtime/envelope/envelope.go
+++ b/runtime/envelope/envelope.go
@@ -271,8 +271,8 @@ func (e *Envelope) runWeavelet(ctx context.Context) error {
 	}
 
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", runtime.ToWeaveletKey, strconv.Itoa(toWeaveletFd)))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", runtime.ToEnvelopeKey, strconv.Itoa(toEnvelopeFd)))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", runtime.ToWeaveletKey, strconv.FormatUint(uint64(toWeaveletFd), 10)))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", runtime.ToEnvelopeKey, strconv.FormatUint(uint64(toEnvelopeFd), 10)))
 	cmd.Env = append(cmd.Env, e.config.Env...)
 
 	// Different sources are read from by different go-routines.

--- a/weavertest/multi.go
+++ b/weavertest/multi.go
@@ -158,8 +158,8 @@ func initMultiProcess(ctx context.Context, t testing.TB, config string) weaver.I
 	})
 
 	initCtx := context.WithValue(ctx, runtime.BootstrapKey{}, runtime.Bootstrap{
-		ToWeaveletFd: int(toWeaveletReader.Fd()),
-		ToEnvelopeFd: int(fromWeaveletWriter.Fd()),
+		ToWeaveletFd: toWeaveletReader.Fd(),
+		ToEnvelopeFd: fromWeaveletWriter.Fd(),
 		TestConfig:   config,
 	})
 	return weaver.Init(initCtx)


### PR DESCRIPTION
This PR fixes a problem with multi-process deployment on Windows. The windows inherit pipe uses handles, cmd.ExtraFiles is not supported on Windows. See issue https://github.com/ServiceWeaver/weaver/issues/127