### PR TITLE
Improve the error message about missing WithConfig[T] embedding

### DIFF
--- a/runtime/codegen/registry.go
+++ b/runtime/codegen/registry.go
@@ -133,7 +133,7 @@ func ComponentConfigValidator(path, cfg string) error {
 	if info.ConfigFn == nil {
 		return fmt.Errorf("unexpected configuration for component %v "+
 			"that does not support configuration (add a "+
-			"weaver.WithConfig[configType] embedded field to %v ",
+			"weaver.WithConfig[configType] embedded field to %v and run weaver generate again)",
 			info.Name, info.Iface)
 	}
 	objConfig := info.ConfigFn(info.New())


### PR DESCRIPTION
While we suggest the user to embed an appropriate `WithConfig[T]`, it's easy for users to make that change and retry building their app immediately.

However, without running `weaver generate` again, they'll see the same error message again, which is likely to confuse them.  Hence, this CL improves the error message to also remind the users to run `weaver generate` again after making appropriate changes to their component.