### PR TITLE
Fixed annoying website wiggles.

### DIFF
--- a/website/assets/css/common.css
+++ b/website/assets/css/common.css
@@ -17,6 +17,7 @@ body {
   font-family: "Roboto", sans-serif;
   padding: 0;
   margin: 0;
+  width: 100vw;
 }
 h1 {
   font-weight: normal;


### PR DESCRIPTION
Before this PR, the website header would sometimes shift slightly left or right depending on which page you were on. This caused the site to wiggle if you switched back and forth between two pages.

I spent some time debugging this. At first, I thought it was some super complicated CSS subtlety related flexbox or something. After a while, it dawned on me that it was much simpler. On pages that were long, the scrollbar appeared, which slightly shrunk the width of the page, causing the header to move left.

This PR fixes the problem by setting the body width to `100vw`.

## Before

[Wiggle.webm](https://user-images.githubusercontent.com/3654277/233488948-dff68abd-ea86-4141-90ad-aa739d34a5da.webm)

## After

[No Wiggle.webm](https://user-images.githubusercontent.com/3654277/233488946-1f36a287-5213-429e-af5d-24fc2436c502.webm)