### PR TITLE
Simplified weaver generate's component type.

### DIFF
--- a/examples/hello/weaver_gen.go
+++ b/examples/hello/weaver_gen.go
@@ -21,7 +21,7 @@ func init() {
 		New:         func() any { return &cache{} },
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return cache_local_stub{impl: impl.(Cache), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return cache_client_stub{stub: stub, setMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/hello/Cache", Method: "Set"}), getMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/hello/Cache", Method: "Get"})}
+			return cache_client_stub{stub: stub, getMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/hello/Cache", Method: "Get"}), setMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/hello/Cache", Method: "Set"})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return cache_server_stub{impl: impl.(Cache), addLoad: addLoad}
@@ -50,23 +50,6 @@ type cache_local_stub struct {
 	tracer trace.Tracer
 }
 
-func (s cache_local_stub) Set(ctx context.Context, a0 string, a1 string) (err error) {
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a child span for this method.
-		ctx, span = s.tracer.Start(ctx, "main.Cache.Set", trace.WithSpanKind(trace.SpanKindInternal))
-		defer func() {
-			if err != nil {
-				span.RecordError(err)
-				span.SetStatus(codes.Error, err.Error())
-			}
-			span.End()
-		}()
-	}
-
-	return s.impl.Set(ctx, a0, a1)
-}
-
 func (s cache_local_stub) Get(ctx context.Context, a0 string) (r0 string, err error) {
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -82,6 +65,23 @@ func (s cache_local_stub) Get(ctx context.Context, a0 string) (r0 string, err er
 	}
 
 	return s.impl.Get(ctx, a0)
+}
+
+func (s cache_local_stub) Set(ctx context.Context, a0 string, a1 string) (err error) {
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "main.Cache.Set", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.Set(ctx, a0, a1)
 }
 
 type reverser_local_stub struct {
@@ -110,8 +110,65 @@ func (s reverser_local_stub) Reverse(ctx context.Context, a0 string) (r0 string,
 
 type cache_client_stub struct {
 	stub       codegen.Stub
-	setMetrics *codegen.MethodMetrics
 	getMetrics *codegen.MethodMetrics
+	setMetrics *codegen.MethodMetrics
+}
+
+func (s cache_client_stub) Get(ctx context.Context, a0 string) (r0 string, err error) {
+	// Update metrics.
+	start := time.Now()
+	s.getMetrics.Count.Add(1)
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "main.Cache.Get", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+			if err != nil {
+				err = errors.Join(weaver.RemoteCallError, err)
+			}
+		}
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			s.getMetrics.ErrorCount.Add(1)
+		}
+		span.End()
+
+		s.getMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
+	}()
+
+	// Preallocate a buffer of the right size.
+	size := 0
+	size += (4 + len(a0))
+	enc := codegen.NewEncoder()
+	enc.Reset(size)
+
+	// Encode arguments.
+	enc.String(a0)
+	var shardKey uint64
+
+	// Call the remote method.
+	s.getMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	var results []byte
+	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	if err != nil {
+		err = errors.Join(weaver.RemoteCallError, err)
+		return
+	}
+	s.getMetrics.BytesReply.Put(float64(len(results)))
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	r0 = dec.String()
+	err = dec.Error()
+	return
 }
 
 func (s cache_client_stub) Set(ctx context.Context, a0 string, a1 string) (err error) {
@@ -168,63 +225,6 @@ func (s cache_client_stub) Set(ctx context.Context, a0 string, a1 string) (err e
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
-	err = dec.Error()
-	return
-}
-
-func (s cache_client_stub) Get(ctx context.Context, a0 string) (r0 string, err error) {
-	// Update metrics.
-	start := time.Now()
-	s.getMetrics.Count.Add(1)
-
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a child span for this method.
-		ctx, span = s.stub.Tracer().Start(ctx, "main.Cache.Get", trace.WithSpanKind(trace.SpanKindClient))
-	}
-
-	defer func() {
-		// Catch and return any panics detected during encoding/decoding/rpc.
-		if err == nil {
-			err = codegen.CatchPanics(recover())
-			if err != nil {
-				err = errors.Join(weaver.RemoteCallError, err)
-			}
-		}
-
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			s.getMetrics.ErrorCount.Add(1)
-		}
-		span.End()
-
-		s.getMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
-	}()
-
-	// Preallocate a buffer of the right size.
-	size := 0
-	size += (4 + len(a0))
-	enc := codegen.NewEncoder()
-	enc.Reset(size)
-
-	// Encode arguments.
-	enc.String(a0)
-	var shardKey uint64
-
-	// Call the remote method.
-	s.getMetrics.BytesRequest.Put(float64(len(enc.Data())))
-	var results []byte
-	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
-	if err != nil {
-		err = errors.Join(weaver.RemoteCallError, err)
-		return
-	}
-	s.getMetrics.BytesReply.Put(float64(len(results)))
-
-	// Decode the results.
-	dec := codegen.NewDecoder(results)
-	r0 = dec.String()
 	err = dec.Error()
 	return
 }
