### PR TITLE
Enable misspell linter and fix typos

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@
 linters:
   enable:
     - nolintlint
+    - misspell
 issues:
   exclude-rules:
     - path: '_test\.go'

--- a/examples/onlineboutique/productcatalogservice/service.go
+++ b/examples/onlineboutique/productcatalogservice/service.go
@@ -152,7 +152,7 @@ func (s *impl) GetProduct(ctx context.Context, productID string) (Product, error
 func (s *impl) SearchProducts(ctx context.Context, query string) ([]Product, error) {
 	time.Sleep(s.extraLatency)
 
-	// Intepret query as a substring match in name or description.
+	// Interpret query as a substring match in name or description.
 	var ps []Product
 	for _, p := range s.parseCatalog() {
 		if strings.Contains(strings.ToLower(p.Name), strings.ToLower(query)) ||

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -66,7 +66,7 @@ func TestSplit(t *testing.T) {
 				t.Fatalf("env.Split(%q): %v", test.s, err)
 			}
 			if !test.good && err == nil {
-				t.Fatalf("env.Split(%q): unexpected succeess", test.s)
+				t.Fatalf("env.Split(%q): unexpected success", test.s)
 			}
 			if test.good && (k != test.k || v != test.v) {
 				t.Fatalf("env.Split(%q): got (%q, %q), want (%q, %q)", test.s, k, v, test.k, test.v)
@@ -94,7 +94,7 @@ func TestParse(t *testing.T) {
 				t.Fatalf("env.Parse(%v): %v", test.env, err)
 			}
 			if test.want == nil && err == nil {
-				t.Fatalf("env.Parse(%v): unexpected succeess", test.env)
+				t.Fatalf("env.Parse(%v): unexpected success", test.env)
 			}
 			if test.want != nil {
 				if diff := cmp.Diff(test.want, vars); diff != "" {

--- a/internal/envelope/conn/weavelet_conn.go
+++ b/internal/envelope/conn/weavelet_conn.go
@@ -204,7 +204,7 @@ func (d *WeaveletConn) GetAddressRPC(req *protos.GetAddressRequest) (*protos.Get
 		return nil, err
 	}
 	if reply.GetAddressReply == nil {
-		return nil, fmt.Errorf("nil GetAddressReply recieved from envelope")
+		return nil, fmt.Errorf("nil GetAddressReply received from envelope")
 	}
 	return reply.GetAddressReply, nil
 }

--- a/internal/net/call/constantresolver.go
+++ b/internal/net/call/constantresolver.go
@@ -20,7 +20,7 @@ import (
 )
 
 // constantResolver is a trivial constant resolver that returns a fixed set of
-// endponts.
+// endpoints.
 type constantResolver struct {
 	endpoints []Endpoint
 }

--- a/routing_test.go
+++ b/routing_test.go
@@ -31,7 +31,7 @@ type nilEndpoint struct{ Addr string }
 
 // Dial implements the call.Endpoint interface.
 func (nilEndpoint) Dial(context.Context) (net.Conn, error) {
-	return nil, fmt.Errorf("unimpemented")
+	return nil, fmt.Errorf("unimplemented")
 }
 
 // Address implements the call.Endpoint interface.


### PR DESCRIPTION
This PR enables `misspell` linter in `golangci-lint` config. Also, correct typos in comments, tests, and error messages.