### PR TITLE
Add a test for the examples

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,6 +49,10 @@ jobs:
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
         if: ${{ matrix.command == 'lint' }}
 
+      - name: Build the weaver binary
+        run: cd cmd/weaver; go build .
+        if: ${{ matrix.command == 'test' || matrix.command == 'testrace' }}
+
       - name: ${{ matrix.command }}
         run: ./dev/build_and_test ${{ matrix.command }}
 

--- a/dev/build_and_test
+++ b/dev/build_and_test
@@ -66,7 +66,7 @@ function cmd_lint() {
 }
 
 function cmd_test() {
-  go test ./...
+  go test -v ./...
 }
 
 function cmd_testrace() {

--- a/dev/build_and_test
+++ b/dev/build_and_test
@@ -66,11 +66,11 @@ function cmd_lint() {
 }
 
 function cmd_test() {
-  go test -v ./...
+  go test -v -p=1 ./...
 }
 
 function cmd_testrace() {
-  go test -race ./...
+  go test -v -p=1 -race ./...
 }
 
 function main() {

--- a/dev/build_and_test
+++ b/dev/build_and_test
@@ -66,11 +66,11 @@ function cmd_lint() {
 }
 
 function cmd_test() {
-  go test -v -p=1 ./...
+  go test -v -p=1 -timeout=120s ./...
 }
 
 function cmd_testrace() {
-  go test -v -p=1 -race ./...
+  go test -v -p=1 -timeout=120s -race ./...
 }
 
 function main() {

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -94,10 +94,15 @@ func (tc httpRequestTestCase) run(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 	t.Cleanup(cancel)
 
+	client := http.DefaultClient
+
 	var resp *http.Response
 	var err error
 	for r := retry.Begin(); r.Continue(ctx); {
-		resp, err = http.Get(tc.url)
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, tc.url, nil)
+		isNilError(t, reqErr)
+
+		resp, err = client.Do(req)
 		if err == nil {
 			break
 		}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -16,7 +16,6 @@ package examples
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -160,14 +159,8 @@ func terminateCmdAndWait(t *testing.T, cmd *exec.Cmd) func() {
 		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
 			t.Fatalf("failed to terminate process: %v", err)
 		}
-
-		err := <-errCh
-		exitError := &exec.ExitError{}
-		if !errors.As(err, &exitError) {
-			t.Fatalf("unexpected error %v (%T)", err, err)
-		}
-		if exitError.ExitCode() != 128+int(syscall.SIGTERM) {
-			t.Fatalf("unexpected error %v", err)
+		if err := <-errCh; err != nil {
+			t.Fatalf("unexpected exit error: %v", err)
 		}
 	}
 }

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -147,19 +147,11 @@ func startCmd(ctx context.Context, t *testing.T, c string) *exec.Cmd {
 }
 
 func terminateCmdAndWait(t *testing.T, cmd *exec.Cmd) func() {
-	errCh := make(chan error)
-	// start waiting on exit in the background before the test case runs to avoid
-	// a race with sending SIGTERM. That race can cause the test to fail with
-	// exitError.ExitCode of -1.
-	go func() {
-		errCh <- cmd.Wait()
-	}()
-
 	return func() {
 		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
 			t.Fatalf("failed to terminate process: %v", err)
 		}
-		if err := <-errCh; err != nil {
+		if err := cmd.Wait(); err != nil {
 			t.Fatalf("unexpected exit error: %v", err)
 		}
 	}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -1,0 +1,173 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/ServiceWeaver/weaver/runtime/retry"
+)
+
+func TestExamples(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"hello": httpRequestTestCase{
+			url:          "http://localhost:12345/hello?name=something",
+			expectedBody: "Hello, gnihtemos!\n",
+		}.run,
+		"collatz": httpRequestTestCase{
+			url:          "http://127.0.0.1:9000?x=8",
+			expectedBody: "8\n4\n2\n1\n",
+		}.run,
+		"reverser": httpRequestTestCase{
+			url:          "http://127.0.0.1:9000/reverse?s=abcdef",
+			expectedBody: "fedcba\n",
+		}.run,
+	}
+
+	examples, err := os.ReadDir(".")
+	isNilError(t, err)
+
+	for _, example := range examples {
+		if !example.IsDir() {
+			continue
+		}
+
+		name := example.Name()
+		t.Run(name, func(t *testing.T) {
+			run := testCases[name]
+			if run == nil {
+				// TODO: make this t.Fatal once existing examples have tests
+				t.Skip("no test case defined")
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			t.Cleanup(cancel)
+
+			chdir(t, name)
+			cmd := startCmd(ctx, t, "go build .")
+			if err := cmd.Wait(); err != nil {
+				t.Fatalf("failed to build binary: %v", err)
+			}
+
+			t.Run("single", func(t *testing.T) {
+				cmd := startCmd(ctx, t, "./"+name)
+				t.Cleanup(terminateCmdAndWait(t, cmd))
+				run(t)
+			})
+
+			t.Run("multi", func(t *testing.T) {
+				cmd := startCmd(ctx, t, "../../cmd/weaver/weaver multi deploy weaver.toml")
+				t.Cleanup(terminateCmdAndWait(t, cmd))
+				run(t)
+			})
+
+			// TODO: other deployers?
+		})
+	}
+}
+
+type httpRequestTestCase struct {
+	url          string
+	expectedBody string
+}
+
+func (tc httpRequestTestCase) run(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	t.Cleanup(cancel)
+
+	var resp *http.Response
+	var err error
+	for r := retry.Begin(); r.Continue(ctx); {
+		resp, err = http.Get(tc.url)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		t.Fatalf("timeout waiting on listener, last error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected response code OK 200, got %v", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	isNilError(t, err)
+
+	if actual := string(body); actual != tc.expectedBody {
+		t.Fatalf("response body is %v, expected %v", actual, tc.expectedBody)
+	}
+}
+
+func isNilError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func chdir(t *testing.T, path string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	isNilError(t, err)
+
+	isNilError(t, os.Chdir(path))
+	t.Cleanup(func() {
+		isNilError(t, os.Chdir(orig))
+	})
+}
+
+func startCmd(ctx context.Context, t *testing.T, c string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, "sh", "-c", c)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	isNilError(t, cmd.Start())
+	return cmd
+}
+
+func terminateCmdAndWait(t *testing.T, cmd *exec.Cmd) func() {
+	errCh := make(chan error)
+	// start waiting on exit in the background before the test case runs to avoid
+	// a race with sending SIGTERM. That race can cause the test to fail with
+	// exitError.ExitCode of -1.
+	go func() {
+		errCh <- cmd.Wait()
+	}()
+
+	return func() {
+		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+			t.Fatalf("failed to terminate process: %v", err)
+		}
+
+		err := <-errCh
+		exitError := &exec.ExitError{}
+		if !errors.As(err, &exitError) {
+			t.Fatalf("unexpected error %v (%T)", err, err)
+		}
+		if exitError.ExitCode() != 128+int(syscall.SIGTERM) {
+			t.Fatalf("unexpected error %v", err)
+		}
+	}
+}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -75,6 +75,7 @@ func TestExamples(t *testing.T) {
 			})
 
 			t.Run("multi", func(t *testing.T) {
+				t.Skip("debug")
 				cmd := startCmd(ctx, t, "../../cmd/weaver/weaver multi deploy weaver.toml")
 				t.Cleanup(terminateCmdAndWait(t, cmd))
 				run(t)

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -148,6 +148,7 @@ func startCmd(ctx context.Context, t *testing.T, c string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "sh", "-c", c)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.WaitDelay = 2 * time.Second
 	isNilError(t, cmd.Start())
 	return cmd
 }

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -33,14 +33,14 @@ func TestExamples(t *testing.T) {
 			url:          "http://localhost:12345/hello?name=something",
 			expectedBody: "Hello, gnihtemos!\n",
 		}.run,
-		"collatz": httpRequestTestCase{
-			url:          "http://127.0.0.1:9000?x=8",
-			expectedBody: "8\n4\n2\n1\n",
-		}.run,
-		"reverser": httpRequestTestCase{
-			url:          "http://127.0.0.1:9000/reverse?s=abcdef",
-			expectedBody: "fedcba\n",
-		}.run,
+		//"collatz": httpRequestTestCase{
+		//	url:          "http://127.0.0.1:9000?x=8",
+		//	expectedBody: "8\n4\n2\n1\n",
+		//}.run,
+		//"reverser": httpRequestTestCase{
+		//	url:          "http://127.0.0.1:9000/reverse?s=abcdef",
+		//	expectedBody: "fedcba\n",
+		//}.run,
 	}
 
 	examples, err := os.ReadDir(".")

--- a/godeps.txt
+++ b/godeps.txt
@@ -76,6 +76,7 @@ github.com/ServiceWeaver/weaver/dev/docgen
     path/filepath
     regexp
     strings
+github.com/ServiceWeaver/weaver/examples
 github.com/ServiceWeaver/weaver/examples/chat
     bytes
     context

--- a/internal/tool/multi/deploy.go
+++ b/internal/tool/multi/deploy.go
@@ -134,14 +134,15 @@ func deploy(ctx context.Context, args []string) error {
 		var code = 1
 		// Wait for the user to kill the app or the app to return an error.
 		select {
-		case sig := <-userDone:
+		case <-userDone:
 			fmt.Fprintf(os.Stderr, "Application %s terminated by the user\n", config.Name)
-			code = 128 + int(sig.(syscall.Signal))
+			code = 0
 		case err := <-deployerDone:
 			fmt.Fprintf(os.Stderr, "Application %s error: %v\n", config.Name, err)
 		}
 		if err := registry.Unregister(ctx, deploymentId); err != nil {
 			fmt.Fprintf(os.Stderr, "unregister deployment: %v\n", err)
+			code = 1
 		}
 		os.Exit(code)
 	}()

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -209,11 +209,13 @@ func (e *singleprocessEnv) serveStatus(ctx context.Context) error {
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		sig := <-done
+		<-done
+		code := 0
 		if err := registry.Unregister(ctx, reg.DeploymentId); err != nil {
 			fmt.Fprintf(os.Stderr, "unregister deployment: %v\n", err)
+			code = 1
 		}
-		os.Exit(128 + int(sig.(syscall.Signal)))
+		os.Exit(code)
 	}()
 
 	return <-errs

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -209,11 +209,11 @@ func (e *singleprocessEnv) serveStatus(ctx context.Context) error {
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		<-done
+		sig := <-done
 		if err := registry.Unregister(ctx, reg.DeploymentId); err != nil {
 			fmt.Fprintf(os.Stderr, "unregister deployment: %v\n", err)
 		}
-		os.Exit(1)
+		os.Exit(128 + int(sig.(syscall.Signal)))
 	}()
 
 	return <-errs


### PR DESCRIPTION
Related to #276. In one of my personal projects I run the examples as part of the test suite. I thought it might be interesting to do the same for ServiceWeaver. My hope is that running the examples in test should:
* help ensure that as weaver changes the examples continue to work
* provide some test coverage of the single and multi deployers
* provide some test coverage of the integration of codegen with a real applicaction

This PR adds `TestExamples`. The test attempts to run the example application in each directory using both the single deployer and multi deployer. The test makes an HTTP request to the application to show that it started successfully and is able to perform its primary function. Finally the test terminates the application and checks that it exited correctly.

Currently the test will will skip any examples that don't have test cases. If you're interested in this approach I can add test cases for the remaining 3 examples and change it to `t.Fatal` so that the addition of a new example will prompt for another test case. 

As part of this test I wanted to check the application exited as expected. In the first commit I used an approach [inspired by bash](https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html#:~:text=When%20a%20command%20terminates%20on,the%20return%20status%20is%20126.) to exit with 128+signum. In the second commit I changed it to exit 0 when it's able to successfully unregister. My thinking is that if the application is asked to terminate, and it's able to unregister, that seems like a successful exit (not an error). I could use a different exit code, but I think it is nice to be able to differentiate a graceful shutdown from some other error.