@@ -301,13 +301,38 @@ type cache_server_stub struct {
 // GetStubFn implements the stub.Server interface.
 func (s cache_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
 	switch method {
-	case "Set":
-		return s.set
 	case "Get":
 		return s.get
+	case "Set":
+		return s.set
 	default:
 		return nil
 	}
+}
+
+func (s cache_server_stub) get(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// Decode arguments.
+	dec := codegen.NewDecoder(args)
+	var a0 string
+	a0 = dec.String()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	r0, appErr := s.impl.Get(ctx, a0)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	enc.String(r0)
+	enc.Error(appErr)
+	return enc.Data(), nil
 }
 
 func (s cache_server_stub) set(ctx context.Context, args []byte) (res []byte, err error) {
@@ -332,31 +357,6 @@ func (s cache_server_stub) set(ctx context.Context, args []byte) (res []byte, er
 
 	// Encode the results.
 	enc := codegen.NewEncoder()
-	enc.Error(appErr)
-	return enc.Data(), nil
-}
-
-func (s cache_server_stub) get(ctx context.Context, args []byte) (res []byte, err error) {
-	// Catch and return any panics detected during encoding/decoding/rpc.
-	defer func() {
-		if err == nil {
-			err = codegen.CatchPanics(recover())
-		}
-	}()
-
-	// Decode arguments.
-	dec := codegen.NewDecoder(args)
-	var a0 string
-	a0 = dec.String()
-
-	// TODO(rgrandl): The deferred function above will recover from panics in the
-	// user code: fix this.
-	// Call the local method.
-	r0, appErr := s.impl.Get(ctx, a0)
-
-	// Encode the results.
-	enc := codegen.NewEncoder()
-	enc.String(r0)
 	enc.Error(appErr)
 	return enc.Data(), nil
 }

--- a/examples/onlineboutique/cartservice/weaver_gen.go
+++ b/examples/onlineboutique/cartservice/weaver_gen.go
@@ -22,7 +22,7 @@ func init() {
 		New:         func() any { return &impl{} },
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return t_client_stub{stub: stub, addItemMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "AddItem"}), getCartMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "GetCart"}), emptyCartMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "EmptyCart"})}
+			return t_client_stub{stub: stub, addItemMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "AddItem"}), emptyCartMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "EmptyCart"}), getCartMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "GetCart"})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return t_server_stub{impl: impl.(T), addLoad: addLoad}
@@ -69,23 +69,6 @@ func (s t_local_stub) AddItem(ctx context.Context, a0 string, a1 CartItem) (err 
 	return s.impl.AddItem(ctx, a0, a1)
 }
 
