### PR TITLE
Allow empty component interfaces.

### DIFF
--- a/internal/tool/generate/generator.go
+++ b/internal/tool/generate/generator.go
@@ -481,13 +481,6 @@ func extractComponent(pkg *packages.Package, file *ast.File, tset *typeSet, spec
 		return offset1 < offset2
 	})
 
-	// Disallow interfaces without any exported methods.
-	if len(methods) == 0 {
-		return nil, errorf(pkg.Fset, spec.Pos(),
-			"Implemented component type %s has no methods.",
-			formatType(pkg, componentType))
-	}
-
 	comp := &component{
 		name:      componentType.Obj().Name(),
 		pos:       spec.Pos(),

--- a/internal/tool/generate/testdata/missing_methods.go
+++ b/internal/tool/generate/testdata/missing_methods.go
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ERROR: has no methods
-
 // Implementation has no methods.
 package foo
 
-import (
-	"github.com/ServiceWeaver/weaver"
-)
+import "github.com/ServiceWeaver/weaver"
 
 type foo interface{}
 


### PR DESCRIPTION
This PR changes `weaver generate` to allow empty component interfaces. We're in the process of converting main to be an explicit component that implements an empty `weaver.Main` interface. This change will allow that. We've also received [an issue][issue] explaining a use case for an interface without any methods.

[issue]: https://github.com/ServiceWeaver/weaver/issues/270