### PR TITLE
Experiment with generic codegen.Register function.

### DIFF
--- a/examples/collatz/weaver_gen.go
+++ b/examples/collatz/weaver_gen.go
@@ -15,18 +15,27 @@ import (
 )
 
 func init() {
-	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/examples/collatz/Even",
-		Iface:       reflect.TypeOf((*Even)(nil)).Elem(),
-		New:         func() any { return &even{} },
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return even_local_stub{impl: impl.(Even), tracer: tracer} },
-		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return even_client_stub{stub: stub, doMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/collatz/Even", Method: "Do"})}
+	codegen.RegisterTyped(codegen.TypedRegistration[Even, even]{
+		LocalStubFn: func(impl *even, tracer trace.Tracer) Even {
+			return even_local_stub{impl: impl, tracer: tracer}
 		},
-		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
-			return even_server_stub{impl: impl.(Even), addLoad: addLoad}
+		ClientStubFn: func(stub codegen.Stub, caller string) Even {
+			return even_client_stub{
+				stub: stub,
+				doMetrics: codegen.MethodMetricsFor(
+					codegen.MethodLabels{
+						Caller:    caller,
+						Component: "github.com/ServiceWeaver/weaver/examples/collatz/Even",
+						Method:    "Do",
+					},
+				),
+			}
+		},
+		ServerStubFn: func(impl *even, addLoad func(uint64, float64)) codegen.Server {
+			return even_server_stub{impl: impl, addLoad: addLoad}
 		},
 	})
+
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/examples/collatz/Odd",
 		Iface:       reflect.TypeOf((*Odd)(nil)).Elem(),


### PR DESCRIPTION
## Background

Recall that `weaver generate` generates code to register every component. A component's registration includes its name, its interface type, and a handful of functions to create things like client and server stubs. Here's an example:

```go
codegen.Register(codegen.Registration{
    Name:        "github.com/ServiceWeaver/weaver/examples/collatz/Even",
    Iface:       reflect.TypeOf((*Even)(nil)).Elem(),
    New:         func() any { return &even{} },
    LocalStubFn: func(impl any, tracer trace.Tracer) any {
        return even_local_stub{impl: impl.(Even), tracer: tracer}
    },
    ClientStubFn: func(stub codegen.Stub, caller string) any {
        return even_client_stub{
            stub: stub,
            doMetrics: codegen.MethodMetricsFor(
                codegen.MethodLabels{
                    Caller: caller,
                    Component: "github.com/ServiceWeaver/weaver/examples/collatz/Even",
                    Method: "Do",
                },
            ),
        }
    },
    ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
        return even_server_stub{impl: impl.(Even), addLoad: addLoad}
    },
})
```

The generated registration today has some small warts.

- `Name` is redundant. It can be derived from `Iface`.
- It might be more convenient to pass `Iface` as a type argument instead of a `reflect.Type`.
- `New` is redundant. It can be derived from `Iface`.
- `LocalStubFn`, `ClientStubFn`, and `ServerStubFn` use a lot of `any`.

## Proposal

This PR explores the possibility of a generic `codegen.Register` function. The above registration would instead look like this:

```go
codegen.Register(codegen.TypedRegistration[Even, even]{
    LocalStubFn: func(impl *even, tracer trace.Tracer) Even {
        return even_local_stub{impl: impl, tracer: tracer}
    },
    ClientStubFn: func(stub codegen.Stub, caller string) Even {
        return even_client_stub{
            stub: stub,
            doMetrics: codegen.MethodMetricsFor(
                codegen.MethodLabels{
                    Caller:    caller,
                    Component: "github.com/ServiceWeaver/weaver/examples/collatz/Even",
                    Method:    "Do",
                },
            ),
        }
    },
    ServerStubFn: func(impl *even, addLoad func(uint64, float64)) codegen.Server {
        return even_server_stub{impl: impl, addLoad: addLoad}
    },
})
```

`Name`, `Iface`, and `New` are removed. `LocalStubFn`, `ClientStubFn`, and `ServerStubFn` are typed. Internally, the codegen package erases the types and converts a `TypedRegistration` into a `Registration`.

We could also generate the implementations of `LocalStubFn`, `ClientStubFn`, and `ServerStubFn` standalone functions. That would look like this:

```go
func init() {
    codegen.Register(codegen.TypedRegistration[Even, even]{
        LocalStubFn: new_even_local_stub,
        ClientStubFn: new_even_client_stub,
        ServerStubFn: new_even_server_stub,
    })
}

// Generated next to even_local_stub.
func new_even_local_stub(impl *even, tracer trace.Tracer) Even {
    return even_local_stub{impl: impl, tracer: tracer}
}

// Generated next to even_client_stub.
func new_even_client_stub(stub codegen.Stub, caller string) Even {
    return even_client_stub{
        stub: stub,
        doMetrics: codegen.MethodMetricsFor(
            codegen.MethodLabels{
                Caller:    caller,
                Component: "github.com/ServiceWeaver/weaver/examples/collatz/Even",
                Method:    "Do",
            },
        ),
    }
}

// Generated next to even_server_stub.
func new_even_server_stub(impl *even, addLoad func(uint64, float64)) codegen.Server {
    return even_server_stub{impl: impl, addLoad: addLoad}
}
```

## Implementation Status

This PR doesn't fully implement the proposal above yet. I introduced a `TypedRegistration` type and a `RegisterTyped` function, but didn't update the code generator to use these. I manually edited a `weaver_gen.go` file to see what it would look like. If we like this idea, I'll finish implementing the PR!

Thanks, Sanjay, for [the suggestion][1].

[1]: https://github.com/ServiceWeaver/weaver/pull/278#issuecomment-1518240169