### PR TITLE
Added inline heading links to website docs.

### DIFF
--- a/website/assets/css/docs.css
+++ b/website/assets/css/docs.css
@@ -151,3 +151,23 @@
 .pre-copy-button:active {
   background: #888;
 }
+
+h1:hover .heading-link,
+h2:hover .heading-link,
+h3:hover .heading-link,
+h4:hover .heading-link,
+h5:hover .heading-link,
+h6:hover .heading-link {
+  visibility: visible;
+}
+
+.heading-link {
+  margin-left: 1ch;
+  text-decoration: none;
+  visibility: hidden;
+  opacity: 50%;
+}
+
+.heading-link:hover {
+  opacity: 100%;
+}

--- a/website/assets/js/toc.js
+++ b/website/assets/js/toc.js
@@ -59,6 +59,13 @@ function init_toc() {
     }
     h.id = id;
 
+    // Append an inline header link.
+    const hlink = document.createElement('a');
+    hlink.classList.add('heading-link');
+    hlink.href = '#' + h.id;
+    hlink.innerHTML = '🔗';  // TODO(mwhittaker): Use an icon?
+    h.appendChild(hlink);
+
     // Generate TOC entry.
     const item = document.createElement('li');
     const link = link_to(h.innerText, '#' + id);


### PR DESCRIPTION
This PR adds inline heading links to the website docs which appear when the cursor hovers over the heading. This is a pretty standard feature on a lot of websites (e.g., [GitHub][1], [go docs][2]). The demo video below doesn't show the address bar, but it is updated when the heading link is clicked.

[Heading Links Demo.webm](https://user-images.githubusercontent.com/3654277/234432044-4822bb6b-5935-40ac-9fb0-05cabe492ea2.webm)

[1]: https://github.com/ServiceWeaver/weaver
[2]: https://pkg.go.dev/github.com/ServiceWeaver/weaver