### PR TITLE
Disallow unexported component interface methods.

### DIFF
--- a/internal/tool/generate/testdata/errors/missing_methods.go
+++ b/internal/tool/generate/testdata/errors/missing_methods.go
@@ -12,23 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ERROR: no exported methods
+// ERROR: has no methods
 
-// Implementation has no exported methods.
+// Implementation has no methods.
 package foo
 
 import (
-	"context"
-
 	"github.com/ServiceWeaver/weaver"
 )
 
-type foo interface {
-	bar(context.Context, int) error
-}
+type foo interface{}
 
 type impl struct{ weaver.Implements[foo] }
-
-func (l *impl) bar(context.Context, int) error {
-	return nil
-}

--- a/internal/tool/generate/testdata/errors/unexported_method.go
+++ b/internal/tool/generate/testdata/errors/unexported_method.go
@@ -1,0 +1,35 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ERROR: unexported
+
+package foo
+
+import (
+	"context"
+
+	"github.com/ServiceWeaver/weaver"
+)
+
+type foo interface {
+	Exported(context.Context) error
+	unexported(context.Context) error
+}
+
+type impl struct {
+	weaver.Implements[foo]
+}
+
+func (*impl) Exported(context.Context) error   { return nil }
+func (*impl) unexported(context.Context) error { return nil }


### PR DESCRIPTION
Previously, if a Service Weaver application included a component interface with unexported methods, the app would panic at runtime. Thanks to ricardo.jmd.oliveira on our [Discord server][discord] for reporting this bug.

Rather than supporting unexported methods, this PR prohibits them. Unexported methods complicate code generation, as client and server stubs have to implement the unexported methods even though these methods will never get called. Furthermore, we're considering allowing component interfaces and implementations to be in separate packages. If we do allow this, it will be even harder to generate implementations of the interface without resorting to some [tricks][].

[discord]: https://discord.gg/FzbQ3SM8R5
[tricks]: https://stackoverflow.com/a/26181609