-func (s t_local_stub) GetCart(ctx context.Context, a0 string) (r0 []CartItem, err error) {
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a child span for this method.
-		ctx, span = s.tracer.Start(ctx, "cartservice.T.GetCart", trace.WithSpanKind(trace.SpanKindInternal))
-		defer func() {
-			if err != nil {
-				span.RecordError(err)
-				span.SetStatus(codes.Error, err.Error())
-			}
-			span.End()
-		}()
-	}
-
-	return s.impl.GetCart(ctx, a0)
-}
-
 func (s t_local_stub) EmptyCart(ctx context.Context, a0 string) (err error) {
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -101,6 +84,23 @@ func (s t_local_stub) EmptyCart(ctx context.Context, a0 string) (err error) {
 	}
 
 	return s.impl.EmptyCart(ctx, a0)
+}
+
+func (s t_local_stub) GetCart(ctx context.Context, a0 string) (r0 []CartItem, err error) {
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "cartservice.T.GetCart", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.GetCart(ctx, a0)
 }
 
 type cartCache_local_stub struct {
@@ -164,8 +164,8 @@ func (s cartCache_local_stub) Remove(ctx context.Context, a0 string) (r0 bool, e
 type t_client_stub struct {
 	stub             codegen.Stub
 	addItemMetrics   *codegen.MethodMetrics
-	getCartMetrics   *codegen.MethodMetrics
 	emptyCartMetrics *codegen.MethodMetrics
+	getCartMetrics   *codegen.MethodMetrics
 }
 
 func (s t_client_stub) AddItem(ctx context.Context, a0 string, a1 CartItem) (err error) {
@@ -226,6 +226,62 @@ func (s t_client_stub) AddItem(ctx context.Context, a0 string, a1 CartItem) (err
 	return
 }
 
+func (s t_client_stub) EmptyCart(ctx context.Context, a0 string) (err error) {
+	// Update metrics.
+	start := time.Now()
+	s.emptyCartMetrics.Count.Add(1)
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "cartservice.T.EmptyCart", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+			if err != nil {
+				err = errors.Join(weaver.RemoteCallError, err)
+			}
+		}
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			s.emptyCartMetrics.ErrorCount.Add(1)
+		}
+		span.End()
+
+		s.emptyCartMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
+	}()
+
+	// Preallocate a buffer of the right size.
+	size := 0
+	size += (4 + len(a0))
+	enc := codegen.NewEncoder()
+	enc.Reset(size)
+
+	// Encode arguments.
+	enc.String(a0)
+	var shardKey uint64
+
+	// Call the remote method.
+	s.emptyCartMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	var results []byte
+	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	if err != nil {
+		err = errors.Join(weaver.RemoteCallError, err)
+		return
+	}
+	s.emptyCartMetrics.BytesReply.Put(float64(len(results)))
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	err = dec.Error()
+	return
+}
+
 func (s t_client_stub) GetCart(ctx context.Context, a0 string) (r0 []CartItem, err error) {
 	// Update metrics.
 	start := time.Now()
@@ -279,62 +335,6 @@ func (s t_client_stub) GetCart(ctx context.Context, a0 string) (r0 []CartItem, e
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
 	r0 = serviceweaver_dec_slice_CartItem_7a7ff11c(dec)
-	err = dec.Error()
-	return
-}
-
-func (s t_client_stub) EmptyCart(ctx context.Context, a0 string) (err error) {
-	// Update metrics.
-	start := time.Now()
-	s.emptyCartMetrics.Count.Add(1)
-
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a child span for this method.
-		ctx, span = s.stub.Tracer().Start(ctx, "cartservice.T.EmptyCart", trace.WithSpanKind(trace.SpanKindClient))
-	}
-
-	defer func() {
-		// Catch and return any panics detected during encoding/decoding/rpc.
-		if err == nil {
-			err = codegen.CatchPanics(recover())
-			if err != nil {
-				err = errors.Join(weaver.RemoteCallError, err)
-			}
-		}
-
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			s.emptyCartMetrics.ErrorCount.Add(1)
-		}
-		span.End()
-
-		s.emptyCartMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
-	}()
-
-	// Preallocate a buffer of the right size.
-	size := 0
-	size += (4 + len(a0))
-	enc := codegen.NewEncoder()
-	enc.Reset(size)
-
-	// Encode arguments.
-	enc.String(a0)
-	var shardKey uint64
-
-	// Call the remote method.
-	s.emptyCartMetrics.BytesRequest.Put(float64(len(enc.Data())))
-	var results []byte
-	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
-	if err != nil {
-		err = errors.Join(weaver.RemoteCallError, err)
-		return
-	}
-	s.emptyCartMetrics.BytesReply.Put(float64(len(results)))
-
-	// Decode the results.
-	dec := codegen.NewDecoder(results)
 	err = dec.Error()
 	return
 }
