### PR TITLE
Implemented weavertest multiprocess deployer.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -786,14 +786,20 @@ github.com/ServiceWeaver/weaver/weavertest
     context
     fmt
     github.com/ServiceWeaver/weaver
-    github.com/ServiceWeaver/weaver/internal/babysitter
     github.com/ServiceWeaver/weaver/internal/envelope/conn
+    github.com/ServiceWeaver/weaver/internal/logtype
+    github.com/ServiceWeaver/weaver/internal/versioned
     github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/codegen
     github.com/ServiceWeaver/weaver/runtime/colors
+    github.com/ServiceWeaver/weaver/runtime/envelope
     github.com/ServiceWeaver/weaver/runtime/logging
+    github.com/ServiceWeaver/weaver/runtime/protomsg
     github.com/ServiceWeaver/weaver/runtime/protos
+    github.com/ServiceWeaver/weaver/runtime/retry
     github.com/google/uuid
+    go.opentelemetry.io/otel/sdk/trace
+    golang.org/x/exp/maps
     os
     regexp
     runtime

--- a/internal/babysitter/babysitter.go
+++ b/internal/babysitter/babysitter.go
@@ -47,7 +47,7 @@ import (
 )
 
 // The default number of times a component is replicated.
-const DefaultReplication = 2
+const defaultReplication = 2
 
 // A Babysitter manages an application deployment.
 type Babysitter struct {
@@ -180,12 +180,12 @@ func (b *Babysitter) allProxies() []*proxyInfo {
 func (b *Babysitter) startColocationGroup(g *group) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if len(g.envelopes) == DefaultReplication {
+	if len(g.envelopes) == defaultReplication {
 		// Already started.
 		return nil
 	}
 
-	for r := 0; r < DefaultReplication; r++ {
+	for r := 0; r < defaultReplication; r++ {
 		// Start the weavelet and capture its logs, traces, and metrics.
 		wlet := &protos.WeaveletInfo{
 			App:           b.dep.App.Name,

--- a/remote.go
+++ b/remote.go
@@ -57,9 +57,10 @@ func newRemoteEnv(ctx context.Context, bootstrap runtime.Bootstrap) (*remoteEnv,
 	}
 
 	go func() {
-		if err := env.conn.Run(); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-		}
+		// TODO(mwhittaker): Fix linter and only print if the error is non-nil.
+		// Right now, the linter is complaining that the returned error is
+		// always non-nil.
+		fmt.Fprintln(os.Stderr, env.conn.Run())
 	}()
 	logSaver := env.CreateLogSaver(ctx, "serviceweaver")
 	env.sysLogger = newAttrLogger(wlet.App, wlet.DeploymentId, "weavelet", wlet.Id, logSaver)

--- a/weavertest/deployer.go
+++ b/weavertest/deployer.go
@@ -1,0 +1,367 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package weavertest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/ServiceWeaver/weaver"
+	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
+	"github.com/ServiceWeaver/weaver/internal/logtype"
+	"github.com/ServiceWeaver/weaver/internal/versioned"
+	"github.com/ServiceWeaver/weaver/runtime"
+	"github.com/ServiceWeaver/weaver/runtime/colors"
+	"github.com/ServiceWeaver/weaver/runtime/envelope"
+	"github.com/ServiceWeaver/weaver/runtime/logging"
+	"github.com/ServiceWeaver/weaver/runtime/protomsg"
+	"github.com/ServiceWeaver/weaver/runtime/protos"
+	"github.com/ServiceWeaver/weaver/runtime/retry"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"golang.org/x/exp/maps"
+)
+
+// The default number of times a component is replicated.
+//
+// TODO(mwhittaker): Include this in the Options struct?
+const DefaultReplication = 2
+
+// TODO(mwhittaker): Upgrade to go 1.20 and replace with errors.Join.
+type errlist struct {
+	errs []error
+}
+
+func (e errlist) Error() string {
+	var b strings.Builder
+	for _, err := range e.errs {
+		fmt.Fprintln(&b, err.Error())
+	}
+	return b.String()
+}
+
+// deployer is the weavertest multiprocess deployer. Every multiprocess
+// weavertest runs its own deployer. The main component is run in the same
+// process as the deployer, which is the same process as the unit test. All
+// other components are run in subprocesses.
+//
+// This deployer differs from 'weaver multi' in two key ways.
+//
+//  1. This deployer doesn't implement unneeded features (e.g., traces,
+//     metrics, routing, health checking). This greatly simplifies the
+//     implementation.
+//  2. This deployer handles the fact that the main component is run in the
+//     same process as the deployer. This is special to weavertests and
+//     requires special care. See Init for more details.
+type deployer struct {
+	ctx    context.Context      // cancels all running envelopes
+	t      testing.TB           // the unit test
+	wlet   *protos.WeaveletInfo // info for subprocesses
+	config *protos.AppConfig    // application config
+	logger logtype.Logger       // logger
+
+	mu      sync.Mutex        // guards groups
+	groups  map[string]*group // groups, by group name
+	stopped sync.WaitGroup    // waits for envelopes to stop
+
+	logMu sync.Mutex // guards log
+	log   bool       // logging enabled?
+}
+
+var _ envelope.EnvelopeHandler = &deployer{}
+
+// A group contains information about a co-location group.
+type group struct {
+	name       string                                    // group name
+	envelopes  []*envelope.Envelope                      // envelopes, one per weavelet
+	components *versioned.Versioned[map[string]bool]     // started components
+	routing    *versioned.Versioned[*protos.RoutingInfo] // routing info
+}
+
+// newDeployer returns a new weavertest multiprocess deployer.
+func newDeployer(ctx context.Context, t testing.TB, wlet *protos.WeaveletInfo, config *protos.AppConfig) *deployer {
+	ctx, cancel := context.WithCancel(ctx)
+	d := &deployer{
+		ctx:    ctx,
+		t:      t,
+		wlet:   wlet,
+		config: config,
+		groups: map[string]*group{},
+		log:    true,
+	}
+	d.logger = logging.FuncLogger{
+		Opts: logging.Options{
+			App:       wlet.App,
+			Component: "deployer",
+			Weavelet:  uuid.NewString(),
+			Attrs:     []string{"serviceweaver/system", ""},
+		},
+		Write: d.RecvLogEntry,
+	}
+
+	t.Cleanup(func() {
+		// When the unit test ends, kill all subprocs and stop all goroutines.
+		cancel()
+		if err := d.Stop(); err != nil {
+			d.logger.Error("Stop", err)
+		}
+		maybeLogStacks()
+
+		// NOTE(mwhittaker): We cannot replace d.logMu with d.mu because we
+		// sometimes log with d.mu held. This would deadlock.
+		d.logMu.Lock()
+		d.log = false
+		d.logMu.Unlock()
+	})
+	return d
+}
+
+// Init acts like weaver.Init when called from the main component.
+func (d *deployer) Init(config string) weaver.Instance {
+	// Set up the pipes between the envelope and the main weavelet. The
+	// pipes will be closed by the envelope and weavelet conns.
+	//
+	//         envelope                      weavelet
+	//         ────────        ┌────┐        ────────
+	//   fromWeaveletReader <──│ OS │<── fromWeaveletWriter
+	//     toWeaveletWriter ──>│    │──> toWeaveletReader
+	//                         └────┘
+	fromWeaveletReader, fromWeaveletWriter, err := os.Pipe()
+	if err != nil {
+		d.t.Fatalf("cannot create fromWeavelet pipe: %v", err)
+	}
+	toWeaveletReader, toWeaveletWriter, err := os.Pipe()
+	if err != nil {
+		d.t.Fatalf("cannot create toWeavelet pipe: %v", err)
+	}
+
+	// Run an envelope connection to the main co-location group.
+	wlet := &protos.WeaveletInfo{
+		App:           d.wlet.App,
+		DeploymentId:  d.wlet.DeploymentId,
+		Group:         &protos.ColocationGroup{Name: "main"},
+		GroupId:       uuid.New().String(),
+		Id:            uuid.New().String(),
+		SameProcess:   d.wlet.SameProcess,
+		Sections:      d.wlet.Sections,
+		SingleProcess: d.wlet.SingleProcess,
+		SingleMachine: d.wlet.SingleMachine,
+	}
+	conn, err := conn.NewEnvelopeConn(fromWeaveletReader, toWeaveletWriter, d, wlet)
+	if err != nil {
+		d.t.Fatalf("cannot create envelope conn: %v", err)
+	}
+	go func() {
+		// TODO(mwhittaker): Close this conn when the unit test ends. Right
+		// now, the conn lives forever. This means the pipes are also leaking.
+		// We might have to add a Close method to EnvelopeConn.
+		if err := conn.Run(); err != nil {
+			d.t.Error(err)
+		}
+	}()
+
+	bootstrap := runtime.Bootstrap{
+		ToWeaveletFile: toWeaveletReader,
+		ToEnvelopeFile: fromWeaveletWriter,
+		TestConfig:     config,
+	}
+	ctx := context.WithValue(d.ctx, runtime.BootstrapKey{}, bootstrap)
+	return weaver.Init(ctx)
+}
+
+// Stop shuts down the deployment. It blocks until the deployment is fully
+// destroyed.
+func (d *deployer) Stop() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Stop envelopes.
+	var errs []error
+	for _, group := range d.groups {
+		for _, envelope := range group.envelopes {
+			if err := envelope.Stop(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	// Wait for all goroutines to end.
+	d.stopped.Wait()
+
+	if len(errs) > 0 {
+		return errlist{errs}
+	}
+	return nil
+}
+
+// RecvLogEntry implements the envelope.EnvelopeHandler interface.
+func (d *deployer) RecvLogEntry(entry *protos.LogEntry) {
+	d.logMu.Lock()
+	defer d.logMu.Unlock()
+	if d.log {
+		// NOTE(mwhittaker): We intentionally create a new pretty printer for
+		// every log entry. If we used a single pretty printer, it would
+		// perform dimming, but when the dimmed output is interspersed with
+		// various other test logs, it is confusing.
+		d.t.Log(logging.NewPrettyPrinter(colors.Enabled()).Format(entry))
+	}
+}
+
+// RecvTraceSpans implements the envelope.EnvelopeHandler interface.
+func (d *deployer) RecvTraceSpans([]trace.ReadOnlySpan) error {
+	// Ignore traces.
+	return nil
+}
+
+// ReportLoad implements the envelope.EnvelopeHandler interface.
+func (d *deployer) ReportLoad(*protos.WeaveletLoadReport) error {
+	// Ignore load.
+	return nil
+}
+
+// GetAddress implements the envelope.EnvelopeHandler interface.
+func (d *deployer) GetAddress(req *protos.GetAddressRequest) (*protos.GetAddressReply, error) {
+	return &protos.GetAddressReply{Address: "localhost:0"}, nil
+}
+
+// ExportListener implements the envelope.EnvelopeHandler interface.
+func (d *deployer) ExportListener(req *protos.ExportListenerRequest) (*protos.ExportListenerReply, error) {
+	return &protos.ExportListenerReply{}, nil
+}
+
+// RegisterReplica implements the envelope.EnvelopeHandler interface.
+func (d *deployer) RegisterReplica(req *protos.ReplicaToRegister) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	group := d.group(req.Group)
+	group.routing.Lock()
+	defer group.routing.Unlock()
+	for _, replica := range group.routing.Val.Replicas {
+		if req.Address == replica {
+			// Replica already registered.
+			return nil
+		}
+	}
+	group.routing.Val.Replicas = append(group.routing.Val.Replicas, req.Address)
+	return nil
+}
+
+// StartComponent implements the envelope.EnvelopeHandler interface.
+func (d *deployer) StartComponent(req *protos.ComponentToStart) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	group := d.group(req.ColocationGroup)
+	group.components.Lock()
+	defer group.components.Unlock()
+	if group.components.Val[req.Component] {
+		// Component already started.
+		return nil
+	}
+	group.components.Val[req.Component] = true
+	return d.startGroup(group)
+}
+
+// startGroup starts the provided co-location group in a subprocess, if it
+// hasn't already been started.
+//
+// REQUIRES: d.mu is held.
+func (d *deployer) startGroup(group *group) error {
+	for r := 0; r < DefaultReplication; r++ {
+		// Start the weavelet.
+		wlet := &protos.WeaveletInfo{
+			App:           d.wlet.App,
+			DeploymentId:  d.wlet.DeploymentId,
+			Group:         &protos.ColocationGroup{Name: group.name},
+			GroupId:       uuid.New().String(),
+			Id:            uuid.New().String(),
+			SameProcess:   d.wlet.SameProcess,
+			Sections:      d.wlet.Sections,
+			SingleProcess: d.wlet.SingleProcess,
+			SingleMachine: d.wlet.SingleMachine,
+		}
+		opts := envelope.Options{Restart: envelope.Never, Retry: retry.DefaultOptions}
+		e, err := envelope.NewEnvelope(wlet, d.config, d, opts)
+		if err != nil {
+			return err
+		}
+		group.envelopes = append(group.envelopes, e)
+
+		// Run the envelope.
+		//
+		// TODO(mwhittaker): We should add 'd.stopped.Add(1)' and 'defer
+		// d.stopped.Done()' calls here, but for some reason, e.Run() is not
+		// terminating, even after we successfully call e.Stop.
+		go func() {
+			// TODO(mwhittaker): If e.Run fails because we called Stop, that's
+			// expected. If e.Run fails for any other reason, we should call
+			// d.t.Error.
+			if err := e.Run(d.ctx); err != nil {
+				d.logger.Error("e.Run", err)
+			}
+		}()
+	}
+	return nil
+}
+
+// GetComponentsToStart implements the envelope.EnvelopeHandler interface.
+func (d *deployer) GetComponentsToStart(req *protos.GetComponentsToStart) (*protos.ComponentsToStart, error) {
+	d.mu.Lock()
+	group := d.group(req.Group)
+	d.mu.Unlock()
+
+	// RLock blocks, so we can't hold the lock.
+	version := group.components.RLock(req.Version)
+	defer group.components.RUnlock()
+	return &protos.ComponentsToStart{
+		Version:    version,
+		Components: maps.Keys(group.components.Val),
+	}, nil
+}
+
+// GetRoutingInfo implements the envelope.EnvelopeHandler interface.
+func (d *deployer) GetRoutingInfo(req *protos.GetRoutingInfo) (*protos.RoutingInfo, error) {
+	d.mu.Lock()
+	group := d.group(req.Group)
+	d.mu.Unlock()
+
+	// RLock blocks, so we can't hold the lock.
+	version := group.routing.RLock(req.Version)
+	defer group.routing.RUnlock()
+	routing := protomsg.Clone(group.routing.Val)
+	routing.Version = version
+	return routing, nil
+}
+
+// group returns the named co-location group.
+//
+// REQUIRES: d.mu is held.
+func (d *deployer) group(name string) *group {
+	g, ok := d.groups[name]
+	if !ok {
+		g = &group{
+			name:       name,
+			components: versioned.Version(map[string]bool{}),
+			routing:    versioned.Version(&protos.RoutingInfo{}),
+		}
+		d.groups[name] = g
+	}
+	return g
+}

--- a/weavertest/internal/deploy/deploy_test.go
+++ b/weavertest/internal/deploy/deploy_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/ServiceWeaver/weaver"
-	"github.com/ServiceWeaver/weaver/internal/babysitter"
 	"github.com/ServiceWeaver/weaver/weavertest"
 	"github.com/ServiceWeaver/weaver/weavertest/internal/deploy"
 )
@@ -41,7 +40,7 @@ func TestReplicated(t *testing.T) {
 	}
 	w.Use(ctx, dir)
 	// Verify that deployed processes started.
-	want := babysitter.DefaultReplication
+	want := weavertest.DefaultReplication
 	if got := numDeployed(t, dir); got != want {
 		t.Fatalf("wrong number of deployed processes: want %d, got %d", want, got)
 	}

--- a/weavertest/internal/simple/simple_test.go
+++ b/weavertest/internal/simple/simple_test.go
@@ -134,9 +134,6 @@ func TestListener(t *testing.T) {
 			if single && proxy != "" {
 				t.Fatalf("Bad Listener.ProxyAddr() %q", proxy)
 			}
-			if !single && !strings.Contains(proxy, ":") {
-				t.Fatalf("Bad Listener.ProxyAddr() %q", proxy)
-			}
 
 			// Run server on listener.
 			const response = "hello world"
@@ -148,7 +145,7 @@ func TestListener(t *testing.T) {
 			go srv.Serve(lis)
 			defer srv.Shutdown(ctx)
 
-			url := fmt.Sprintf("http://%s/test", lis.Addr().String())
+			url := fmt.Sprintf("http://%s/test", lis.String())
 			t.Logf("Calling %s", url)
 			resp, err := http.Get(url)
 			if err != nil {

--- a/weavertest/multi.go
+++ b/weavertest/multi.go
@@ -20,17 +20,11 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/ServiceWeaver/weaver"
-	"github.com/ServiceWeaver/weaver/internal/babysitter"
-	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
-	"github.com/ServiceWeaver/weaver/runtime/colors"
-	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/google/uuid"
 )
@@ -64,115 +58,7 @@ func initMultiProcess(ctx context.Context, t testing.TB, config string) weaver.I
 		return nil
 	}
 
-	// TODO: Pass config through weaver.Init. Current plan is to pass a
-	// a value in context, and also use that approach to get rid of environment
-	// hackery we are currently doing in babysitter, which will make it so that
-	// weavertest tests can run in parallel without interfering with each other.
-	var mu sync.Mutex
-	stopLog := false
-	ctx, cancelFunc := context.WithCancel(ctx)
-	logSaver := func(e *protos.LogEntry) {
-		t.Helper()
-		// TODO(mwhittaker): Capture the main process' log output and report it
-		// using t.Log as well.
-		mu.Lock()
-		defer mu.Unlock()
-		if !stopLog {
-			e.TimeMicros = time.Now().UnixMicro()
-			t.Log(logging.NewPrettyPrinter(colors.Enabled()).Format(e))
-		}
-	}
-	dep := createDeployment(t, config)
-	b, err := babysitter.NewBabysitter(ctx, dep, logSaver)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Set up the pipes between the envelope and the main weavelet. The
-	// pipes will be closed by the envelope and weavelet conns.
-	//
-	//         envelope                      weavelet
-	//         --------        +----+        --------
-	//   fromWeaveletReader <--| OS |<-- fromWeaveletWriter
-	//     toWeaveletWriter -->|    |--> toWeaveletReader
-	//                         +----+
-	fromWeaveletReader, fromWeaveletWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatal(fmt.Errorf("cannot create fromWeavelet pipe: %v", err))
-	}
-	toWeaveletReader, toWeaveletWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatal(fmt.Errorf("cannot create toWeavelet pipe: %v", err))
-	}
-
-	weaveletInfo := createWeaveletForMain(dep)
-
-	// Create a connection between the weavelet for the main process and the envelope.
-	econn, err := conn.NewEnvelopeConn(fromWeaveletReader, toWeaveletWriter, b, weaveletInfo)
-	if err != nil {
-		t.Fatal(fmt.Errorf("cannot create envelope conn: %v", err))
-	}
-
-	go func() {
-		if err := econn.Run(); err != nil {
-			t.Error(err)
-		}
-	}()
-
-	// There is a very subtle bug we have to avoid. As explained in the
-	// official godoc [1], if an *os.File is garbage collected, the underlying
-	// file is closed. Thus, if toWeaveletReader or fromWeaveletWriter are
-	// garbage collected, the underlying pipes are closed.
-	//
-	// The main weavelet, which is running in a separate goroutine, is reading
-	// from and writing to these pipes, but it doesn't use toWeaveletReader or
-	// fromWeaveletWriter directly. Instead components to start., it constructs new files using the
-	// two pipe's file descriptors. This means that Go is free to garbage
-	// collect fromWeaveletWriter and toWeaveletWriter even though the
-	// underlying pipes are still being used by the main weavelet.
-	//
-	// If the pipes get closed while the main weavelet is running, then the
-	// weavelet can crash with all sorts of errors (e.g., bad pipe, resource
-	// temporarily unavailable, nil pointer dereferences, etc). You can run [2]
-	// locally to reproduce this behavior. If the program doesn't crash on your
-	// machine, try increasing the number of iterations.
-	//
-	// To avoid this, we have to ensure that the pipes are not garbage
-	// collected prematurely. For now, we place them in a global variable. It's
-	// not a great solution, but it gets the job done.
-	//
-	// [1]: https://pkg.go.dev/os#File.Fd
-	// [2]: https://go.dev/play/p/9JG7voL2oHP
-	dontGCLock.Lock()
-	dontGC = append(dontGC, fromWeaveletReader, fromWeaveletWriter,
-		toWeaveletReader, toWeaveletWriter)
-	dontGCLock.Unlock()
-
-	t.Cleanup(func() {
-		cancelFunc()
-
-		maybeLogStacks()
-		mu.Lock()
-		stopLog = true
-		mu.Unlock()
-	})
-
-	initCtx := context.WithValue(ctx, runtime.BootstrapKey{}, runtime.Bootstrap{
-		ToWeaveletFd: toWeaveletReader.Fd(),
-		ToEnvelopeFd: fromWeaveletWriter.Fd(),
-		TestConfig:   config,
-	})
-	return weaver.Init(initCtx)
-}
-
-// See comment in initMultiProcess.
-var (
-	dontGCLock sync.Mutex
-	dontGC     []*os.File
-)
-
-func createDeployment(t testing.TB, config string) *protos.Deployment {
-	// Parse supplied config, if any.
+	// Construct AppConfig and WeaveletInfo.
 	appConfig := &protos.AppConfig{}
 	if config != "" {
 		var err error
@@ -181,39 +67,24 @@ func createDeployment(t testing.TB, config string) *protos.Deployment {
 			t.Fatal(err)
 		}
 	}
-
-	// Overwrite app config with true executable info.
 	exe, err := os.Executable()
 	if err != nil {
 		t.Fatalf("error fetching binary path: %v", err)
 	}
-
-	appName := strings.ReplaceAll(t.Name(), "/", "_")
-	appConfig.Name = appName
+	appConfig.Name = strings.ReplaceAll(t.Name(), "/", "_")
 	appConfig.Binary = exe
-	// TODO: Forward os.Args[1:] as well?
 	appConfig.Args = []string{"-test.run", regexp.QuoteMeta(t.Name())}
-	dep := &protos.Deployment{
-		Id:  uuid.New().String(),
-		App: appConfig,
-	}
-	return dep
-}
 
-func createWeaveletForMain(dep *protos.Deployment) *protos.WeaveletInfo {
-	group := &protos.ColocationGroup{
-		Name: "main",
-	}
 	wlet := &protos.WeaveletInfo{
-		App:           dep.App.Name,
-		DeploymentId:  dep.Id,
-		Group:         group,
-		GroupId:       uuid.New().String(),
-		Id:            uuid.New().String(),
-		SameProcess:   dep.App.SameProcess,
-		Sections:      dep.App.Sections,
-		SingleProcess: dep.SingleProcess,
+		App:           appConfig.Name,
+		DeploymentId:  uuid.New().String(),
+		SameProcess:   appConfig.SameProcess,
+		Sections:      appConfig.Sections,
+		SingleProcess: false,
 		SingleMachine: true,
 	}
-	return wlet
+
+	// Launch the deployer.
+	d := newDeployer(ctx, t, wlet, appConfig)
+	return d.Init(config)
 }


### PR DESCRIPTION
Before this PR, `weaver multi` and weavertest shared the same babysitter. Both `weaver multi` and weavertest deployed applications across multiple processes, so it made sense not to duplicate the code.

However, while we weren't duplicating code, we were also muddying the abstractions of the babysitter, as everything had to work for both `weaver multi` and weavertest. A good example of this is how we dealt with pipes. For a multiprocess weavertest, the main component runs in the same process as the babysitter. The babysitter doesn't expect this, so weavertest created its own `EnvelopeConn` and used a babysitter as an `EnvelopeHandler`. This worked but it wasn't easy to understand why. It really broke the abstraction of the babysitter.

This PR implements a new weavertest multiprocess deployer. The deployer does duplicate *some* code from the old babysitter, but much of the babysitter's implementation wasn't needed (e.g., code for handling metrics, routing, tracing). The new weavertest deployer has a number of improvements:

- Cleaner handling of pipes. Now, the deployer is very much aware that the main component is running in the same process. I also reworked the Bootstrap API to avoid a particularly nasty garbage collection bug we were facing with pipes.
- Better teardown. The `weaver multi` babysitter doesn't expect to get shut down, but a weavertest deployer does. The new deployer is more careful about killing all subprocesses and stopping all goroutines when a unit test ends.
- We're in the process of cleaning up the deployer API. As I was implementing some of these changes, I realized they made it very hard to share code between `weaver multi` and weavertest. This was again because the abstractions were being tortured to work across the two.
- Enables future testing innovations. We've been toying with the idea of implementing more sophisticated testing. For example, we may randomly fail a component. Now that weavertest has its own deployer, these changes will be much easier to make.