### PR TITLE
Upgraded to go 1.20.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["1.19", "1.20"]
+        version: ["1.20"]
         command: ["build", "vet", "lint", "test", "testrace"]
     steps:
       - name: Check out repository
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["1.19", "1.20"]
+        version: ["1.20"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ServiceWeaver/weaver
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.2.0

--- a/website/docs.md
+++ b/website/docs.md
@@ -35,7 +35,7 @@ section for a tutorial on how to write Service Weaver applications.
 
 # Installation
 
-Ensure you have [Go installed][go_install], version 1.19 or higher. Then, run
+Ensure you have [Go installed][go_install], version 1.20 or higher. Then, run
 the following to install the `weaver` command:
 
 ```console


### PR DESCRIPTION
This PR upgrades the Service Weaver module to go 1.20. We will no longer support go 1.19 and earlier. This will let us use some nice go 1.20 features like error trees: https://tip.golang.org/doc/go1.20#errors.