### PR TITLE
Fixed "weaver metrics" histogram average bug.

### DIFF
--- a/internal/status/metrics.go
+++ b/internal/status/metrics.go
@@ -217,7 +217,17 @@ func formatMetrics(metrics []*protos.MetricSnapshot) {
 
 				row = append(row, entry)
 			}
+
 			entry := colors.Atom{S: fmt.Sprint(m.Value)}
+			if typ == protos.MetricType_HISTOGRAM {
+				count := uint64(0)
+				for _, bucketCount := range m.Counts {
+					count += bucketCount
+				}
+				if count != 0 {
+					entry = colors.Atom{S: fmt.Sprint(m.Value / float64(count))}
+				}
+			}
 			if m.Value == 0 {
 				entry.Color = dim
 			}


### PR DESCRIPTION
Recall that the `weaver single metrics` and `weaver multi metrics` commands aggregate and print deployment metrics:

```console
$ weaver single metrics
╭──────────────────────────────────────────────────────────────────────────╮
│ // The line length, n, passed to Wrap                                    │
│ wrap_line_length: HISTOGRAM                                              │
├───────────────────┬────────────────────┬───────────────────────┬─────────┤
│ serviceweaver_app │ serviceweaver_node │ serviceweaver_version │ Average │
├───────────────────┼────────────────────┼───────────────────────┼─────────┤
│ wrap              │ e4f6ebcd           │ 793ac157              │ 40      │
╰───────────────────┴────────────────────┴───────────────────────┴─────────╯
```

Before this PR, the tools were reporting the sum instead of the average of a histogram. This PR fixes the bug.