### PR TITLE
Moved "weaver version" into subcommands.

### DIFF
--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -22,22 +22,18 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
-	"runtime/debug"
 	"strings"
 
 	"github.com/ServiceWeaver/weaver/internal/tool/generate"
 	"github.com/ServiceWeaver/weaver/internal/tool/multi"
 	"github.com/ServiceWeaver/weaver/internal/tool/single"
 	"github.com/ServiceWeaver/weaver/internal/tool/ssh"
-	swruntime "github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
 const usage = `USAGE
 
   weaver generate                 // weaver code generator
-  weaver version                  // show weaver version
   weaver single    <command> ...  // for single process deployments
   weaver multi     <command> ...  // for multiprocess deployments
   weaver ssh       <command> ...  // for multimachine deployments
@@ -81,23 +77,6 @@ func main() {
 			fmt.Fprint(os.Stderr, err)
 			os.Exit(1)
 		}
-		return
-
-	case "version":
-		semver := fmt.Sprintf("%d.%d.%d", swruntime.Major, swruntime.Minor, swruntime.Patch)
-		commit := "?"
-		if info, ok := debug.ReadBuildInfo(); ok {
-			for _, setting := range info.Settings {
-				// vcs.revision stores the commit at which the weaver tool was
-				// built. See https://pkg.go.dev/runtime/debug#BuildSetting for
-				// more information.
-				if setting.Key == "vcs.revision" {
-					commit = setting.Value
-					break
-				}
-			}
-		}
-		fmt.Printf("weaver version: commit=%s deployer=v%s target=%s/%s\n", commit, semver, runtime.GOOS, runtime.GOARCH)
 		return
 
 	case "single", "multi", "ssh":

--- a/godeps.txt
+++ b/godeps.txt
@@ -55,12 +55,9 @@ github.com/ServiceWeaver/weaver/cmd/weaver
     github.com/ServiceWeaver/weaver/internal/tool/multi
     github.com/ServiceWeaver/weaver/internal/tool/single
     github.com/ServiceWeaver/weaver/internal/tool/ssh
-    github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/tool
     os
     os/exec
-    runtime
-    runtime/debug
     strings
 github.com/ServiceWeaver/weaver/dev/docgen
     bytes
@@ -775,11 +772,14 @@ github.com/ServiceWeaver/weaver/runtime/tool
     errors
     flag
     fmt
+    github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/colors
     github.com/ServiceWeaver/weaver/runtime/logging
     io
     os
     os/exec
+    runtime
+    runtime/debug
     sort
     strings
     text/template

--- a/internal/tool/multi/multi.go
+++ b/internal/tool/multi/multi.go
@@ -64,5 +64,6 @@ var (
 		"metrics":   status.MetricsCommand("weaver multi", defaultRegistry),
 		"profile":   status.ProfileCommand("weaver multi", defaultRegistry),
 		"purge":     tool.PurgeCmd(purgeSpec),
+		"version":   tool.VersionCmd("weaver multi"),
 	}
 )

--- a/internal/tool/single/single.go
+++ b/internal/tool/single/single.go
@@ -49,6 +49,7 @@ var (
 		"metrics":   status.MetricsCommand("weaver single", defaultRegistry),
 		"profile":   status.ProfileCommand("weaver single", defaultRegistry),
 		"purge":     tool.PurgeCmd(purgeSpec),
+		"version":   tool.VersionCmd("weaver single"),
 	}
 )
 

--- a/internal/tool/ssh/ssh.go
+++ b/internal/tool/ssh/ssh.go
@@ -30,6 +30,7 @@ var (
 		"deploy":    &deployCmd,
 		"logs":      tool.LogsCmd(&logsSpec),
 		"dashboard": status.DashboardCommand(dashboardSpec),
+		"version":   tool.VersionCmd("weaver ssh"),
 
 		// Hidden commands.
 		"babysitter": &babysitterCmd,

--- a/runtime/tool/version.go
+++ b/runtime/tool/version.go
@@ -1,0 +1,53 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+
+	rt "github.com/ServiceWeaver/weaver/runtime"
+)
+
+// VersionCmd returns a command to show a deployer's version.
+func VersionCmd(tool string) *Command {
+	return &Command{
+		Name:        "version",
+		Flags:       flag.NewFlagSet("version", flag.ContinueOnError),
+		Description: fmt.Sprintf("Show %q version", tool),
+		Help:        fmt.Sprintf("Usage:\n  %s version", tool),
+		Fn: func(context.Context, []string) error {
+			semver := fmt.Sprintf("%d.%d.%d", rt.Major, rt.Minor, rt.Patch)
+			commit := "?"
+			if info, ok := debug.ReadBuildInfo(); ok {
+				for _, setting := range info.Settings {
+					// vcs.revision stores the commit at which the weaver tool
+					// was built. See [1] for more information.
+					//
+					// [1]: https://pkg.go.dev/runtime/debug#BuildSetting
+					if setting.Key == "vcs.revision" {
+						commit = setting.Value
+						break
+					}
+				}
+			}
+			fmt.Printf("%s: commit=%s deployer=v%s target=%s/%s\n", tool, commit, semver, runtime.GOOS, runtime.GOARCH)
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
Before this PR, there was a global `weaver version` command that showed the version of the weaver binary. I realized this was confusing because `weaver gke` invokes a different binary. I moved the `weaver version` command into subcommands: `weaver single version`, `weaver multi version`, and `weaver ssh version`. In a future PR, I'll add a version subcommand for gke and gke-local as well.

## Example

```console
$ weaver single version
weaver single: commit=aa550f0a097180c05b0eb4fb2e20b05bf11b9a1a deployer=v0.2.0 target=linux/amd64
$ weaver multi version
weaver multi: commit=aa550f0a097180c05b0eb4fb2e20b05bf11b9a1a deployer=v0.2.0 target=linux/amd64
$ weaver ssh version
weaver ssh: commit=aa550f0a097180c05b0eb4fb2e20b05bf11b9a1a deployer=v0.2.0 target=linux/amd64
```