### PR TITLE
Merge envelope Serve() and Wait() methods.

### DIFF
--- a/internal/babysitter/babysitter.go
+++ b/internal/babysitter/babysitter.go
@@ -290,15 +290,14 @@ func (b *Babysitter) startColocationGroup(g *group) error {
 			return err
 		}
 		h.envelope = e
-		e.Serve(h)
-		if err := b.registerReplica(g, e.WeaveletInfo()); err != nil {
-			return err
-		}
 		b.running.Go(func() error {
-			err := e.Wait()
+			err := e.Serve(h)
 			b.stop(err)
 			return err
 		})
+		if err := b.registerReplica(g, e.WeaveletInfo()); err != nil {
+			return err
+		}
 		if err := e.UpdateComponents(components); err != nil {
 			return err
 		}

--- a/internal/tool/ssh/impl/babysitter.go
+++ b/internal/tool/ssh/impl/babysitter.go
@@ -110,8 +110,7 @@ func RunBabysitter(ctx context.Context) error {
 	}
 	c := metricsCollector{logger: b.logger, envelope: e, info: info}
 	go c.run(ctx)
-	e.Serve(b)
-	return e.Wait()
+	return e.Serve(b)
 }
 
 type metricsCollector struct {

--- a/weavertest/deployer.go
+++ b/weavertest/deployer.go
@@ -210,9 +210,8 @@ func (d *deployer) Init(config string) weaver.Instance {
 		subscribed: map[string]bool{},
 		conn:       connection{conn: e},
 	}
-	e.Serve(handler)
 	d.running.Go(func() error {
-		err := e.Wait()
+		err := e.Serve(handler)
 		d.stop(err)
 		return err
 	})
@@ -379,9 +378,8 @@ func (d *deployer) startGroup(g *group) error {
 		if err != nil {
 			return err
 		}
-		e.Serve(handler)
 		d.running.Go(func() error {
-			err := e.Wait()
+			err := e.Serve(handler)
 			d.stop(err)
 			return err
 		})


### PR DESCRIPTION
This simplifies the API and makes errors less likely (e.g., Wait() on an envelope without calling Serve() beforehand). Suggested by mwhittaker@.

Other changes:
  * Simplified the code for envelope/envelope-conn.