### PR TITLE
Export healthz URL path and default handler.

### DIFF
--- a/component.go
+++ b/component.go
@@ -46,13 +46,13 @@ type Instance interface {
 	// Listener returns a network listener with the given name that is suitable
 	// for hosting an HTTP server.
 	//
-	// Name may be used by the Service Weaver framework to route client traffic to the
-	// corresponding network listener. As such, listener names should follow the
-	// DNS format for names.
+	// Name may be used by the Service Weaver framework to route client traffic
+	// to the corresponding network listener. As such, listener names should
+	// follow the DNS format for names.
 	//
-	// HTTP servers constructed using this listener are expected to perform health
-	// checks on the reserved "/healthz" URL prefix. (Note that this URL prefix
-	// is configured to never receive any user traffic.)
+	// HTTP servers constructed using this listener are expected to perform
+	// health checks on the reserved HealthzURL path. (Note that this
+	// URL path is configured to never receive any user traffic.)
 	//
 	// If different processes in an application call Listener() multiple times
 	// with the same listener name but different options, the options value from

--- a/examples/chat/server.go
+++ b/examples/chat/server.go
@@ -72,7 +72,7 @@ func (s *server) label(r *http.Request) string {
 	}
 
 	switch r.URL.Path {
-	case "/", "/thumbnail", "/newthread", "/newpost", "/healthz":
+	case "/", "/thumbnail", "/newthread", "/newpost", weaver.HealthzURL:
 		return r.URL.Path
 	default:
 		return "unknown"
@@ -96,7 +96,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.newThread(w, r, user)
 	case "/newpost":
 		s.newPost(w, r, user)
-	case "/healthz":
+	case weaver.HealthzURL:
 		// Returns OK status.
 	default:
 		http.Error(w, "not found", http.StatusNotFound)

--- a/examples/collatz/server.go
+++ b/examples/collatz/server.go
@@ -42,7 +42,7 @@ func newServer(root weaver.Instance) (*server, error) {
 	}
 	s := &server{root: root, odd: odd, even: even}
 	s.mux.Handle("/", weaver.InstrumentHandlerFunc("collatz", s.handle))
-	s.mux.Handle("/healthz", weaver.InstrumentHandlerFunc("/healthz", s.handleHealthz))
+	s.mux.HandleFunc(weaver.HealthzURL, weaver.HealthzHandler)
 	return s, nil
 }
 
@@ -82,8 +82,4 @@ func (s *server) handle(w http.ResponseWriter, r *http.Request) {
 	}
 	fmt.Fprintf(&builder, "%d\n", x)
 	fmt.Fprint(w, builder.String())
-}
-
-func (s *server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
-	fmt.Fprintln(w, "ok")
 }

--- a/examples/onlineboutique/frontend/frontend.go
+++ b/examples/onlineboutique/frontend/frontend.go
@@ -186,9 +186,7 @@ func NewServer(root weaver.Instance) (*Server, error) {
 	r.Handle("/cart/checkout", instrument("cart_checkout", s.placeOrderHandler, []string{post}))
 	r.Handle("/static/", weaver.InstrumentHandler("static", http.StripPrefix("/static/", http.FileServer(http.FS(staticHTML)))))
 	r.Handle("/robots.txt", instrument("robots", func(w http.ResponseWriter, _ *http.Request) { fmt.Fprint(w, "User-agent: *\nDisallow: /") }, nil))
-
-	// No instrumentation of /healthz
-	r.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { fmt.Fprint(w, "ok") })
+	r.HandleFunc(weaver.HealthzURL, weaver.HealthzHandler)
 
 	// Set handler and return.
 	var handler http.Handler = r

--- a/examples/reverser/main.go
+++ b/examples/reverser/main.go
@@ -68,11 +68,7 @@ func main() {
 			}
 			fmt.Fprintln(w, reversed)
 		}))
-
-	// Serve the /healthz endpoint.
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "OK")
-	})
+	mux.HandleFunc(weaver.HealthzURL, weaver.HealthzHandler)
 
 	handler := otelhttp.NewHandler(&mux, "http")
 	http.Serve(lis, handler)

--- a/runtime/protos/runtime.pb.go
+++ b/runtime/protos/runtime.pb.go
@@ -2066,17 +2066,12 @@ func (*ActivateComponentReply) Descriptor() ([]byte, []int) {
 // are some examples of how different deployers may handle a
 // GetListenerAddressRequest.
 //
-// - The singleprocess deployer may instruct the weavelet to listen directly
-//
-//	on localhost:9000.
-//
-// - The multiprocess deployer may instruct the weavelet to listen on
-//
-//	localhost:0. It will separately start a proxy on localhost:9000.
-//
-// - The SSH deployer may instruct the weavelet to listen on
-//
-//	$HOSTNAME:0. It will separately start a proxy on localhost:9000.
+//   - The singleprocess deployer may instruct the weavelet to listen directly
+//     on localhost:9000.
+//   - The multiprocess deployer may instruct the weavelet to listen on
+//     localhost:0. It will separately start a proxy on localhost:9000.
+//   - The SSH deployer may instruct the weavelet to listen on
+//     $HOSTNAME:0. It will separately start a proxy on localhost:9000.
 type GetListenerAddressRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache


### PR DESCRIPTION
Also, change the URL path to "/debug/weaver/healthz", to avoid interference with application handlers.

Based on @ghemawat's suggestions.