### PR TITLE
Delete perfetto.db files on weaver purge

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -584,6 +584,7 @@ github.com/ServiceWeaver/weaver/internal/tool/single
     github.com/ServiceWeaver/weaver/internal/files
     github.com/ServiceWeaver/weaver/internal/must
     github.com/ServiceWeaver/weaver/internal/status
+    github.com/ServiceWeaver/weaver/runtime/perfetto
     github.com/ServiceWeaver/weaver/runtime/tool
     path/filepath
 github.com/ServiceWeaver/weaver/internal/tool/ssh

--- a/internal/status/dashboard.go
+++ b/internal/status/dashboard.go
@@ -89,6 +89,7 @@ type Command struct {
 // DashboardSpec configures the command returned by DashboardCommand.
 type DashboardSpec struct {
 	Tool     string                                   // tool name (e.g., "weaver single")
+	Mode     string                                   // tool mode (e.g. "single", "multi", "ssh")
 	Registry func(context.Context) (*Registry, error) // registry of deployments
 	Commands func(deploymentId string) []Command      // commands for a deployment
 }
@@ -132,7 +133,7 @@ Flags:
 			}
 			url := "http://" + lis.Addr().String()
 
-			traceDB, err := perfetto.Open(ctx)
+			traceDB, err := perfetto.Open(ctx, spec.Mode)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "cannot open Perfetto database: %v\n", err)
 			} else {

--- a/internal/tool/multi/deployer.go
+++ b/internal/tool/multi/deployer.go
@@ -133,7 +133,7 @@ func newDeployer(ctx context.Context, deploymentId string, config *protos.AppCon
 	})
 
 	// Create the trace saver.
-	traceDB, err := perfetto.Open(ctx)
+	traceDB, err := perfetto.Open(ctx, "multi")
 	if err != nil {
 		return nil, fmt.Errorf("cannot open Perfetto database: %w", err)
 	}

