### PR TITLE
Added "weaver purge" command.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -380,6 +380,7 @@ github.com/ServiceWeaver/weaver/internal/metrics
     strings
     sync
     time
+github.com/ServiceWeaver/weaver/internal/must
 github.com/ServiceWeaver/weaver/internal/net/benchmarks
 github.com/ServiceWeaver/weaver/internal/net/call
     bufio
@@ -494,6 +495,7 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     fmt
     github.com/ServiceWeaver/weaver/internal/files
     github.com/ServiceWeaver/weaver/internal/metrics
+    github.com/ServiceWeaver/weaver/internal/must
     github.com/ServiceWeaver/weaver/internal/proxy
     github.com/ServiceWeaver/weaver/internal/status
     github.com/ServiceWeaver/weaver/runtime
@@ -530,6 +532,7 @@ github.com/ServiceWeaver/weaver/internal/tool/single
     context
     fmt
     github.com/ServiceWeaver/weaver/internal/files
+    github.com/ServiceWeaver/weaver/internal/must
     github.com/ServiceWeaver/weaver/internal/status
     github.com/ServiceWeaver/weaver/runtime/tool
     path/filepath
@@ -766,6 +769,7 @@ github.com/ServiceWeaver/weaver/runtime/retry
     sync
     time
 github.com/ServiceWeaver/weaver/runtime/tool
+    bufio
     context
     encoding/json
     errors

--- a/internal/must/must.go
+++ b/internal/must/must.go
@@ -1,0 +1,28 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package must provides a generic Must function.
+package must
+
+// Must is a generic implementation of the Go Must idiom [1, 2]. It panics if
+// the provided error is non-nil and returns x otherwise.
+//
+// [1]: https://pkg.go.dev/text/template#Must
+// [2]: https://pkg.go.dev/regexp#MustCompile
+func Must[T any](x T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return x
+}

--- a/internal/tool/multi/deploy.go
+++ b/internal/tool/multi/deploy.go
@@ -174,13 +174,21 @@ func deploy(ctx context.Context, args []string) error {
 	}
 }
 
-// defaultRegistry returns the default registry in
-// $XDG_DATA_HOME/serviceweaver/multi_registry, or
+// defaultRegistryDir() returns $XDG_DATA_HOME/serviceweaver/multi_registry, or
 // ~/.local/share/serviceweaver/multi_registry if XDG_DATA_HOME is not set.
-func defaultRegistry(ctx context.Context) (*status.Registry, error) {
+func defaultRegistryDir() (string, error) {
 	dir, err := files.DefaultDataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "multi_registry"), nil
+}
+
+// defaultRegistry returns a registry in defaultRegistryDir().
+func defaultRegistry(ctx context.Context) (*status.Registry, error) {
+	dir, err := defaultRegistryDir()
 	if err != nil {
 		return nil, err
 	}
-	return status.NewRegistry(ctx, filepath.Join(dir, "multi_registry"))
+	return status.NewRegistry(ctx, dir)
 }

--- a/internal/tool/multi/multi.go
+++ b/internal/tool/multi/multi.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/ServiceWeaver/weaver/internal/must"
 	"github.com/ServiceWeaver/weaver/internal/status"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
@@ -41,6 +42,14 @@ var (
 		},
 	}
 
+	purgeSpec = &tool.PurgeSpec{
+		Tool: "weaver multi",
+		Paths: []string{
+			logdir,
+			must.Must(defaultRegistryDir()),
+		},
+	}
+
 	Commands = map[string]*tool.Command{
 		"deploy": &deployCmd,
 		"logs": tool.LogsCmd(&tool.LogsSpec{
@@ -53,5 +62,6 @@ var (
 		"status":    status.StatusCommand("weaver multi", defaultRegistry),
 		"metrics":   status.MetricsCommand("weaver multi", defaultRegistry),
 		"profile":   status.ProfileCommand("weaver multi", defaultRegistry),
+		"purge":     tool.PurgeCmd(purgeSpec),
 	}
 )

--- a/internal/tool/single/single.go
+++ b/internal/tool/single/single.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/ServiceWeaver/weaver/internal/files"
+	"github.com/ServiceWeaver/weaver/internal/must"
 	"github.com/ServiceWeaver/weaver/internal/status"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
@@ -36,11 +37,17 @@ var (
 		},
 	}
 
+	purgeSpec = &tool.PurgeSpec{
+		Tool:  "weaver single",
+		Paths: []string{filepath.Join(must.Must(files.DefaultDataDir()), "single_registry")},
+	}
+
 	Commands = map[string]*tool.Command{
 		"status":    status.StatusCommand("weaver single", defaultRegistry),
 		"dashboard": status.DashboardCommand(dashboardSpec),
 		"metrics":   status.MetricsCommand("weaver single", defaultRegistry),
 		"profile":   status.ProfileCommand("weaver single", defaultRegistry),
+		"purge":     tool.PurgeCmd(purgeSpec),
 	}
 )
 

