### PR TITLE
Unflaked weavelet race condition.

### DIFF
--- a/env.go
+++ b/env.go
@@ -36,6 +36,9 @@ type env interface {
 	// listen on to receive messages from other weavelets.
 	WeaveletListener() net.Listener
 
+	// ServeWeaveletConn blocks serving requests from the envelope.
+	ServeWeaveletConn() error
+
 	// RegisterComponentToStart registers a component to start.
 	RegisterComponentToStart(ctx context.Context, component string, routed bool) error
 

--- a/remote.go
+++ b/remote.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"sync"
 
 	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
@@ -57,12 +56,6 @@ func newRemoteEnv(ctx context.Context, bootstrap runtime.Bootstrap, handler conn
 		conn: conn,
 	}
 
-	go func() {
-		// TODO(mwhittaker): Fix linter and only print if the error is non-nil.
-		// Right now, the linter is complaining that the returned error is
-		// always non-nil.
-		fmt.Fprintln(os.Stderr, env.conn.Serve())
-	}()
 	logSaver := env.CreateLogSaver(ctx, "serviceweaver")
 	env.sysLogger = newAttrLogger(info.App, info.DeploymentId, "weavelet", info.Id, logSaver)
 	env.sysLogger = env.sysLogger.With("serviceweaver/system", "")
@@ -77,6 +70,11 @@ func (e *remoteEnv) WeaveletSetupInfo() *protos.WeaveletSetupInfo {
 // WeaveletListener implements the Env interface.
 func (e *remoteEnv) WeaveletListener() net.Listener {
 	return e.conn.Listener()
+}
+
+// ServeWeaveletConn implements the Env interface.
+func (e *remoteEnv) ServeWeaveletConn() error {
+	return e.conn.Serve()
 }
 
 // RegisterComponentToStart implements the Env interface.

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -143,6 +143,11 @@ func (e *singleprocessEnv) WeaveletListener() net.Listener {
 	panic("singleprocess.WeaveletListener unimplemented")
 }
 
+func (e *singleprocessEnv) ServeWeaveletConn() error {
+	// Should never be called.
+	panic("singleprocess.ServeWeaveletConn unimplemented")
+}
+
 func (e *singleprocessEnv) RegisterComponentToStart(_ context.Context, component string, _ bool) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/weavelet.go
+++ b/weavelet.go
@@ -218,6 +218,8 @@ func (w *weavelet) start() (Instance, error) {
 	// method invocations are process-local and executed as regular go function
 	// calls.
 	if !w.info.SingleProcess {
+		startWork(w.ctx, "serve weavelet conn", w.env.ServeWeaveletConn)
+
 		lis := w.env.WeaveletListener()
 		addr := call.NetworkAddress(fmt.Sprintf("tcp://%s", lis.Addr().String()))
 		w.dialAddr = addr


### PR DESCRIPTION
Before this PR, there was a race condition in starting the weavelet. The weavelet created a `WeaveletConn` with itself as a handler. This `WeaveletConn` would immediately start serving requests and calling into the handler. However, the handler (i.e. the weavlet) wasn't yet fully constructed. There was a race between initializing some fields of the weavelet and those fields being used by the handler.

This PR fixes the race by delaying when the `WeaveletConn` starts serving until after the weavelet is fully initialized.