--- a/internal/tool/multi/multi.go
+++ b/internal/tool/multi/multi.go
@@ -32,6 +32,7 @@ var (
 
 	dashboardSpec = &status.DashboardSpec{
 		Tool:     "weaver multi",
+		Mode:     "multi",
 		Registry: defaultRegistry,
 		Commands: func(deploymentId string) []status.Command {
 			return []status.Command{
@@ -49,7 +50,7 @@ var (
 		Paths: []string{
 			logdir,
 			must.Must(defaultRegistryDir()),
-			must.Must(perfetto.DatabaseFilePath()),
+			must.Must(perfetto.DatabaseFilePath("multi")),
 		},
 	}
 

--- a/internal/tool/multi/multi.go
+++ b/internal/tool/multi/multi.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ServiceWeaver/weaver/internal/must"
 	"github.com/ServiceWeaver/weaver/internal/status"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
+	"github.com/ServiceWeaver/weaver/runtime/perfetto"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
@@ -48,6 +49,7 @@ var (
 		Paths: []string{
 			logdir,
 			must.Must(defaultRegistryDir()),
+			must.Must(perfetto.DatabaseFilePath()),
 		},
 	}
 

--- a/internal/tool/single/single.go
+++ b/internal/tool/single/single.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ServiceWeaver/weaver/internal/files"
 	"github.com/ServiceWeaver/weaver/internal/must"
 	"github.com/ServiceWeaver/weaver/internal/status"
+	"github.com/ServiceWeaver/weaver/runtime/perfetto"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
@@ -36,11 +37,13 @@ var (
 			}
 		},
 	}
-
 	purgeSpec = &tool.PurgeSpec{
-		Tool:  "weaver single",
-		Kill:  "weaver single (dashboard|profile)",
-		Paths: []string{filepath.Join(must.Must(files.DefaultDataDir()), "single_registry")},
+		Tool: "weaver single",
+		Kill: "weaver single (dashboard|profile)",
+		Paths: []string{
+			filepath.Join(must.Must(files.DefaultDataDir()), "single_registry"),
+			must.Must(perfetto.DatabaseFilePath()),
+		},
 	}
 
 	Commands = map[string]*tool.Command{

--- a/internal/tool/single/single.go
+++ b/internal/tool/single/single.go
@@ -29,6 +29,7 @@ import (
 var (
 	dashboardSpec = &status.DashboardSpec{
 		Tool:     "weaver single",
+		Mode:     "single",
 		Registry: defaultRegistry,
 		Commands: func(deploymentId string) []status.Command {
 			return []status.Command{
@@ -42,7 +43,7 @@ var (
 		Kill: "weaver single (dashboard|profile)",
 		Paths: []string{
 			filepath.Join(must.Must(files.DefaultDataDir()), "single_registry"),
-			must.Must(perfetto.DatabaseFilePath()),
+			must.Must(perfetto.DatabaseFilePath("single")),
 		},
 	}
 

--- a/internal/tool/ssh/dashboard.go
+++ b/internal/tool/ssh/dashboard.go
@@ -24,6 +24,7 @@ import (
 
 var dashboardSpec = &status.DashboardSpec{
 	Tool:     "weaver ssh",
+	Mode:     "ssh",
 	Registry: impl.DefaultRegistry,
 	Commands: func(deploymentId string) []status.Command {
 		return []status.Command{

--- a/internal/tool/ssh/impl/manager.go
+++ b/internal/tool/ssh/impl/manager.go
@@ -156,7 +156,7 @@ func RunManager(ctx context.Context, dep *protos.Deployment, locations []string,
 	})
 
 	// Create the trace saver.
-	traceDB, err := perfetto.Open(ctx)
+	traceDB, err := perfetto.Open(ctx, "ssh")
 	if err != nil {
 		return nil, fmt.Errorf("cannot open Perfetto database: %w", err)
 	}

--- a/runtime/perfetto/db.go
+++ b/runtime/perfetto/db.go
@@ -96,18 +96,18 @@ type DB struct {
 }
 
 // DatabaseFilePath returns the path of the file that stores the trace database.
-func DatabaseFilePath() (string, error) {
+func DatabaseFilePath(mode string) (string, error) {
 	dataDir, err := files.DefaultDataDir()
 	if err != nil {
 		return "", err
 	}
-	// TODO(mwhittaker): Use a different db for every deployer.
-	return filepath.Join(dataDir, "perfetto.db"), nil
+	return filepath.Join(dataDir, fmt.Sprintf("perfetto_%s.db", mode)), nil
 }
 
-// Open opens the default trace database on the local machine.
-func Open(ctx context.Context) (*DB, error) {
-	fname, err := DatabaseFilePath()
+// Open opens the default trace database on the local machine. mode specifies
+// the weaver mode (e.g. single, multi, ssh) for which the database is being open.
+func Open(ctx context.Context, mode string) (*DB, error) {
+	fname, err := DatabaseFilePath(mode)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/perfetto/db.go
+++ b/runtime/perfetto/db.go
@@ -95,16 +95,22 @@ type DB struct {
 	replicaNumCache *lru.Cache[replicaCacheKey, int]
 }
 
+// DatabaseFilePath returns the path of the file that stores the trace database.
+func DatabaseFilePath() (string, error) {
+	dataDir, err := files.DefaultDataDir()
+	if err != nil {
+		return "", err
+	}
+	// TODO(mwhittaker): Use a different db for every deployer.
+	return filepath.Join(dataDir, "perfetto.db"), nil
+}
+
 // Open opens the default trace database on the local machine.
 func Open(ctx context.Context) (*DB, error) {
-	dataDir, err := files.DefaultDataDir()
+	fname, err := DatabaseFilePath()
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO(mwhittaker): Use a different db for every deployer. Have the purge
-	// commands delete the db.
-	fname := filepath.Join(dataDir, "perfetto.db")
 	return open(ctx, fname)
 }
 

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -109,7 +109,7 @@ func newSingleprocessEnv(bootstrap runtime.Bootstrap) (*singleprocessEnv, error)
 		return nil, err
 	}
 
-	traceDB, err := perfetto.Open(ctx)
+	traceDB, err := perfetto.Open(ctx, "single")
 	if err != nil {
 		return nil, fmt.Errorf("cannot open Perfetto database: %w", err)
 	}


### PR DESCRIPTION
Changes in the schema of perfetto database can result in application crashes such as the following:

`Application bankofanthos error: SQL logic error: no such column: weavelet_id (1)`

These crashes happen because of a schema mismatch between an existing perfetto.db file and that of the running application.  This change thus expands `weaver purge` command to delete the perfetto.db files as well.