### PR TITLE
Made purge kill processes as well.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -779,6 +779,7 @@ github.com/ServiceWeaver/weaver/runtime/tool
     github.com/ServiceWeaver/weaver/runtime/logging
     io
     os
+    os/exec
     sort
     strings
     text/template

--- a/internal/tool/multi/multi.go
+++ b/internal/tool/multi/multi.go
@@ -44,6 +44,7 @@ var (
 
 	purgeSpec = &tool.PurgeSpec{
 		Tool: "weaver multi",
+		Kill: "weaver multi (dashboard|deploy|logs|profile)",
 		Paths: []string{
 			logdir,
 			must.Must(defaultRegistryDir()),

--- a/internal/tool/single/single.go
+++ b/internal/tool/single/single.go
@@ -39,6 +39,7 @@ var (
 
 	purgeSpec = &tool.PurgeSpec{
 		Tool:  "weaver single",
+		Kill:  "weaver single (dashboard|profile)",
 		Paths: []string{filepath.Join(must.Must(files.DefaultDataDir()), "single_registry")},
 	}
 


### PR DESCRIPTION
## Example

```console
$ weaver multi purge
WARNING: You are about to kill all processes which match the following regex:

    weaver multi (dashboard|deploy|logs|profile)

This currently includes the following processes:

    291044 /usr/local/google/home/mwhittaker/github/ServiceWeaver/weaver/cmd/weaver/weaver multi deploy weaver.toml
    308483 /usr/local/google/home/mwhittaker/github/ServiceWeaver/weaver/cmd/weaver/weaver multi dashboard

You will also delete the following paths used to store logs and data for
"weaver multi" Service Weaver applications. This data will be deleted
immediately and irrevocably. Are you sure you want to proceed?"

    - /tmp/serviceweaver/logs/weaver-multi
    - /usr/local/google/home/mwhittaker/.local/share/serviceweaver/multi_registry

Enter (y)es to continue: y

weaver killed (pid 291044)
weaver killed (pid 308483)
Deleting /tmp/serviceweaver/logs/weaver-multi... ✅
Deleting /usr/local/google/home/mwhittaker/.local/share/serviceweaver/multi_registry... ✅
```

## Overview

Before this PR, `weaver multi purge` removed all files and data produced by `weaver multi`. And the same for `weaver single purge`. This PR changes the two commands to kill processes as well. `weaver multi purge`, for example, kills every process matching the following regex:

    weaver multi (dashboard|deploy|logs|profile)

Thanks @rgrandl for the great suggestion!