### PR TITLE
Factored common functionality to routing package.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -423,6 +423,13 @@ github.com/ServiceWeaver/weaver/internal/queue
 github.com/ServiceWeaver/weaver/internal/register
     fmt
     sync
+github.com/ServiceWeaver/weaver/internal/routing
+    fmt
+    github.com/ServiceWeaver/weaver/runtime/protos
+    golang.org/x/exp/slices
+    math
+    sort
+    strings
 github.com/ServiceWeaver/weaver/internal/status
     bytes
     context
@@ -492,6 +499,7 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     github.com/ServiceWeaver/weaver/internal/files
     github.com/ServiceWeaver/weaver/internal/metrics
     github.com/ServiceWeaver/weaver/internal/proxy
+    github.com/ServiceWeaver/weaver/internal/routing
     github.com/ServiceWeaver/weaver/internal/status
     github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/codegen
@@ -501,7 +509,6 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     github.com/ServiceWeaver/weaver/runtime/metrics
     github.com/ServiceWeaver/weaver/runtime/perfetto
     github.com/ServiceWeaver/weaver/runtime/profiling
-    github.com/ServiceWeaver/weaver/runtime/protomsg
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/retry
     github.com/ServiceWeaver/weaver/runtime/tool
@@ -513,13 +520,11 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     golang.org/x/sync/errgroup
     google.golang.org/protobuf/types/known/timestamppb
     io
-    math
     net
     net/http
     os
     os/signal
     path/filepath
-    sort
     sync
     syscall
     time
@@ -560,6 +565,7 @@ github.com/ServiceWeaver/weaver/internal/tool/ssh/impl
     github.com/ServiceWeaver/weaver/internal/metrics
     github.com/ServiceWeaver/weaver/internal/proto
     github.com/ServiceWeaver/weaver/internal/proxy
+    github.com/ServiceWeaver/weaver/internal/routing
     github.com/ServiceWeaver/weaver/internal/status
     github.com/ServiceWeaver/weaver/internal/traceio
     github.com/ServiceWeaver/weaver/internal/versioned
@@ -578,14 +584,12 @@ github.com/ServiceWeaver/weaver/internal/tool/ssh/impl
     google.golang.org/protobuf/reflect/protoreflect
     google.golang.org/protobuf/runtime/protoimpl
     google.golang.org/protobuf/types/known/timestamppb
-    math
     net
     net/http
     os
     os/exec
     path/filepath
     reflect
