### PR TITLE
Fixed subtle potential EnvelopeConn deadlock.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.13.0
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771
 	golang.org/x/image v0.5.0
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/tools v0.2.0
 	google.golang.org/genproto v0.0.0-20221109142239-94d6d90a7d66

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/godeps.txt
+++ b/godeps.txt
@@ -369,6 +369,7 @@ github.com/ServiceWeaver/weaver/internal/envelope/conn
     github.com/ServiceWeaver/weaver/runtime/protomsg
     github.com/ServiceWeaver/weaver/runtime/protos
     go.opentelemetry.io/otel/sdk/trace
+    golang.org/x/sync/errgroup
     google.golang.org/protobuf/proto
     io
     net


### PR DESCRIPTION
###  The Bug

Recall that an envelope and a weavelet issue RPCs to one another via a pair of pipes. Before this PR, the envelope's main loop looked something like this:

```go
for {
    msg := &protos.WeaveletMsg{}
    e.conn.recv(msg)
    e.handleMessage(msg)
}
```

An envelope receives both RPC requests and RPC responses from the weavelet. `conn.recv` handles the RPC responses internally but returns all RPC requests, which are then handled by `handleMessage`.

This code is susceptible to a subtle deadlock. Consider what happens when, in the process of handling an RPC *from* the weavelet, `handleMessage` issues an RPC *to* the weavelet. `handleMessage` sends an RPC request to the weavelet and then blocks waiting for a response. The weavelet receives and responds to the request. Because `handleMessage` is blocking, `conn.recv` is never called, but `conn.recv` needs to be called to wake up `handleMessage`.

Currently, our code does not deadlock because none of our deployers issue RPCs to a weavelet when processing an RPC from a weavelet. However, [our pending deployer API changes][1] will make this communication pattern very common. When an envelope receives a request to start a component for example, the envelope will issue `UpdateComponent` RPCs to all the weavelets that should start the component.

### A Broken Fix

My first thought to fix the bug was to run every invocation of `handleMessage` in its own goroutine. This is similar to how our RPC server is implemented (see [`internal/net/call/call.go`][2]). However, the envelope is required to process RPCs from the weavelet in order. Among many reasons, this strict ordering guarantee ensures that logs are reported chronologically.

### This PR's Fix

This PR fixes the bug by instead running one goroutine to receive messages and another goroutine to handle them. Messages are exchanged between the two goroutines using a channel to preserve their order.

### A Proposed Fix

This PR works (I think), but I think the code is now a bit complicated. I think we may be able to simplify things if we used four pipes instead of two. The four pipes will be divided into two pairs. One pair will be used for RPCs from the envelope to the weavelet, and the other pair will be used for RPCs from the weavelet to the envelope.

[1]: https://github.com/ServiceWeaver/weaver/pull/162
[2]: https://github.com/ServiceWeaver/weaver/blob/dbe6df4ba8c063a18d41c5f51f9b70f47af67abc/internal/net/call/call.go#L716