@@ -533,10 +533,10 @@ func (s t_server_stub) GetStubFn(method string) func(ctx context.Context, args [
 	switch method {
 	case "AddItem":
 		return s.addItem
-	case "GetCart":
-		return s.getCart
 	case "EmptyCart":
 		return s.emptyCart
+	case "GetCart":
+		return s.getCart
 	default:
 		return nil
 	}
@@ -568,6 +568,30 @@ func (s t_server_stub) addItem(ctx context.Context, args []byte) (res []byte, er
 	return enc.Data(), nil
 }
 
+func (s t_server_stub) emptyCart(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// Decode arguments.
+	dec := codegen.NewDecoder(args)
+	var a0 string
+	a0 = dec.String()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	appErr := s.impl.EmptyCart(ctx, a0)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
+
 func (s t_server_stub) getCart(ctx context.Context, args []byte) (res []byte, err error) {
 	// Catch and return any panics detected during encoding/decoding/rpc.
 	defer func() {
@@ -589,30 +613,6 @@ func (s t_server_stub) getCart(ctx context.Context, args []byte) (res []byte, er
 	// Encode the results.
 	enc := codegen.NewEncoder()
 	serviceweaver_enc_slice_CartItem_7a7ff11c(enc, r0)
-	enc.Error(appErr)
-	return enc.Data(), nil
-}
-
-func (s t_server_stub) emptyCart(ctx context.Context, args []byte) (res []byte, err error) {
-	// Catch and return any panics detected during encoding/decoding/rpc.
-	defer func() {
-		if err == nil {
-			err = codegen.CatchPanics(recover())
-		}
-	}()
-
-	// Decode arguments.
-	dec := codegen.NewDecoder(args)
-	var a0 string
-	a0 = dec.String()
-
-	// TODO(rgrandl): The deferred function above will recover from panics in the
-	// user code: fix this.
-	// Call the local method.
-	appErr := s.impl.EmptyCart(ctx, a0)
-
-	// Encode the results.
-	enc := codegen.NewEncoder()
 	enc.Error(appErr)
 	return enc.Data(), nil
 }

--- a/examples/onlineboutique/currencyservice/weaver_gen.go
+++ b/examples/onlineboutique/currencyservice/weaver_gen.go
@@ -22,7 +22,7 @@ func init() {
 		New:         func() any { return &impl{} },
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return t_client_stub{stub: stub, getSupportedCurrenciesMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T", Method: "GetSupportedCurrencies"}), convertMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T", Method: "Convert"})}
+			return t_client_stub{stub: stub, convertMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T", Method: "Convert"}), getSupportedCurrenciesMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T", Method: "GetSupportedCurrencies"})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return t_server_stub{impl: impl.(T), addLoad: addLoad}
@@ -35,23 +35,6 @@ func init() {
 type t_local_stub struct {
 	impl   T
 	tracer trace.Tracer
-}
-
-func (s t_local_stub) GetSupportedCurrencies(ctx context.Context) (r0 []string, err error) {
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a child span for this method.
-		ctx, span = s.tracer.Start(ctx, "currencyservice.T.GetSupportedCurrencies", trace.WithSpanKind(trace.SpanKindInternal))
-		defer func() {
-			if err != nil {
-				span.RecordError(err)
-				span.SetStatus(codes.Error, err.Error())
-			}
-			span.End()
-		}()
-	}
-
-	return s.impl.GetSupportedCurrencies(ctx)
 }
 
 func (s t_local_stub) Convert(ctx context.Context, a0 money.T, a1 string) (r0 money.T, err error) {
@@ -71,61 +54,29 @@ func (s t_local_stub) Convert(ctx context.Context, a0 money.T, a1 string) (r0 mo
 	return s.impl.Convert(ctx, a0, a1)
 }
 
+func (s t_local_stub) GetSupportedCurrencies(ctx context.Context) (r0 []string, err error) {
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "currencyservice.T.GetSupportedCurrencies", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.GetSupportedCurrencies(ctx)
+}
+
 // Client stub implementations.
 
 type t_client_stub struct {
 	stub                          codegen.Stub
-	getSupportedCurrenciesMetrics *codegen.MethodMetrics
 	convertMetrics                *codegen.MethodMetrics
-}
-
-func (s t_client_stub) GetSupportedCurrencies(ctx context.Context) (r0 []string, err error) {
-	// Update metrics.
-	start := time.Now()
-	s.getSupportedCurrenciesMetrics.Count.Add(1)
-
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a child span for this method.
-		ctx, span = s.stub.Tracer().Start(ctx, "currencyservice.T.GetSupportedCurrencies", trace.WithSpanKind(trace.SpanKindClient))
-	}
-
-	defer func() {
-		// Catch and return any panics detected during encoding/decoding/rpc.
-		if err == nil {
-			err = codegen.CatchPanics(recover())
-			if err != nil {
-				err = errors.Join(weaver.RemoteCallError, err)
-			}
-		}
-
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			s.getSupportedCurrenciesMetrics.ErrorCount.Add(1)
-		}
-		span.End()
-
-		s.getSupportedCurrenciesMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
-	}()
-
-	var shardKey uint64
-
-	// Call the remote method.
-	s.getSupportedCurrenciesMetrics.BytesRequest.Put(0)
-	var results []byte
-	results, err = s.stub.Run(ctx, 1, nil, shardKey)
-	if err != nil {
-		err = errors.Join(weaver.RemoteCallError, err)
-		return
-	}
-	s.getSupportedCurrenciesMetrics.BytesReply.Put(float64(len(results)))
-
-	// Decode the results.
-	dec := codegen.NewDecoder(results)
-	r0 = serviceweaver_dec_slice_string_4af10117(dec)
-	err = dec.Error()
-	return
+	getSupportedCurrenciesMetrics *codegen.MethodMetrics
 }
 
 func (s t_client_stub) Convert(ctx context.Context, a0 money.T, a1 string) (r0 money.T, err error) {
@@ -181,6 +132,55 @@ func (s t_client_stub) Convert(ctx context.Context, a0 money.T, a1 string) (r0 m
 	return
 }
 
+func (s t_client_stub) GetSupportedCurrencies(ctx context.Context) (r0 []string, err error) {
+	// Update metrics.
+	start := time.Now()
+	s.getSupportedCurrenciesMetrics.Count.Add(1)
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "currencyservice.T.GetSupportedCurrencies", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+			if err != nil {
+				err = errors.Join(weaver.RemoteCallError, err)
+			}
+		}
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			s.getSupportedCurrenciesMetrics.ErrorCount.Add(1)
+		}
+		span.End()
+
+		s.getSupportedCurrenciesMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
+	}()
+
+	var shardKey uint64
+
+	// Call the remote method.
+	s.getSupportedCurrenciesMetrics.BytesRequest.Put(0)
+	var results []byte
+	results, err = s.stub.Run(ctx, 1, nil, shardKey)
+	if err != nil {
+		err = errors.Join(weaver.RemoteCallError, err)
+		return
+	}
+	s.getSupportedCurrenciesMetrics.BytesReply.Put(float64(len(results)))
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	r0 = serviceweaver_dec_slice_string_4af10117(dec)
+	err = dec.Error()
+	return
+}
+
 // Server stub implementations.
 
 type t_server_stub struct {
@@ -191,33 +191,13 @@ type t_server_stub struct {
 // GetStubFn implements the stub.Server interface.
 func (s t_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
 	switch method {
-	case "GetSupportedCurrencies":
-		return s.getSupportedCurrencies
 	case "Convert":
 		return s.convert
+	case "GetSupportedCurrencies":
+		return s.getSupportedCurrencies
 	default:
 		return nil
 	}
-}
-
-func (s t_server_stub) getSupportedCurrencies(ctx context.Context, args []byte) (res []byte, err error) {
-	// Catch and return any panics detected during encoding/decoding/rpc.
-	defer func() {
-		if err == nil {
-			err = codegen.CatchPanics(recover())
-		}
-	}()
-
-	// TODO(rgrandl): The deferred function above will recover from panics in the
-	// user code: fix this.
-	// Call the local method.
-	r0, appErr := s.impl.GetSupportedCurrencies(ctx)
-
-	// Encode the results.
-	enc := codegen.NewEncoder()
-	serviceweaver_enc_slice_string_4af10117(enc, r0)
-	enc.Error(appErr)
-	return enc.Data(), nil
 }
 
 func (s t_server_stub) convert(ctx context.Context, args []byte) (res []byte, err error) {
@@ -243,6 +223,26 @@ func (s t_server_stub) convert(ctx context.Context, args []byte) (res []byte, er
 	// Encode the results.
 	enc := codegen.NewEncoder()
 	(r0).WeaverMarshal(enc)
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
+
+func (s t_server_stub) getSupportedCurrencies(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	r0, appErr := s.impl.GetSupportedCurrencies(ctx)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	serviceweaver_enc_slice_string_4af10117(enc, r0)
 	enc.Error(appErr)
 	return enc.Data(), nil
 }

--- a/examples/onlineboutique/productcatalogservice/weaver_gen.go
+++ b/examples/onlineboutique/productcatalogservice/weaver_gen.go
@@ -22,7 +22,7 @@ func init() {
 		New:         func() any { return &impl{} },
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return t_client_stub{stub: stub, listProductsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "ListProducts"}), getProductMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "GetProduct"}), searchProductsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "SearchProducts"})}
+			return t_client_stub{stub: stub, getProductMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "GetProduct"}), listProductsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "ListProducts"}), searchProductsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "SearchProducts"})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return t_server_stub{impl: impl.(T), addLoad: addLoad}
@@ -35,23 +35,6 @@ func init() {
 type t_local_stub struct {
 	impl   T
 	tracer trace.Tracer
-}
-
-func (s t_local_stub) ListProducts(ctx context.Context) (r0 []Product, err error) {
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a child span for this method.
-		ctx, span = s.tracer.Start(ctx, "productcatalogservice.T.ListProducts", trace.WithSpanKind(trace.SpanKindInternal))
-		defer func() {
-			if err != nil {
-				span.RecordError(err)
-				span.SetStatus(codes.Error, err.Error())
-			}
-			span.End()
-		}()
-	}
-
-	return s.impl.ListProducts(ctx)
 }
 
 func (s t_local_stub) GetProduct(ctx context.Context, a0 string) (r0 Product, err error) {
@@ -69,6 +52,23 @@ func (s t_local_stub) GetProduct(ctx context.Context, a0 string) (r0 Product, er
 	}
 
 	return s.impl.GetProduct(ctx, a0)
+}
+
+func (s t_local_stub) ListProducts(ctx context.Context) (r0 []Product, err error) {
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "productcatalogservice.T.ListProducts", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.ListProducts(ctx)
 }
 
 func (s t_local_stub) SearchProducts(ctx context.Context, a0 string) (r0 []Product, err error) {
@@ -92,58 +92,9 @@ func (s t_local_stub) SearchProducts(ctx context.Context, a0 string) (r0 []Produ
 
 type t_client_stub struct {
 	stub                  codegen.Stub
-	listProductsMetrics   *codegen.MethodMetrics
 	getProductMetrics     *codegen.MethodMetrics
+	listProductsMetrics   *codegen.MethodMetrics
 	searchProductsMetrics *codegen.MethodMetrics
-}
-
-func (s t_client_stub) ListProducts(ctx context.Context) (r0 []Product, err error) {
-	// Update metrics.
-	start := time.Now()
-	s.listProductsMetrics.Count.Add(1)
-
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a child span for this method.
-		ctx, span = s.stub.Tracer().Start(ctx, "productcatalogservice.T.ListProducts", trace.WithSpanKind(trace.SpanKindClient))
-	}
-
-	defer func() {
-		// Catch and return any panics detected during encoding/decoding/rpc.
-		if err == nil {
-			err = codegen.CatchPanics(recover())
-			if err != nil {
-				err = errors.Join(weaver.RemoteCallError, err)
-			}
-		}
-
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			s.listProductsMetrics.ErrorCount.Add(1)
-		}
-		span.End()
-
-		s.listProductsMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
-	}()
-
-	var shardKey uint64
-
-	// Call the remote method.
-	s.listProductsMetrics.BytesRequest.Put(0)
-	var results []byte
-	results, err = s.stub.Run(ctx, 1, nil, shardKey)
-	if err != nil {
-		err = errors.Join(weaver.RemoteCallError, err)
-		return
-	}
-	s.listProductsMetrics.BytesReply.Put(float64(len(results)))
-
-	// Decode the results.
-	dec := codegen.NewDecoder(results)
-	r0 = serviceweaver_dec_slice_Product_3e9d9e07(dec)
-	err = dec.Error()
-	return
 }
 
 func (s t_client_stub) GetProduct(ctx context.Context, a0 string) (r0 Product, err error) {
@@ -199,6 +150,55 @@ func (s t_client_stub) GetProduct(ctx context.Context, a0 string) (r0 Product, e
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
 	(&r0).WeaverUnmarshal(dec)
+	err = dec.Error()
+	return
+}
+
+func (s t_client_stub) ListProducts(ctx context.Context) (r0 []Product, err error) {
+	// Update metrics.
+	start := time.Now()
+	s.listProductsMetrics.Count.Add(1)
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "productcatalogservice.T.ListProducts", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+			if err != nil {
+				err = errors.Join(weaver.RemoteCallError, err)
+			}
+		}
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			s.listProductsMetrics.ErrorCount.Add(1)
+		}
+		span.End()
+
+		s.listProductsMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
+	}()
+
+	var shardKey uint64
+
+	// Call the remote method.
+	s.listProductsMetrics.BytesRequest.Put(0)
+	var results []byte
+	results, err = s.stub.Run(ctx, 1, nil, shardKey)
+	if err != nil {
+		err = errors.Join(weaver.RemoteCallError, err)
+		return
+	}
+	s.listProductsMetrics.BytesReply.Put(float64(len(results)))
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	r0 = serviceweaver_dec_slice_Product_3e9d9e07(dec)
 	err = dec.Error()
 	return
 }