-    sort
     sync
     syscall
     time

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -1,0 +1,96 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package routing includes utilities for routing and assignments. See
+// https://serviceweaver.dev/docs.html#routing for more information on routing.
+package routing
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/ServiceWeaver/weaver/runtime/protos"
+	"golang.org/x/exp/slices"
+)
+
+// FormatAssignment pretty formats the provided assignment.
+func FormatAssignment(a *protos.Assignment) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Assignment Version %d\n", a.Version)
+	if len(a.Slices) == 0 {
+		return b.String()
+	}
+
+	hex := func(x uint64) string {
+		return fmt.Sprintf("0x%016x", x)
+	}
+	for i, si := range a.Slices[:len(a.Slices)-1] {
+		sj := a.Slices[i+1]
+		fmt.Fprintf(&b, "[%s, %s): %v\n", hex(si.Start), hex(sj.Start), si.Replicas)
+	}
+	slast := a.Slices[len(a.Slices)-1]
+	fmt.Fprintf(&b, "[%s, %s]: %v\n", hex(slast.Start), hex(math.MaxUint64), slast.Replicas)
+	return b.String()
+}
+
+// EqualSlices returns an assignment with slices of roughly equal size.
+// Replicas are assigned to slices in a round robin fashion. The returned
+// assignment has a version of 0.
+func EqualSlices(replicas []string) *protos.Assignment {
+	if len(replicas) == 0 {
+		return &protos.Assignment{}
+	}
+
+	// Note that the replicas should be sorted. This is required because we
+	// want to do a deterministic assignment of slices to replicas among
+	// different invocations, to avoid unnecessary churn while generating new
+	// assignments.
+	replicas = slices.Clone(replicas)
+	sort.Strings(replicas)
+
+	// Form n roughly equally sized slices, where n is the least power of two
+	// larger than the number of replicas.
+	//
+	// TODO(mwhittaker): Shouldn't we pick a number divisible by the number of
+	// replicas? Otherwise, not every replica gets the same number of slices.
+	n := nextPowerOfTwo(len(replicas))
+	slices := make([]*protos.Assignment_Slice, n)
+	start := uint64(0)
+	delta := math.MaxUint64 / uint64(n)
+	for i := 0; i < n; i++ {
+		slices[i] = &protos.Assignment_Slice{Start: start}
+		start += delta
+	}
+
+	// Assign replicas to slices in a round robin fashion.
+	for i, slice := range slices {
+		slice.Replicas = []string{replicas[i%len(replicas)]}
+	}
+	return &protos.Assignment{Slices: slices}
+}
+
+// nextPowerOfTwo returns the least power of 2 that is greater or equal to x.
+func nextPowerOfTwo(x int) int {
+	switch {
+	case x == 0:
+		return 1
+	case x&(x-1) == 0:
+		// x is already power of 2.
+		return x
+	default:
+		return int(math.Pow(2, math.Ceil(math.Log2(float64(x)))))
+	}
+}

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -1,0 +1,108 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ServiceWeaver/weaver/runtime/protos"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func ExampleFormatAssignment() {
+	assignment := &protos.Assignment{
+		Slices: []*protos.Assignment_Slice{
+			{Start: 0x0, Replicas: []string{"a", "b"}},
+			{Start: 0x3333333333333333, Replicas: []string{"a", "c"}},
+			{Start: 0x6666666666666666, Replicas: []string{"b", "c"}},
+			{Start: 0x9999999999999999, Replicas: []string{"a", "b", "c"}},
+		},
+		Version: 42,
+	}
+	fmt.Println(FormatAssignment(assignment))
+
+	// OUTPUT:
+	// Assignment Version 42
+	// [0x0000000000000000, 0x3333333333333333): [a b]
+	// [0x3333333333333333, 0x6666666666666666): [a c]
+	// [0x6666666666666666, 0x9999999999999999): [b c]
+	// [0x9999999999999999, 0xffffffffffffffff]: [a b c]
+}
+
+func TestFormatAssignmentOnAssignmentWithNoSlices(t *testing.T) {
+	assignment := &protos.Assignment{Version: 42}
+	got := FormatAssignment(assignment)
+	const want = "Assignment Version 42\n"
+	if got != want {
+		t.Fatalf("FormatAssignment: got %q, want %q", got, want)
+	}
+}
+
+func TestEqualSlicesNoReplicas(t *testing.T) {
+	got := EqualSlices([]string{})
+	want := &protos.Assignment{}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("EqualSlices: (-want +got):\n%s", diff)
+	}
+}
+
+func TestEqualSlicesOneReplica(t *testing.T) {
+	got := EqualSlices([]string{"a"})
+	want := &protos.Assignment{
+		Slices: []*protos.Assignment_Slice{
+			{Start: 0, Replicas: []string{"a"}},
+		},
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("EqualSlices: (-want +got):\n%s", diff)
+	}
+}
+
+func TestEqualSlicesThreeReplicas(t *testing.T) {
+	// - There are 3 replicas.
+	// - The least power of 2 larger than 3 is 4, so we create 4 slices.
+	// - The slice width is math.MaxUint64 / 4 = 4611686018427387903.75, which
+	//   is rounded down to 4611686018427387903.
+	// - 2 * 4611686018427387903 = 9223372036854775806.
+	// - 3 * 4611686018427387903 = 13835058055282163709.
+	got := EqualSlices([]string{"a", "b", "c"})
+	want := &protos.Assignment{
+		Slices: []*protos.Assignment_Slice{
+			{Start: 0, Replicas: []string{"a"}},
+			{Start: 4611686018427387903, Replicas: []string{"b"}},
+			{Start: 9223372036854775806, Replicas: []string{"c"}},
+			{Start: 13835058055282163709, Replicas: []string{"a"}},
+		},
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("EqualSlices: (-want +got):\n%s", diff)
+	}
+}
+
+func TestNextPowerOfTwo(t *testing.T) {
+	for _, test := range []struct{ x, want int }{
+		{0, 1}, {1, 1},
+		{2, 2},
+		{3, 4}, {4, 4},
+		{5, 8}, {6, 8}, {7, 8}, {8, 8},
+		{9, 16}, {10, 16}, {11, 16}, {12, 16}, {13, 16}, {14, 16}, {15, 16}, {16, 16},
+	} {
+		if got, want := nextPowerOfTwo(test.x), test.want; got != want {
+			t.Errorf("nextPowerOfTwo(%d): got %d, want %d", test.x, got, want)
+		}
+	}
+}

--- a/internal/tool/multi/deployer.go
+++ b/internal/tool/multi/deployer.go
@@ -18,23 +18,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"net/http"
-	"sort"
 	"sync"
 	"syscall"
 	"time"
 
 	imetrics "github.com/ServiceWeaver/weaver/internal/metrics"
 	"github.com/ServiceWeaver/weaver/internal/proxy"
+	"github.com/ServiceWeaver/weaver/internal/routing"
 	"github.com/ServiceWeaver/weaver/internal/status"
 	"github.com/ServiceWeaver/weaver/runtime/envelope"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/perfetto"
 	"github.com/ServiceWeaver/weaver/runtime/profiling"
