### PR TITLE
Added multiple components to step-by-step tutorial

### DIFF
--- a/examples/hello/cache.go
+++ b/examples/hello/cache.go
@@ -1,0 +1,58 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/ServiceWeaver/weaver"
+)
+
+// Cache component.
+type Cache interface {
+	Set(ctx context.Context, key, value string) error
+	Get(ctx context.Context, key string) (string, error)
+}
+
+// Implementation of the Cache component.
+type cache struct {
+	weaver.Implements[Cache]
+	mu   sync.Mutex
+	data map[string]string
+}
+
+func (c *cache) Init(context.Context) error {
+	c.data = map[string]string{}
+	return nil
+}
+
+func (c *cache) Set(_ context.Context, key, value string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data[key] = value
+	return nil
+}
+
+func (c *cache) Get(_ context.Context, key string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	value, ok := c.data[key]
+	if !ok {
+		return "", fmt.Errorf("key %q not found", key)
+	}
+	return value, nil
+}

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -25,20 +25,22 @@ import (
 //go:generate ../../cmd/weaver/weaver generate
 
 func main() {
-	// Get a network listener on address "localhost:12345".
+	// Initialize the Service Weaver application.
 	root := weaver.Init(context.Background())
-	opts := weaver.ListenerOptions{LocalAddress: "localhost:12345"}
-	lis, err := root.Listener("hello", opts)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("hello listener available on %v\n", lis)
 
 	// Get a client to the Reverser component.
 	reverser, err := weaver.Get[Reverser](root)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Get a network listener on address "localhost:12345".
+	opts := weaver.ListenerOptions{LocalAddress: "localhost:12345"}
+	lis, err := root.Listener("hello", opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("hello listener available on %v\n", lis)
 
 	// Serve the /hello endpoint.
 	http.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {

--- a/examples/hello/weaver_gen.go
+++ b/examples/hello/weaver_gen.go
@@ -12,6 +12,18 @@ import (
 
 func init() {
 	codegen.Register(codegen.Registration{
+		Name:        "github.com/ServiceWeaver/weaver/examples/hello/Cache",
+		Iface:       reflect.TypeOf((*Cache)(nil)).Elem(),
+		New:         func() any { return &cache{} },
+		LocalStubFn: func(impl any, tracer trace.Tracer) any { return cache_local_stub{impl: impl.(Cache), tracer: tracer} },
+		ClientStubFn: func(stub codegen.Stub, caller string) any {
+			return cache_client_stub{stub: stub, setMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/hello/Cache", Method: "Set"}), getMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/hello/Cache", Method: "Get"})}
+		},
+		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
+			return cache_server_stub{impl: impl.(Cache), addLoad: addLoad}
+		},
+	})
+	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/examples/hello/Reverser",
 		Iface: reflect.TypeOf((*Reverser)(nil)).Elem(),
 		New:   func() any { return &reverser{} },
@@ -28,6 +40,45 @@ func init() {
 }
 
 // Local stub implementations.
+
+type cache_local_stub struct {
+	impl   Cache
+	tracer trace.Tracer
+}
+
+func (s cache_local_stub) Set(ctx context.Context, a0 string, a1 string) (err error) {
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "main.Cache.Set", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.Set(ctx, a0, a1)
+}
+
+func (s cache_local_stub) Get(ctx context.Context, a0 string) (r0 string, err error) {
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "main.Cache.Get", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.Get(ctx, a0)
+}
 
 type reverser_local_stub struct {
 	impl   Reverser
@@ -52,6 +103,121 @@ func (s reverser_local_stub) Reverse(ctx context.Context, a0 string) (r0 string,
 }
 
 // Client stub implementations.
+
+type cache_client_stub struct {
+	stub       codegen.Stub
+	setMetrics *codegen.MethodMetrics
+	getMetrics *codegen.MethodMetrics
+}
+
+func (s cache_client_stub) Set(ctx context.Context, a0 string, a1 string) (err error) {
+	// Update metrics.
+	start := time.Now()
+	s.setMetrics.Count.Add(1)
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "main.Cache.Set", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+		err = s.stub.WrapError(err)
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			s.setMetrics.ErrorCount.Add(1)
+		}
+		span.End()
+
+		s.setMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
+	}()
+
+	// Preallocate a buffer of the right size.
+	size := 0
+	size += (4 + len(a0))
+	size += (4 + len(a1))
+	enc := codegen.NewEncoder()
+	enc.Reset(size)
+
+	// Encode arguments.
+	enc.String(a0)
+	enc.String(a1)
+	var shardKey uint64
+
+	// Call the remote method.
+	s.setMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	var results []byte
+	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	if err != nil {
+		return
+	}
+	s.setMetrics.BytesReply.Put(float64(len(results)))
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	err = dec.Error()
+	return
+}
+
+func (s cache_client_stub) Get(ctx context.Context, a0 string) (r0 string, err error) {
+	// Update metrics.
+	start := time.Now()
+	s.getMetrics.Count.Add(1)
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "main.Cache.Get", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+		err = s.stub.WrapError(err)
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			s.getMetrics.ErrorCount.Add(1)
+		}
+		span.End()
+
+		s.getMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
+	}()
+
+	// Preallocate a buffer of the right size.
+	size := 0
+	size += (4 + len(a0))
+	enc := codegen.NewEncoder()
+	enc.Reset(size)
+
+	// Encode arguments.
+	enc.String(a0)
+	var shardKey uint64
+
+	// Call the remote method.
+	s.getMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	var results []byte
+	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	if err != nil {
+		return
+	}
+	s.getMetrics.BytesReply.Put(float64(len(results)))
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	r0 = dec.String()
+	err = dec.Error()
+	return
+}
 
 type reverser_client_stub struct {
 	stub           codegen.Stub
@@ -113,6 +279,74 @@ func (s reverser_client_stub) Reverse(ctx context.Context, a0 string) (r0 string
 }
 
 // Server stub implementations.
+
+type cache_server_stub struct {
+	impl    Cache
+	addLoad func(key uint64, load float64)
+}
+
+// GetStubFn implements the stub.Server interface.
+func (s cache_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
+	switch method {
+	case "Set":
+		return s.set
+	case "Get":
+		return s.get
+	default:
+		return nil
+	}
+}
+
+func (s cache_server_stub) set(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// Decode arguments.
+	dec := codegen.NewDecoder(args)
+	var a0 string
+	a0 = dec.String()
+	var a1 string
+	a1 = dec.String()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	appErr := s.impl.Set(ctx, a0, a1)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
+
+func (s cache_server_stub) get(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// Decode arguments.
+	dec := codegen.NewDecoder(args)
+	var a0 string
+	a0 = dec.String()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	r0, appErr := s.impl.Get(ctx, a0)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	enc.String(r0)
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
 
 type reverser_server_stub struct {
 	impl    Reverser

--- a/godeps.txt
+++ b/godeps.txt
@@ -147,6 +147,7 @@ github.com/ServiceWeaver/weaver/examples/hello
     log
     net/http
     reflect
+    sync
     time
 github.com/ServiceWeaver/weaver/examples/onlineboutique
     context


### PR DESCRIPTION
Before this PR, it wasn't clear from our docs how a component could get a handle to another component. This PR expands the step-by-step tutorial with a new `Cache` component used by the `Reverser` component. The step-by-step guide now explains `Init` methods and how components can get handles to one another. I also moved some text around so that components are now introduced before listeners.

See also #188 and #185.