### PR TITLE
Remove unused parameters and remote-only methods from env interface

### DIFF
--- a/env.go
+++ b/env.go
@@ -16,7 +16,6 @@ package weaver
 
 import (
 	"context"
-	"net"
 
 	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
 	"github.com/ServiceWeaver/weaver/internal/logtype"
@@ -31,13 +30,6 @@ type env interface {
 	// WeaveletSetupInfo returns the weavelet's setup information sent by
 	// the deployer.
 	WeaveletSetupInfo() *protos.WeaveletSetupInfo
-
-	// WeaveletListener returns the internal listener the weavelet should
-	// listen on to receive messages from other weavelets.
-	WeaveletListener() net.Listener
-
-	// ServeWeaveletConn blocks serving requests from the envelope.
-	ServeWeaveletConn() error
 
 	// RegisterComponentToStart registers a component to start.
 	RegisterComponentToStart(ctx context.Context, component string, routed bool) error

--- a/env.go
+++ b/env.go
@@ -51,7 +51,7 @@ type env interface {
 
 	// CreateLogSaver creates and returns a function that saves log entries
 	// to the environment.
-	CreateLogSaver(ctx context.Context, component string) func(entry *protos.LogEntry)
+	CreateLogSaver() func(entry *protos.LogEntry)
 
 	// SystemLogger returns the Logger for system messages.
 	SystemLogger() logtype.Logger

--- a/env.go
+++ b/env.go
@@ -59,7 +59,7 @@ type env interface {
 	// CreateTraceExporter returns an exporter that should be used for
 	// exporting trace spans. A nil exporter value means that no traces
 	// should be exported.
-	CreateTraceExporter() (sdktrace.SpanExporter, error)
+	CreateTraceExporter() sdktrace.SpanExporter
 }
 
 // getEnv returns the env to use for this weavelet.

--- a/remote.go
+++ b/remote.go
@@ -56,7 +56,7 @@ func newRemoteEnv(ctx context.Context, bootstrap runtime.Bootstrap, handler conn
 		conn: conn,
 	}
 
-	logSaver := env.CreateLogSaver(ctx, "serviceweaver")
+	logSaver := env.CreateLogSaver()
 	env.sysLogger = newAttrLogger(info.App, info.DeploymentId, "weavelet", info.Id, logSaver)
 	env.sysLogger = env.sysLogger.With("serviceweaver/system", "")
 	return env, nil
@@ -105,7 +105,7 @@ func (e *remoteEnv) ExportListener(_ context.Context, lis *protos.Listener, opts
 }
 
 // CreateLogSaver implements the Env interface.
-func (e *remoteEnv) CreateLogSaver(context.Context, string) func(entry *protos.LogEntry) {
+func (e *remoteEnv) CreateLogSaver() func(entry *protos.LogEntry) {
 	return func(entry *protos.LogEntry) {
 		// Hold lock while creating entry and writing so that records are
 		// printed in timestamp order, and without their contents getting

--- a/remote.go
+++ b/remote.go
@@ -122,8 +122,8 @@ func (e *remoteEnv) SystemLogger() logtype.Logger {
 }
 
 // CreateTraceExporter implements the Env interface.
-func (e *remoteEnv) CreateTraceExporter() (sdktrace.SpanExporter, error) {
-	return traceio.NewWriter(e.conn.SendTraceSpans), nil
+func (e *remoteEnv) CreateTraceExporter() sdktrace.SpanExporter {
+	return traceio.NewWriter(e.conn.SendTraceSpans)
 }
 
 // parseEndpoints parses a list of endpoint addresses into a list of

--- a/remote.go
+++ b/remote.go
@@ -17,7 +17,6 @@ package weaver
 import (
 	"context"
 	"fmt"
-	"net"
 	"sync"
 
 	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
@@ -65,11 +64,6 @@ func newRemoteEnv(ctx context.Context, bootstrap runtime.Bootstrap, handler conn
 // WeaveletSetupInfo implements the Env interface.
 func (e *remoteEnv) WeaveletSetupInfo() *protos.WeaveletSetupInfo {
 	return e.info
-}
-
-// WeaveletListener implements the Env interface.
-func (e *remoteEnv) WeaveletListener() net.Listener {
-	return e.conn.Listener()
 }
 
 // ServeWeaveletConn implements the Env interface.

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -143,16 +143,6 @@ func (e *singleprocessEnv) WeaveletSetupInfo() *protos.WeaveletSetupInfo {
 	return e.info
 }
 
-func (e *singleprocessEnv) WeaveletListener() net.Listener {
-	// Should never be called.
-	panic("singleprocess.WeaveletListener unimplemented")
-}
-
-func (e *singleprocessEnv) ServeWeaveletConn() error {
-	// Should never be called.
-	panic("singleprocess.ServeWeaveletConn unimplemented")
-}
-
 func (e *singleprocessEnv) RegisterComponentToStart(_ context.Context, component string, _ bool) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -326,7 +326,7 @@ func (e *singleprocessEnv) Profile(_ context.Context, req *protos.RunProfiling) 
 	return profile, nil
 }
 
-func (e *singleprocessEnv) CreateLogSaver(_ context.Context, component string) func(entry *protos.LogEntry) {
+func (e *singleprocessEnv) CreateLogSaver() func(entry *protos.LogEntry) {
 	pp := logging.NewPrettyPrinter(colors.Enabled())
 	return func(entry *protos.LogEntry) {
 		fmt.Fprintln(os.Stderr, pp.Format(entry))

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -333,8 +333,8 @@ func (e *singleprocessEnv) CreateLogSaver() func(entry *protos.LogEntry) {
 	}
 }
 
-func (e *singleprocessEnv) CreateTraceExporter() (sdktrace.SpanExporter, error) {
-	return traceio.NewWriter(e.traceSaver), nil
+func (e *singleprocessEnv) CreateTraceExporter() sdktrace.SpanExporter {
+	return traceio.NewWriter(e.traceSaver)
 }
 
 func (e *singleprocessEnv) SystemLogger() logtype.Logger {

--- a/weavelet.go
+++ b/weavelet.go
@@ -212,10 +212,10 @@ func (w *weavelet) start() (Instance, error) {
 	// For a singleprocess deployment, no server is launched because all
 	// method invocations are process-local and executed as regular go function
 	// calls.
-	if !w.info.SingleProcess {
-		startWork(w.ctx, "serve weavelet conn", w.env.ServeWeaveletConn)
+	if remote, ok := w.env.(*remoteEnv); ok {
+		startWork(w.ctx, "serve weavelet conn", remote.conn.Serve)
 
-		lis := w.env.WeaveletListener()
+		lis := remote.conn.Listener()
 		addr := call.NetworkAddress(fmt.Sprintf("tcp://%s", lis.Addr().String()))
 		w.dialAddr = addr
 		for _, c := range w.componentsByName {

--- a/weavelet.go
+++ b/weavelet.go
@@ -202,7 +202,7 @@ func (w *weavelet) start() (Instance, error) {
 
 	if w.info.RunMain {
 		// Set appropriate logger and tracer for main.
-		logSaver := w.env.CreateLogSaver(w.ctx, "main")
+		logSaver := w.env.CreateLogSaver()
 		w.root.logger = newAttrLogger(
 			w.root.info.Name, w.info.DeploymentId, w.root.info.Name, w.info.Id, logSaver)
 	}
@@ -543,7 +543,7 @@ func (w *weavelet) getImpl(c *component) (*componentImpl, error) {
 		// component is still being constructed is easy to get wrong. Figure out a
 		// way to make this less error-prone.
 		c.impl = &componentImpl{component: c}
-		logSaver := w.env.CreateLogSaver(w.ctx, c.info.Name)
+		logSaver := w.env.CreateLogSaver()
 		logger := newAttrLogger(w.info.App, w.info.DeploymentId, c.info.Name, w.info.Id, logSaver)
 		c.logger = logger
 		c.tracer = w.tracer

--- a/weavelet.go
+++ b/weavelet.go
@@ -108,11 +108,6 @@ func newWeavelet(ctx context.Context, componentInfos []*codegen.Registration) (*
 	}
 	w.info = wletInfo
 
-	exporter, err := env.CreateTraceExporter()
-	if err != nil {
-		return nil, fmt.Errorf("internal error: cannot create trace exporter: %w", err)
-	}
-
 	for _, info := range componentInfos {
 		c := &component{
 			wlet: w,
@@ -132,7 +127,7 @@ func newWeavelet(ctx context.Context, componentInfos []*codegen.Registration) (*
 	const instrumentationLibrary = "github.com/ServiceWeaver/weaver/serviceweaver"
 	const instrumentationVersion = "0.0.1"
 	tracerProvider := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter),
+		sdktrace.WithBatcher(env.CreateTraceExporter()),
 		sdktrace.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
 			semconv.ServiceNameKey.String(fmt.Sprintf("serviceweaver/%s", wletInfo.Id)),


### PR DESCRIPTION
For your consideration, this PR removes a few things from the `env` interface.

The `CreateLogSaver` args were not used. Both callers use `newAttrLogger` to add attributes to the logger. This seems like a nice way to handle attributes. The error return from `CreateTraceExporter` was also not used.

The primary change is to remove the two remote-only methods from the interface. These methods are called from a block that is only used when not single process.