### PR TITLE
Supress two erroneous golangci-lint errors.

### DIFF
--- a/runtime/codegen/registry_test.go
+++ b/runtime/codegen/registry_test.go
@@ -104,10 +104,13 @@ func init() {
 		ServerStubFn: server,
 	})
 	codegen.Register(codegen.Registration{
-		Name:         typeWithConfig,
-		Iface:        reflect.TypeOf((*componentWithConfig)(nil)).Elem(),
-		New:          func() any { return &componentWithConfig{} },
-		ConfigFn:     func(i any) any { return i.(*componentWithConfig).Config() },
+		Name:  typeWithConfig,
+		Iface: reflect.TypeOf((*componentWithConfig)(nil)).Elem(),
+		New:   func() any { return &componentWithConfig{} },
+		ConfigFn: func(i any) any {
+			// TODO(mwhittaker): Remove the nolint once golangci-lint supports go 1.21.
+			return i.(*componentWithConfig).Config() //nolint:typecheck
+		},
 		LocalStubFn:  local,
 		ClientStubFn: client,
 		ServerStubFn: server,

--- a/weavertest/internal/simple/simple.go
+++ b/weavertest/internal/simple/simple.go
@@ -39,7 +39,8 @@ type source struct {
 }
 
 func (s *source) Init(_ context.Context) error {
-	s.Logger().Debug("simple.Init")
+	// TODO(mwhittaker): Remove the nolint once golangci-lint supports go 1.21.
+	s.Logger().Debug("simple.Init") //nolint:typecheck
 	dst, err := weaver.Get[Destination](s)
 	s.dst = dst
 	return err


### PR DESCRIPTION
Ever since our desktops upgraded to Go 1.21, golangci-lint has been reporting two odd typecheck errors even though the code compiles just fine. I added some nolint annotations to supress these errors with some TODOs to remove them once golangci-lint is fixed.