### PR TITLE
Fixed `weaver multi` and `weaver ssh` main bug.

### DIFF
--- a/internal/tool/multi/deployer.go
+++ b/internal/tool/multi/deployer.go
@@ -266,7 +266,7 @@ func (d *deployer) startColocationGroup(g *group) error {
 			Sections:      d.config.Sections,
 			SingleProcess: false,
 			SingleMachine: true,
-			RunMain:       g.components["main"],
+			RunMain:       g.components["github.com/ServiceWeaver/weaver/Main"],
 		}
 		e, err := envelope.NewEnvelope(d.ctx, info, d.config)
 		if err != nil {
@@ -322,7 +322,9 @@ func checkVersion(appVersion *protos.SemVer) error {
 }
 
 func (d *deployer) startMain() error {
-	return d.activateComponent(&protos.ActivateComponentRequest{Component: "main"})
+	return d.activateComponent(&protos.ActivateComponentRequest{
+		Component: "github.com/ServiceWeaver/weaver/Main",
+	})
 }
 
 // ActivateComponent implements the envelope.EnvelopeHandler interface.

--- a/internal/tool/multi/deployer.go
+++ b/internal/tool/multi/deployer.go
@@ -266,7 +266,7 @@ func (d *deployer) startColocationGroup(g *group) error {
 			Sections:      d.config.Sections,
 			SingleProcess: false,
 			SingleMachine: true,
-			RunMain:       g.components["github.com/ServiceWeaver/weaver/Main"],
+			RunMain:       g.components[runtime.Main],
 		}
 		e, err := envelope.NewEnvelope(d.ctx, info, d.config)
 		if err != nil {
@@ -323,7 +323,7 @@ func checkVersion(appVersion *protos.SemVer) error {
 
 func (d *deployer) startMain() error {
 	return d.activateComponent(&protos.ActivateComponentRequest{
-		Component: "github.com/ServiceWeaver/weaver/Main",
+		Component: runtime.Main,
 	})
 }
 

--- a/internal/tool/ssh/impl/manager.go
+++ b/internal/tool/ssh/impl/manager.go
@@ -250,7 +250,7 @@ func (m *manager) run() error {
 
 	// Start the main process.
 	if err := m.startComponent(m.ctx, &protos.ActivateComponentRequest{
-		Component: "main",
+		Component: "github.com/ServiceWeaver/weaver/Main",
 	}); err != nil {
 		return err
 	}
@@ -552,7 +552,7 @@ func (m *manager) startComponent(ctx context.Context, req *protos.ActivateCompon
 	update()
 
 	// Start the colocation group, if it hasn't already started.
-	return m.startColocationGroup(g, req.Component == "main")
+	return m.startColocationGroup(g, req.Component == "github.com/ServiceWeaver/weaver/Main")
 }
 
 // REQUIRES: g.mu is NOT held.

--- a/internal/tool/ssh/impl/manager.go
+++ b/internal/tool/ssh/impl/manager.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ServiceWeaver/weaver/internal/files"
 	imetrics "github.com/ServiceWeaver/weaver/internal/metrics"
 	"github.com/ServiceWeaver/weaver/internal/routing"
+	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/perfetto"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
@@ -250,7 +251,7 @@ func (m *manager) run() error {
 
 	// Start the main process.
 	if err := m.startComponent(m.ctx, &protos.ActivateComponentRequest{
-		Component: "github.com/ServiceWeaver/weaver/Main",
+		Component: runtime.Main,
 	}); err != nil {
 		return err
 	}
@@ -552,7 +553,7 @@ func (m *manager) startComponent(ctx context.Context, req *protos.ActivateCompon
 	update()
 
 	// Start the colocation group, if it hasn't already started.
-	return m.startColocationGroup(g, req.Component == "github.com/ServiceWeaver/weaver/Main")
+	return m.startColocationGroup(g, req.Component == runtime.Main)
 }
 
 // REQUIRES: g.mu is NOT held.

--- a/runtime/weavelet.go
+++ b/runtime/weavelet.go
@@ -20,6 +20,9 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 )
 
+// Main is the name of the main component.
+const Main = "github.com/ServiceWeaver/weaver/Main"
+
 // CheckEnvelopeInfo checks that EnvelopeInfo is well-formed.
 func CheckEnvelopeInfo(w *protos.EnvelopeInfo) error {
 	if w == nil {


### PR DESCRIPTION
Before, `weaver multi` and `weaver ssh` assumed the name of the main component was "main". Recently, we switched it to
"github.com/ServiceWeaver/weaver/main". Both the meaver multi and weaver ssh deployers would instruct a weavelet to start "main", but no such component was registered, and the app would immediately crash.