### PR TITLE
Silent expected warning messages in generator_test.go.

### DIFF
--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -73,7 +73,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, generate.Usage)
 		}
 		generateFlags.Parse(flag.Args()[1:]) //nolint:errcheck // does os.Exit on error
-		if err := generate.Generate(".", flag.Args()[1:]); err != nil {
+		if err := generate.Generate(".", flag.Args()[1:], generate.Options{}); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}

--- a/internal/tool/generate/generator_test.go
+++ b/internal/tool/generate/generator_test.go
@@ -99,7 +99,10 @@ func runGenerator(t *testing.T, directory, filename, contents string, subdirs []
 	}
 
 	// Run "weaver generate".
-	if err := Generate(tmp, []string{tmp}); err != nil {
+	opt := Options{
+		Warn: func(err error) { t.Log(err) },
+	}
+	if err := Generate(tmp, []string{tmp}, opt); err != nil {
 		return "", err
 	}
 	output, err := os.ReadFile(filepath.Join(tmp, generatedCodeFile))


### PR DESCRIPTION
Add an Options argument to generate.Generate that contains a function used to report warnings. In generator_test.go fill this with a function that reports the warning via testing.T.Log.