--- a/runtime/tool/purge.go
+++ b/runtime/tool/purge.go
@@ -1,0 +1,114 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+)
+
+// PurgeSpec configures the command returned by PurgeCmd.
+type PurgeSpec struct {
+	Tool  string   // tool name (e.g., "weaver multi")
+	Paths []string // paths to delete
+	// TODO(mwhittaker): Add a regex to kill processes.
+
+	force bool // the --force flag
+}
+
+// PurgeCmd returns a command to delete a set of paths.
+func PurgeCmd(spec *PurgeSpec) *Command {
+	// Sanity check spec.
+	if len(spec.Paths) == 0 {
+		panic(fmt.Errorf("PurgeSpec with no paths"))
+	}
+
+	// Create flags and help.
+	flags := flag.NewFlagSet("purge", flag.ContinueOnError)
+	flags.BoolVar(&spec.force, "force", false, "Purge without prompt")
+	const help = `Usage:
+  {{.Tool}} purge [--force]
+
+Flags:
+  -h, --help	Print this help message.
+{{.Flags}}
+
+Description:
+  "{{.Tool}} purge" deletes any logs or data produced by {{.Tool}}.`
+	var b strings.Builder
+	t := template.Must(template.New(spec.Tool).Parse(help))
+	content := struct{ Tool, Flags string }{spec.Tool, FlagsHelp(flags)}
+	if err := t.Execute(&b, content); err != nil {
+		panic(err)
+	}
+
+	return &Command{
+		Name:        "purge",
+		Flags:       flags,
+		Description: "Purge Service Weaver logs and data",
+		Help:        b.String(),
+		Fn:          spec.purge,
+	}
+}
+
+func (spec *PurgeSpec) purge(context.Context, []string) error {
+	if !spec.force {
+		// Warn the user they're about to delete stuff.
+		var b strings.Builder
+		for _, path := range spec.Paths {
+			fmt.Fprintf(&b, "    - %s\n", path)
+		}
+		fmt.Printf(`WARNING: You are about to delete the following directories used to store logs
+and data for %q Service Weaver applications. This data will be deleted
+immediately and irrevocably. Any currently running applications deployed with
+%q will be corrupted. Are you sure you want to proceed?"
+
+%s
+Enter (y)es to continue: `, spec.Tool, spec.Tool, b.String())
+
+		// Get confirmation from the user.
+		reader := bufio.NewReader(os.Stdin)
+		text, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		text = text[:len(text)-1] // strip the trailing "\n"
+		text = strings.ToLower(text)
+		if !(text == "y" || text == "yes") {
+			fmt.Println("")
+			fmt.Println("Purge aborted.")
+			return nil
+		}
+		fmt.Println("")
+	}
+
+	// Delete the directories.
+	for _, path := range spec.Paths {
+		fmt.Printf("Deleting %s... ", path)
+		if err := os.RemoveAll(path); err != nil {
+			fmt.Println("❌")
+			return err
+		}
+		fmt.Println("✅")
+	}
+
+	// TODO(mwhittaker): Delete lingering processes too?
+	return nil
+}

--- a/website/news.md
+++ b/website/news.md
@@ -14,6 +14,8 @@
  limitations under the License.
 -->
 
+*2023-04-05*&nbsp;&nbsp; New blog post on [how to implement a Service Weaver deployer][deployers_blog].
+
 *2023-04-03*&nbsp;&nbsp; Service Weaver at Container Day in Amsterdam. [Register][container_day_register] if you want to learn more.
 
 *2023-03-30*&nbsp;&nbsp; We are now on Discord. Follow us [here][sw_discord].
@@ -24,7 +26,7 @@
 
 *2023-03-11*&nbsp;&nbsp; [InfoQ][infoq] wrote a blog [post][infoq_sw_blog_post] about Service Weaver.
 
-*2023-03-03*&nbsp;&nbsp; [Article][sw_medium_post] on [Medium][medium_link] about Service Weaver. 
+*2023-03-03*&nbsp;&nbsp; [Article][sw_medium_post] on [Medium][medium_link] about Service Weaver.
 
 *2023-03-02*&nbsp;&nbsp; We had a great time [talking][sw_launch_twitter_space] about Service Weaver with [Kelsey Hightower][kelsey_tweeter].
 
@@ -45,3 +47,4 @@
 [jeff_sw_tweet]: https://twitter.com/JeffDean/status/1631379386476953600
 [kelsey_sw_launch_tweet]: https://twitter.com/kelseyhightower/status/1630995723956412420
 [container_day_register]: https://rsvp.withgoogle.com/events/google-container-day/
+[deployers_blog]: https://serviceweaver.dev/blog/deployers.html


### PR DESCRIPTION
## Example

```console
$ weaver multi purge
WARNING: You are about to delete the following directories used to store logs
and data for local Service Weaver applications. This data will be deleted
immediately and irrevocably. Are you sure you want to proceed?

    - /tmp/serviceweaver/logs/weaver-multi
    - /usr/local/google/home/mwhittaker/.local/share/serviceweaver/multi_registry

Enter (y)es to continue: y

Deleting /tmp/serviceweaver/logs/weaver-multi... ✅
Deleting /usr/local/google/home/mwhittaker/.local/share/serviceweaver/multi_registry... ✅
```

## Overview

This PR introduces `weaver single purge` and `weaver multi purge` commands that delete all logs and data produced by locally run Service Weaver applications. In the future, we may also want to kill lingering processes. For example, we could kill the gke-local controller and distributors.

## Motivation

The motivation for this PR is the same as #220. We're seeing some issues (e.g., #179, #154) that I think may be cause by version issues. Users run `weaver multi logs` on logs produced by a different version of Service Weaver, for example. `weaver purge` makes it easier to debug these kinds of issues, as we can tell people to run `weaver purge` before reproducing their reported bug.