### PR TITLE
Automatically fetch needed components.

### DIFF
--- a/component.go
+++ b/component.go
@@ -151,6 +151,20 @@ func (i *Implements[T]) setInstance(c *componentImpl) { i.componentImpl = c }
 //nolint:unused
 func (i *Implements[T]) implements(T) {}
 
+// Ref[T] is a field that can be placed inside a component implementation
+// struct. T must be a component type. Service Weaver will automatically
+// fill such a field with a handle to the corresponding component.
+type Ref[T any] struct {
+	value T
+}
+
+// Get returns a handle to the component of type T.
+func (r Ref[T]) Get() T { return r.value }
+
+// isRef is an internal interface that is only implemented by Ref[T] and is
+// used by the implementation to check that a value is of type Ref[T].
+func (r Ref[T]) isRef() {}
+
 // A Listener is Service Weaver's implementation of a net.Listener.
 //
 // A Listener implements the net.Listener interface, so you can use a Listener

--- a/examples/chat/server.go
+++ b/examples/chat/server.go
@@ -40,25 +40,12 @@ var flagAddress = flag.String("http", ":0", "host:port to use for when running l
 type server struct {
 	weaver.Implements[weaver.Main]
 	httpServer http.Server
-	store      SQLStore
-	scaler     ImageScaler
-	cache      LocalCache
+	store      weaver.Ref[SQLStore]
+	scaler     weaver.Ref[ImageScaler]
+	cache      weaver.Ref[LocalCache]
 }
 
 func serve(ctx context.Context, s *server) error {
-	var err error
-	s.store, err = weaver.Get[SQLStore](s)
-	if err != nil {
-		return err
-	}
-	s.scaler, err = weaver.Get[ImageScaler](s)
-	if err != nil {
-		return err
-	}
-	s.cache, err = weaver.Get[LocalCache](s)
-	if err != nil {
-		return err
-	}
 	s.httpServer.Handler = instrument(s.label, s)
 	lis, err := s.Listener("chat", weaver.ListenerOptions{LocalAddress: *flagAddress})
 	if err != nil {
@@ -133,7 +120,7 @@ func (s *server) redirectToFeed(w http.ResponseWriter, r *http.Request, user str
 
 func (s *server) generateFeed(w http.ResponseWriter, r *http.Request, user string) {
 	ctx := r.Context()
-	threads, err := s.store.GetFeed(ctx, user)
+	threads, err := s.store.Get().GetFeed(ctx, user)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -158,7 +145,7 @@ func (s *server) serveThumbnail(w http.ResponseWriter, r *http.Request, user str
 	ctx := r.Context()
 	q := r.URL.Query()
 	key := q.Get("id")
-	if thumb, err := s.cache.Get(ctx, key); err == nil {
+	if thumb, err := s.cache.Get().Get(ctx, key); err == nil {
 		w.Write([]byte(thumb))
 		return
 	}
@@ -167,19 +154,19 @@ func (s *server) serveThumbnail(w http.ResponseWriter, r *http.Request, user str
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	img, err := s.store.GetImage(ctx, user, ImageID(id))
+	img, err := s.store.Get().GetImage(ctx, user, ImageID(id))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
 	const maxSize = 128
-	small, err := s.scaler.Scale(ctx, img, maxSize, maxSize)
+	small, err := s.scaler.Get().Scale(ctx, img, maxSize, maxSize)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	w.Write(small)
-	_ = s.cache.Put(ctx, key, string(small))
+	_ = s.cache.Get().Put(ctx, key, string(small))
 }
 
 func (s *server) newThread(w http.ResponseWriter, r *http.Request, user string) {
@@ -200,7 +187,7 @@ func (s *server) newThread(w http.ResponseWriter, r *http.Request, user string) 
 	}
 	_ = img
 
-	_, err = s.store.CreateThread(r.Context(), user, time.Now(), others, msg, img)
+	_, err = s.store.Get().CreateThread(r.Context(), user, time.Now(), others, msg, img)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -219,7 +206,7 @@ func (s *server) newPost(w http.ResponseWriter, r *http.Request, user string) {
 		http.Error(w, "no message", http.StatusBadRequest)
 		return
 	}
-	err = s.store.CreatePost(r.Context(), user, time.Now(), ThreadID(tid), msg)
+	err = s.store.Get().CreatePost(r.Context(), user, time.Now(), ThreadID(tid), msg)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/fillrefs.go
+++ b/fillrefs.go
@@ -1,0 +1,68 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package weaver
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// fillRefs initializes Ref[T] fields in a component implement struct.
+//   - impl should be a pointer to the implementation struct
+//   - get should be a function that returns the component of interface type
+//     T when passed the reflect.Type for T.
+func fillRefs(impl any, get func(reflect.Type) (any, error)) error {
+	p := reflect.ValueOf(impl)
+	if p.Kind() != reflect.Pointer {
+		return fmt.Errorf("not a pointer")
+	}
+	s := p.Elem()
+	if s.Kind() != reflect.Struct {
+		return fmt.Errorf("not a struct pointer")
+	}
+	isRef := reflect.TypeOf((*interface{ isRef() })(nil)).Elem()
+	for i, n := 0, s.NumField(); i < n; i++ {
+		// Handle field with type weaver.Ref[T].
+		ref := s.Field(i)
+		if !ref.Type().Implements(isRef) {
+			continue
+		}
+		// Sanity check that field type structure matches weaver.Ref[T].
+		if ref.Kind() != reflect.Struct {
+			continue // XXX Panic?
+		}
+		if ref.NumField() != 1 {
+			continue // XXX Panic?
+		}
+		if ref.Type().Field(0).Name != "value" {
+			continue // XXX Panic?
+		}
+		valueField := ref.Field(0)
+		component, err := get(valueField.Type())
+		if err != nil {
+			return fmt.Errorf("setting field %v.%s: %w", s.Type(), s.Type().Field(i).Name, err)
+		}
+		setPossiblyUnexported(valueField, reflect.ValueOf(component))
+	}
+	return nil
+}
+
+// setPossiblyUnexported sets dst to value. It is equivalent to reflect.Value.Set
+// except that it works even if dst was accessed via unexported fields.
+func setPossiblyUnexported(dst, value reflect.Value) {
+	// Use UnsafePointer + NewAt so we can handle unexported fields.
+	dst = reflect.NewAt(dst.Type(), dst.Addr().UnsafePointer()).Elem()
+	dst.Set(value)
+}

--- a/fillrefs_test.go
+++ b/fillrefs_test.go
@@ -1,0 +1,77 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package weaver
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type impl struct {
+	A Ref[int]
+	B Ref[string]
+	C Ref[bool]
+}
+
+func getValue(t reflect.Type) (any, error) {
+	if t == reflect.TypeOf(int(0)) {
+		return 42, nil
+	}
+	if t == reflect.TypeOf("") {
+		return "hello", nil
+	}
+	return nil, fmt.Errorf("unsupported type %v", t)
+}
+
+func TestFillRefs(t *testing.T) {
+	var x struct {
+		a Ref[int]
+		b Ref[string]
+	}
+	if err := fillRefs(&x, getValue); err != nil {
+		t.Fatal(err)
+	}
+	if x.a.value != 42 {
+		t.Errorf("expecting x.a to be 42, got %d", x.a.value)
+	}
+	if x.b.value != "hello" {
+		t.Errorf("expecting x.b to be `hello`, got %s", x.b.value)
+	}
+}
+
+func TestFillRefsErrors(t *testing.T) {
+	type badref struct {
+		Ref[bool]
+	}
+	type testCase struct {
+		name   string
+		impl   any    // impl argument to pass to fillRefs
+		expect string // Returned error must contain this string
+	}
+	for _, c := range []testCase{
+		{"not-pointer", impl{}, "not a pointer"},
+		{"not-struct-pointer", new(int), "not a struct pointer"},
+		{"unsupported-type", &badref{}, "unsupported"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			err := fillRefs(c.impl, getValue)
+			if err == nil || !strings.Contains(err.Error(), c.expect) {
+				t.Fatalf("unexpected error %v; expecting %s", err, c.expect)
+			}
+		})
+	}
+}

--- a/runtime/protos/runtime.pb.go
+++ b/runtime/protos/runtime.pb.go
@@ -2117,12 +2117,17 @@ func (*ActivateComponentReply) Descriptor() ([]byte, []int) {
 // are some examples of how different deployers may handle a
 // GetListenerAddressRequest.
 //
-//   - The singleprocess deployer may instruct the weavelet to listen directly
-//     on localhost:9000.
-//   - The multiprocess deployer may instruct the weavelet to listen on
-//     localhost:0. It will separately start a proxy on localhost:9000.
-//   - The SSH deployer may instruct the weavelet to listen on
-//     $HOSTNAME:0. It will separately start a proxy on localhost:9000.
+// - The singleprocess deployer may instruct the weavelet to listen directly
+//
+//	on localhost:9000.
+//
+// - The multiprocess deployer may instruct the weavelet to listen on
+//
+//	localhost:0. It will separately start a proxy on localhost:9000.
+//
+// - The SSH deployer may instruct the weavelet to listen on
+//
+//	$HOSTNAME:0. It will separately start a proxy on localhost:9000.
 type GetListenerAddressRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/weavertest/internal/deploy/deploy.go
+++ b/weavertest/internal/deploy/deploy.go
@@ -56,26 +56,20 @@ type Widget interface {
 // widget is a Service Weaver component that deploys started Service Weaver components.
 type widget struct {
 	weaver.Implements[Widget]
+	started weaver.Ref[Started]
 }
 
-// Use deploys a started component and calls MarkStarted on every replica.
+// Use calls MarkStarted on every replica.
 func (w *widget) Use(ctx context.Context, dir string) error {
 	// Print to stderr. This tests that weavertest output is captured correctly.
 	fmt.Fprintf(os.Stderr, "widget.Use(%q)\n", dir)
-
-	var started Started
-	var err error
-	started, err = weaver.Get[Started](w)
-	if err != nil {
-		return err
-	}
 
 	// There are n started replicas, and we want to call MarkStarted on all
 	// of them. We don't have a way to call MarkStarted on a specific replica,
 	// so we call MarkStarted a bunch of times. This makes it very likely that
 	// every replica receives at least one call to MarkStarted.
 	for i := 0; i < 1000; i++ {
-		if err := started.MarkStarted(ctx, dir); err != nil {
+		if err := w.started.Get().MarkStarted(ctx, dir); err != nil {
 			return err
 		}
 	}

--- a/weavertest/internal/simple/simple.go
+++ b/weavertest/internal/simple/simple.go
@@ -38,18 +38,11 @@ type Source interface {
 
 type source struct {
 	weaver.Implements[Source]
-	dst Destination
-}
-
-func (s *source) Init(_ context.Context) error {
-	s.Logger().Debug("simple.Init") //nolint:nolintlint,typecheck // golangci-lint false positive on Go tip
-	dst, err := weaver.Get[Destination](s)
-	s.dst = dst
-	return err
+	dst weaver.Ref[Destination]
 }
 
 func (s *source) Emit(ctx context.Context, file, msg string) error {
-	return s.dst.Record(ctx, file, msg)
+	return s.dst.Get().Record(ctx, file, msg)
 }
 
 type Destination interface {


### PR DESCRIPTION
If component X needs component Y, X's implementation can contain a field of type `weaver.Ref[Y]` that will be filled in automatically with `Y` when `X` is created.

A future change will fix all code to use this new mechanism and then remove `weaver.Get[T]`