### PR TITLE
move internal babysitter under the multi deployer tool

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -318,34 +318,6 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique/types/money
     fmt
     github.com/ServiceWeaver/weaver
     github.com/ServiceWeaver/weaver/runtime/codegen
-github.com/ServiceWeaver/weaver/internal/babysitter
-    context
-    errors
-    fmt
-    github.com/ServiceWeaver/weaver/internal/metrics
-    github.com/ServiceWeaver/weaver/internal/proxy
-    github.com/ServiceWeaver/weaver/internal/status
-    github.com/ServiceWeaver/weaver/runtime/envelope
-    github.com/ServiceWeaver/weaver/runtime/logging
-    github.com/ServiceWeaver/weaver/runtime/metrics
-    github.com/ServiceWeaver/weaver/runtime/perfetto
-    github.com/ServiceWeaver/weaver/runtime/profiling
-    github.com/ServiceWeaver/weaver/runtime/protomsg
-    github.com/ServiceWeaver/weaver/runtime/protos
-    github.com/google/uuid
-    go.opentelemetry.io/otel/sdk/trace
-    golang.org/x/exp/maps
-    golang.org/x/exp/slices
-    golang.org/x/exp/slog
-    golang.org/x/sync/errgroup
-    google.golang.org/protobuf/types/known/timestamppb
-    math
-    net
-    net/http
-    sort
-    sync
-    syscall
-    time
 github.com/ServiceWeaver/weaver/internal/benchmarks
     context
     fmt
@@ -516,24 +488,40 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     errors
     flag
     fmt
-    github.com/ServiceWeaver/weaver/internal/babysitter
     github.com/ServiceWeaver/weaver/internal/files
+    github.com/ServiceWeaver/weaver/internal/metrics
+    github.com/ServiceWeaver/weaver/internal/proxy
     github.com/ServiceWeaver/weaver/internal/status
     github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/codegen
     github.com/ServiceWeaver/weaver/runtime/colors
+    github.com/ServiceWeaver/weaver/runtime/envelope
     github.com/ServiceWeaver/weaver/runtime/logging
+    github.com/ServiceWeaver/weaver/runtime/metrics
+    github.com/ServiceWeaver/weaver/runtime/perfetto
+    github.com/ServiceWeaver/weaver/runtime/profiling
+    github.com/ServiceWeaver/weaver/runtime/protomsg
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/retry
     github.com/ServiceWeaver/weaver/runtime/tool
     github.com/google/uuid
+    go.opentelemetry.io/otel/sdk/trace
+    golang.org/x/exp/maps
+    golang.org/x/exp/slices
+    golang.org/x/exp/slog
+    golang.org/x/sync/errgroup
+    google.golang.org/protobuf/types/known/timestamppb
     io
+    math
     net
     net/http
     os
     os/signal
     path/filepath
+    sort
+    sync
     syscall
+    time
 github.com/ServiceWeaver/weaver/internal/tool/single
     context
     fmt

--- a/internal/tool/ssh/impl/manager.go
+++ b/internal/tool/ssh/impl/manager.go
@@ -300,7 +300,7 @@ func (m *manager) registerStatusPages(mux *http.ServeMux) {
 
 // Status implements the status.Server interface.
 //
-// TODO(rgrandl): the implementation is the same as the internal/babysitter.go.
+// TODO(rgrandl): the implementation is the same as the internal/tool/multi/deployer.go.
 // See if we can remove duplication.
 func (m *manager) Status(ctx context.Context) (*status.Status, error) {
 	stats := m.statsProcessor.GetStatsStatusz()


### PR DESCRIPTION
The internal babysitter is used only by the multi deployer. It makes sense to move it in the tool/multi directory.

Also, renamed babysitter to deployer, because really there is a single babysitter managing everything which is the actual deployer. Some methods can be private now.