-	"github.com/ServiceWeaver/weaver/runtime/protomsg"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -359,7 +357,9 @@ func (d *deployer) activateComponent(req *protos.ActivateComponentRequest) error
 		// Create an initial assignment.
 		if req.Routed {
 			replicas := maps.Keys(target.addresses)
-			target.assignments[req.Component] = routingAlgo(&protos.Assignment{}, replicas)
+			assignment := routingAlgo(&protos.Assignment{}, replicas)
+			target.assignments[req.Component] = assignment
+			d.logger.Debug(fmt.Sprintf("Initial assignment for component %s:\n%s", req.Component, routing.FormatAssignment(assignment)))
 		}
 
 		// Notify the subscribers.
@@ -389,7 +389,9 @@ func (d *deployer) registerReplica(g *group, info *protos.WeaveletInfo) error {
 	// Update all assignments.
 	replicas := maps.Keys(g.addresses)
 	for component, assignment := range g.assignments {
-		g.assignments[component] = routingAlgo(assignment, replicas)
+		assignment = routingAlgo(assignment, replicas)
+		g.assignments[component] = assignment
+		d.logger.Debug(fmt.Sprintf("Updated assignment for component %s:\n%s", component, routing.FormatAssignment(assignment)))
 	}
 
 	// Notify subscribers.
@@ -569,72 +571,10 @@ func (d *deployer) Metrics(context.Context) (*status.Metrics, error) {
 	return m, nil
 }
 
-// routingAlgo is an implementation of a routing algorithm that distributes the
-// entire key space approximately equally across all healthy resources.
-//
-// The algorithm is as follows:
-//   - split the entire key space in a number of slices that is more likely to
-//     spread the key space uniformly among all healthy resources.
-//   - distribute the slices round robin across all healthy resources
 func routingAlgo(currAssignment *protos.Assignment, candidates []string) *protos.Assignment {
-	newAssignment := protomsg.Clone(currAssignment)
-	newAssignment.Version++
-
-	// Note that the healthy resources should be sorted. This is required because
-	// we want to do a deterministic assignment of slices to resources among
-	// different invocations, to avoid unnecessary churn while generating
-	// new assignments.
-	sort.Strings(candidates)
-
-	if len(candidates) == 0 {
-		newAssignment.Slices = nil
-		return newAssignment
-	}
-
-	const minSliceKey = 0
-	const maxSliceKey = math.MaxUint64
-
-	// If there is only one healthy resource, assign the entire key space to it.
-	if len(candidates) == 1 {
-		newAssignment.Slices = []*protos.Assignment_Slice{
-			{Start: minSliceKey, Replicas: candidates},
-		}
-		return newAssignment
-	}
-
-	// Compute the total number of slices in the assignment.
-	numSlices := nextPowerOfTwo(len(candidates))
-
-	// Split slices in equal subslices in order to generate numSlices.
-	splits := [][]uint64{{minSliceKey, maxSliceKey}}
-	var curr []uint64
-	for ok := true; ok; ok = len(splits) != numSlices {
-		curr, splits = splits[0], splits[1:]
-		midPoint := curr[0] + uint64(math.Floor(0.5*float64(curr[1]-curr[0])))
-		splitl := []uint64{curr[0], midPoint}
-		splitr := []uint64{midPoint, curr[1]}
-		splits = append(splits, splitl, splitr)
-	}
-
-	// Sort the computed slices in increasing order based on the start key, in
-	// order to provide a deterministic assignment across multiple runs, hence to
-	// minimize churn.
-	sort.Slice(splits, func(i, j int) bool {
-		return splits[i][0] <= splits[j][0]
-	})
-
-	// Assign the computed slices to resources in a round robin fashion.
-	slices := make([]*protos.Assignment_Slice, len(splits))
-	rId := 0
-	for i, s := range splits {
-		slices[i] = &protos.Assignment_Slice{
-			Start:    s[0],
-			Replicas: []string{candidates[rId]},
-		}
-		rId = (rId + 1) % len(candidates)
-	}
-	newAssignment.Slices = slices
-	return newAssignment
+	assignment := routing.EqualSlices(candidates)
+	assignment.Version = currAssignment.Version + 1
+	return assignment
 }
 
 // serveHTTP serves HTTP traffic on the provided listener using the provided
@@ -649,15 +589,6 @@ func serveHTTP(ctx context.Context, lis net.Listener, handler http.Handler) erro
 	case <-ctx.Done():
 		return server.Shutdown(ctx)
 	}
-}
-
-// nextPowerOfTwo returns the next power of 2 that is greater or equal to x.
-func nextPowerOfTwo(x int) int {
-	// If x is already power of 2, return x.
-	if x&(x-1) == 0 {
-		return x
-	}
-	return int(math.Pow(2, math.Ceil(math.Log2(float64(x)))))
 }
 
 // runProfiling runs a profiling request on a set of processes.


### PR DESCRIPTION
Before this PR, the multi deployer and SSH deployer had duplicate implementations of some routing logic. This PR:

- pulls out the duplicate code into a runtime/routing package,
- simplifies the implementation of the routing algorithm,
- adds a pretty printer&mdash;which is useful when debugging&mdash;and 
- adds some unit tests.

I can move the code to `internal/` if we think other deployers won't use it.