### PR TITLE
Allow envelope RPCs to proceed even before Serve() is called.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -368,6 +368,7 @@ github.com/ServiceWeaver/weaver/internal/envelope/conn
     bytes
     context
     fmt
+    github.com/ServiceWeaver/weaver/internal/queue
     github.com/ServiceWeaver/weaver/internal/traceio
     github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/metrics
@@ -441,6 +442,10 @@ github.com/ServiceWeaver/weaver/internal/proxy
     math/rand
     net/http
     net/http/httputil
+    sync
+github.com/ServiceWeaver/weaver/internal/queue
+    context
+    github.com/ServiceWeaver/weaver/internal/cond
     sync
 github.com/ServiceWeaver/weaver/internal/register
     fmt

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ServiceWeaver/weaver/internal/cond"
+)
+
+// Queue is a thread-safe queue.
+//
+// Unlike a Go channel, Queue doesn't have any constraints on how many
+// elements can be in the queue.
+type Queue[T any] struct {
+	mu    sync.Mutex
+	elems []T
+	wait  *cond.Cond
+}
+
+// Push places elem at the back of the queue.
+func (q *Queue[T]) Push(elem T) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.init()
+	q.elems = append(q.elems, elem)
+	q.wait.Signal()
+}
+
+// Pop removes the element from the front of the queue and returns it.
+// It blocks if the queue is empty.
+// It returns an error if the passed-in context is canceled.
+func (q *Queue[T]) Pop(ctx context.Context) (elem T, err error) {
+	if err = ctx.Err(); err != nil {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.init()
+	for len(q.elems) == 0 {
+		if err = q.wait.Wait(ctx); err != nil {
+			return
+		}
+	}
+	elem = q.elems[0]
+	q.elems = q.elems[1:]
+	return
+}
+
+// init initializes the queue.
+//
+// REQUIRES: q.mu is held
+func (q *Queue[T]) init() {
+	if q.wait == nil {
+		q.wait = cond.NewCond(&q.mu)
+	}
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1,0 +1,106 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ServiceWeaver/weaver/internal/queue"
+	"golang.org/x/sync/errgroup"
+)
+
+const x = 42
+
+func pop[E any](q *queue.Queue[E]) E {
+	elem, err := q.Pop(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	return elem
+
+}
+
+func TestPushThenPop(t *testing.T) {
+	var q queue.Queue[int]
+	q.Push(x)
+	if got, want := pop(&q), x; got != want {
+		t.Fatalf("Pop: got %v, want %v", got, want)
+	}
+}
+
+func TestPopThenPush(t *testing.T) {
+	var q queue.Queue[int]
+	go q.Push(x)
+	if got, want := pop(&q), x; got != want {
+		t.Fatalf("Pop: got %v, want %v", got, want)
+	}
+}
+
+func TestMultiplePoprs(t *testing.T) {
+	var q queue.Queue[int]
+	var group errgroup.Group
+	var sum atomic.Int64
+	for i := 0; i < 10; i++ {
+		group.Go(func() error {
+			got, err := q.Pop(context.Background())
+			if err != nil {
+				return err
+			}
+			sum.Add(int64(got))
+			return nil
+		})
+	}
+	time.Sleep(20 * time.Millisecond) // Give poprs a chance to block.
+	for i := 1; i < 11; i++ {
+		q.Push(i)
+	}
+	if err := group.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := sum.Load(), int64(55); got != want {
+		t.Fatalf("Pop: got %v, want %v", got, want)
+	}
+}
+
+func TestMultiplePushrs(t *testing.T) {
+	var q queue.Queue[int]
+	for i := 1; i < 11; i++ {
+		i := i
+		go q.Push(i)
+	}
+	var sum int
+	for i := 0; i < 10; i++ {
+		sum += pop(&q)
+	}
+	if sum != 55 {
+		t.Fatalf("Pop: got %v, want 55", sum)
+	}
+}
+
+func TestContextCancel(t *testing.T) {
+	var q queue.Queue[int]
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond) // Give popr a chance to block
+		cancel()
+	}()
+	if _, err := q.Pop(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Pop: got %v, want %v", err, context.Canceled)
+	}
+}


### PR DESCRIPTION
This prevents a deadlock in the following situation.

```
  e, err := NewEnvelope(ctx, wlet, config)
  e.UpdateComponents([]string{"foo", "bar"})
  err = e.Serve()
```

Based on discussions with mwhittaker@.