### PR TITLE
Suppress golangci-lint false positives with Go tip.

### DIFF
--- a/runtime/codegen/registry_test.go
+++ b/runtime/codegen/registry_test.go
@@ -107,7 +107,7 @@ func init() {
 		Name:         typeWithConfig,
 		Iface:        reflect.TypeOf((*componentWithConfig)(nil)).Elem(),
 		New:          func() any { return &componentWithConfig{} },
-		ConfigFn:     func(i any) any { return i.(*componentWithConfig).Config() },
+		ConfigFn:     func(i any) any { return i.(*componentWithConfig).Config() }, //nolint:nolintlint,typecheck // golangci-lint false positive on Go tip
 		LocalStubFn:  local,
 		ClientStubFn: client,
 		ServerStubFn: server,

--- a/runtime/protos/runtime.pb.go
+++ b/runtime/protos/runtime.pb.go
@@ -2066,12 +2066,17 @@ func (*ActivateComponentReply) Descriptor() ([]byte, []int) {
 // are some examples of how different deployers may handle a
 // GetListenerAddressRequest.
 //
-//   - The singleprocess deployer may instruct the weavelet to listen directly
-//     on localhost:9000.
-//   - The multiprocess deployer may instruct the weavelet to listen on
-//     localhost:0. It will separately start a proxy on localhost:9000.
-//   - The SSH deployer may instruct the weavelet to listen on
-//     $HOSTNAME:0. It will separately start a proxy on localhost:9000.
+// - The singleprocess deployer may instruct the weavelet to listen directly
+//
+//	on localhost:9000.
+//
+// - The multiprocess deployer may instruct the weavelet to listen on
+//
+//	localhost:0. It will separately start a proxy on localhost:9000.
+//
+// - The SSH deployer may instruct the weavelet to listen on
+//
+//	$HOSTNAME:0. It will separately start a proxy on localhost:9000.
 type GetListenerAddressRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/weavertest/internal/simple/simple.go
+++ b/weavertest/internal/simple/simple.go
@@ -39,7 +39,7 @@ type source struct {
 }
 
 func (s *source) Init(_ context.Context) error {
-	s.Logger().Debug("simple.Init")
+	s.Logger().Debug("simple.Init") //nolint:nolintlint,typecheck // golangci-lint false positive on Go tip
 	dst, err := weaver.Get[Destination](s)
 	s.dst = dst
 	return err


### PR DESCRIPTION
golangci-lint currently gives a couple of false positives (no such field or method) errors when built with an upcoming Go release. Suppress these errors until the next Go release and the corresponding golangci-lint fix.