### PR TITLE
Fix status cmd error on windows

### DIFF
--- a/internal/status/registry.go
+++ b/internal/status/registry.go
@@ -222,6 +222,10 @@ func (r *Registry) dead(ctx context.Context, reg Registration) bool {
 		// There is no status server for this deployment, so we consider
 		// the deployment dead.
 		return true
+	case errors.Is(err, syscall.Errno(10061)):
+		// The syscall.ECONNREFUSED doesn't work on Windows. Windows will return
+		// WSAECONNREFUSED(syscall.Errno = 10061) when the connection is refused.
+		return true
 	case err != nil:
 		// Something went wrong. The deployment may be dead, but we're not 100%
 		// sure, so we return false.


### PR DESCRIPTION
A dead deployment `Registry.dead()` will return `true` because the `syscall.ECONNREFUSED` doesn't work on Windows. So there will be problems when running the status command. Same issue https://github.com/ServiceWeaver/weaver/issues/111 https://github.com/ServiceWeaver/weaver/issues/130 https://github.com/ServiceWeaver/weaver/issues/187