### PR TITLE
Generator Cleanups

### DIFF
--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -74,7 +74,7 @@ func main() {
 		}
 		generateFlags.Parse(flag.Args()[1:]) //nolint:errcheck // does os.Exit on error
 		if err := generate.Generate(".", flag.Args()[1:]); err != nil {
-			fmt.Fprint(os.Stderr, err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		return

--- a/examples/chat/weaver_gen.go
+++ b/examples/chat/weaver_gen.go
@@ -939,29 +939,6 @@ func serviceweaver_dec_slice_Post_29a9ee83(dec *codegen.Decoder) []Post {
 
 // Encoding/decoding implementations.
 
-func serviceweaver_enc_slice_string_4af10117(enc *codegen.Encoder, arg []string) {
-	if arg == nil {
-		enc.Len(-1)
-		return
-	}
-	enc.Len(len(arg))
-	for i := 0; i < len(arg); i++ {
-		enc.String(arg[i])
-	}
-}
-
-func serviceweaver_dec_slice_string_4af10117(dec *codegen.Decoder) []string {
-	n := dec.Len()
-	if n == -1 {
-		return nil
-	}
-	res := make([]string, n)
-	for i := 0; i < n; i++ {
-		res[i] = dec.String()
-	}
-	return res
-}
-
 func serviceweaver_enc_slice_byte_87461245(enc *codegen.Encoder, arg []byte) {
 	if arg == nil {
 		enc.Len(-1)
@@ -981,6 +958,29 @@ func serviceweaver_dec_slice_byte_87461245(dec *codegen.Decoder) []byte {
 	res := make([]byte, n)
 	for i := 0; i < n; i++ {
 		res[i] = dec.Byte()
+	}
+	return res
+}
+
+func serviceweaver_enc_slice_string_4af10117(enc *codegen.Encoder, arg []string) {
+	if arg == nil {
+		enc.Len(-1)
+		return
+	}
+	enc.Len(len(arg))
+	for i := 0; i < len(arg); i++ {
+		enc.String(arg[i])
+	}
+}
+
+func serviceweaver_dec_slice_string_4af10117(dec *codegen.Decoder) []string {
+	n := dec.Len()
+	if n == -1 {
+		return nil
+	}
+	res := make([]string, n)
+	for i := 0; i < n; i++ {
+		res[i] = dec.String()
 	}
 	return res
 }

--- a/godeps.txt
+++ b/godeps.txt
@@ -523,6 +523,7 @@ github.com/ServiceWeaver/weaver/internal/status
 github.com/ServiceWeaver/weaver/internal/tool/generate
     bytes
     crypto/sha256
+    errors
     fmt
     github.com/ServiceWeaver/weaver/internal/files
     github.com/ServiceWeaver/weaver/runtime/colors
@@ -531,6 +532,7 @@ github.com/ServiceWeaver/weaver/internal/tool/generate
     go/parser
     go/token
     go/types
+    golang.org/x/exp/maps
     golang.org/x/tools/go/packages
     golang.org/x/tools/go/types/typeutil
     io

--- a/internal/tool/generate/testdata/errors/extra_routing_function.go
+++ b/internal/tool/generate/testdata/errors/extra_routing_function.go
@@ -24,11 +24,16 @@ import (
 )
 
 type foo interface {
+	Foo(context.Context) error
 }
 
 type impl struct {
 	weaver.Implements[foo]
 	weaver.WithRouter[fooRouter]
+}
+
+func (impl) Foo(context.Context) error {
+	return nil
 }
 
 type fooRouter struct{}

--- a/internal/tool/generate/types.go
+++ b/internal/tool/generate/types.go
@@ -578,17 +578,6 @@ func (tset *typeSet) genTypeString(t types.Type) string {
 	return types.TypeString(t, qualifier)
 }
 
-// typeString pretty prints a type.
-func (tset *typeSet) typeString(t types.Type) string {
-	var qualifier = func(pkg *types.Package) string {
-		if pkg == tset.pkg.Types {
-			return ""
-		}
-		return pkg.Name()
-	}
-	return types.TypeString(t, qualifier)
-}
-
 // isInvalid returns true iff the given type is invalid.
 func isInvalid(t types.Type) bool {
 	return t.String() == "invalid type"


### PR DESCRIPTION
## `weaver generate` Refresher
 
`weaver generate` has two phases. In the first phase, it analyzes and validates the provided code. For example:
    
- It finds every component interface and implementation.
- It checks that the implementation implements the interface and that all method arguments and returns are serializable.
- It finds every router type and checks that the router's methods match the component's methods.
    
In the second phase, it generates code and places it in weaver_gen.go files.
    
## Changes
    
Before this PR, the `generator` type was responsible for both validation and generation. This PR changes validation to use pure functions and makes `generator` responsible solely for generation. I also made a bunch of miscellaneous cleanups.
    
Now that validation is performed as pure functions, the flow of errors is more explicit. Before, all errors were placed in `generator.errors`, which made it a bit confusing to what was failing. For example, code generation almost never fails. I don't think this was clear before.
    
A question to reviewers, would you prefer we place all the validation code in a separate file? Right now, generator.go is pretty long (2100+ lines).