### PR TITLE
Tweaked website's page widths and line heights.

### DIFF
--- a/website/assets/css/blog.css
+++ b/website/assets/css/blog.css
@@ -15,10 +15,8 @@
  */
 
 /* Limit the page content width to keep lines readable. */
-.page_blog {
-  padding-left: 20px;
-  padding-right: 20px;
-  max-width: 60em;
+.blog-contents {
+  max-width: 50rem;
   margin-left: auto;
   margin-right: auto;
 }

--- a/website/assets/css/common.css
+++ b/website/assets/css/common.css
@@ -46,9 +46,15 @@ code {
 
 /* Limit the page content width to keep lines readable. */
 .page {
-  max-width: 80em;
+  max-width: 65rem;
   margin-left: auto;
   margin-right: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.page p, .page li {
+  line-height: 1.5;
 }
 
 header {

--- a/website/assets/css/docs.css
+++ b/website/assets/css/docs.css
@@ -104,8 +104,12 @@
 .contents {
   flex: 1 0 auto;
   width: 10em;
-  padding-left: 1ch;
-  padding-right: 1ch;
+}
+
+@media (min-width: 800px) {
+  .contents {
+    padding-left: 1rem;
+  }
 }
 
 .contents pre {

--- a/website/assets/css/home.css
+++ b/website/assets/css/home.css
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-.contents {
-  padding-left: 4ch;
-  padding-right: 4ch;
-}
-
 #serviceweaver-jumbotron {
   background: rgba(255, 234, 167, 1.0);
   border-radius: 1em;
@@ -56,6 +51,12 @@
   padding: 0.75ch;
 }
 
+.serviceweaver-subtitle {
+  max-width: 75%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .intro-row {
   display: flex;
   flex-wrap: wrap;
@@ -73,7 +74,7 @@
   margin-left: auto;
   margin-right: auto;
   flex: 0 0 auto;
-  width: 45%;
+  width: 47%;
   min-width: 20em;
 }
 

--- a/website/index.html
+++ b/website/index.html
@@ -19,7 +19,7 @@
     Write your application as a <strong>modular binary</strong>. Deploy it
     as a set of <em>microservices</em>.
   </h1>
-  <p>
+  <p class="serviceweaver-subtitle">
     Service Weaver is a programming framework for writing and deploying cloud
     applications.
   </p>

--- a/website/templates/blog_entry.html
+++ b/website/templates/blog_entry.html
@@ -23,8 +23,8 @@
   </head>
   <body>
     {{template "header.html" .}}
-    <div class="page_blog">
-      <div class="contents">
+    <div class="page">
+      <div class="blog-contents">
         {{.Contents}}
       </div>
     </div>

--- a/website/templates/contact.html
+++ b/website/templates/contact.html
@@ -15,19 +15,17 @@ limitations under the License.
 -->
 
 <html>
-<head>
-  {{template "head.html" .}}
-  <title>Service Weaver Contact Us</title>
-  <link rel="stylesheet" href="/assets/css/common.css">
-</head>
-<body>
-{{template "header.html" .}}
-<div class="page">
-  <div class="contents">
-    {{.Contents}}
-  </div>
-</div>
-{{template "footer.html" .}}
-</body>
+  <head>
+    {{template "head.html" .}}
+    <title>Service Weaver Contact Us</title>
+    <link rel="stylesheet" href="/assets/css/common.css">
+  </head>
+  <body>
+    {{template "header.html" .}}
+    <div class="page">
+      {{.Contents}}
+    </div>
+    {{template "footer.html" .}}
+  </body>
 </html>
 

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -24,9 +24,7 @@
   <body>
     {{template "header.html" .}}
     <div class="page">
-      <div class="contents">
-        {{.Contents}}
-      </div>
+      {{.Contents}}
     </div>
     {{template "footer.html" .}}
   </body>


### PR DESCRIPTION
This PR tweaks the website's page widths and line heights. Specifically, I narrowed the default page width from 80rem to 65rem. I shrunk the blog posts to 50rem. I also increased the line-height from 1 to 1.5. I also some made some miscellaneous cleanups. I removed some unused CSS classes, fixed some padding issues, etc.

| before | after |
| - | - | 
| ![before](https://user-images.githubusercontent.com/3654277/229226688-862bdfcf-74c5-44c5-a24d-564fee9ba1d7.png) | ![after](https://user-images.githubusercontent.com/3654277/229226685-40fedc28-d0ab-409f-8dfd-322fae89baa4.png) |