@@ -270,35 +270,15 @@ type t_server_stub struct {
 // GetStubFn implements the stub.Server interface.
 func (s t_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
 	switch method {
-	case "ListProducts":
-		return s.listProducts
 	case "GetProduct":
 		return s.getProduct
+	case "ListProducts":
+		return s.listProducts
 	case "SearchProducts":
 		return s.searchProducts
 	default:
 		return nil
 	}
-}
-
-func (s t_server_stub) listProducts(ctx context.Context, args []byte) (res []byte, err error) {
-	// Catch and return any panics detected during encoding/decoding/rpc.
-	defer func() {
-		if err == nil {
-			err = codegen.CatchPanics(recover())
-		}
-	}()
-
-	// TODO(rgrandl): The deferred function above will recover from panics in the
-	// user code: fix this.
-	// Call the local method.
-	r0, appErr := s.impl.ListProducts(ctx)
-
-	// Encode the results.
-	enc := codegen.NewEncoder()
-	serviceweaver_enc_slice_Product_3e9d9e07(enc, r0)
-	enc.Error(appErr)
-	return enc.Data(), nil
 }
 
 func (s t_server_stub) getProduct(ctx context.Context, args []byte) (res []byte, err error) {
@@ -322,6 +302,26 @@ func (s t_server_stub) getProduct(ctx context.Context, args []byte) (res []byte,
 	// Encode the results.
 	enc := codegen.NewEncoder()
 	(r0).WeaverMarshal(enc)
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
+
+func (s t_server_stub) listProducts(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	r0, appErr := s.impl.ListProducts(ctx)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	serviceweaver_enc_slice_Product_3e9d9e07(enc, r0)
 	enc.Error(appErr)
 	return enc.Data(), nil
 }

--- a/internal/tool/generate/testdata/errors/router_not_a_named_type.go
+++ b/internal/tool/generate/testdata/errors/router_not_a_named_type.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ERROR: must be a type with routing methods
+// ERROR: int is not a named type
 
-// Router not a type.
+// weaver.WithRouter[int] is invalid because int is not a named type.
 package foo
 
 import (


### PR DESCRIPTION
Before this PR, `weaver generate` had the following type to represent components:

```go
type component struct {
    name          string           // component interface name
    pos           token.Pos        // Location of component implementation
    fullName      string           // package-prefixed component interface name
    implName      string           // name of the component implementation type
    intf          *types.Interface // component's interface type
    file          *ast.File        // file that contains component's implementation
    methods       []*types.Func    // exported component methods, in deterministic order
    router        *types.Named     // router type for the component, or nil if there is no router.
    hasConfig     bool             // True iff implementation contains a weaver.WithConfig field.
    routingKey    types.Type       // routing key, or nil if there is no router.
    routedMethods map[string]bool  // the set of methods with a routing function
}
```

Many of these fields were either easily derivable from other fields (e.g., `name`, `fullName`, `implName`) or just straight up unused (e.g., `pos`, `file`). This PR simplifies the type to the following.

```go
type component struct {
    intf          *types.Named    // component interface
    impl          *types.Named    // component implementation
    router        *types.Named    // router, or nil if there is no router
    routingKey    types.Type      // routing key, or nil if there is no router
    routedMethods map[string]bool // the set of methods with a routing function
    hasConfig     bool            // implementation embeds weaver.WithConfig?
}
```

In making this change, I also cleaned up a couple of small things here and there (e.g., imprecise `token.Pos`'s in errors, some returns that should have been continues).

Note that some `weaver_gen.go` files changed because I simplified (and made more deterministic I think) the order in which methods are processed. None of the generated code should be different, just shuffled around.