### PR TITLE
Changed deployers to persist data in one spot.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -9,12 +9,12 @@ github.com/ServiceWeaver/weaver
     github.com/DataDog/hyperloglog
     github.com/ServiceWeaver/weaver/internal/cond
     github.com/ServiceWeaver/weaver/internal/envelope/conn
-    github.com/ServiceWeaver/weaver/internal/files
     github.com/ServiceWeaver/weaver/internal/metrics
     github.com/ServiceWeaver/weaver/internal/net/call
     github.com/ServiceWeaver/weaver/internal/private
     github.com/ServiceWeaver/weaver/internal/register
     github.com/ServiceWeaver/weaver/internal/status
+    github.com/ServiceWeaver/weaver/internal/tool/single
     github.com/ServiceWeaver/weaver/internal/traceio
     github.com/ServiceWeaver/weaver/metrics
     github.com/ServiceWeaver/weaver/runtime
@@ -553,7 +553,6 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     errors
     flag
     fmt
-    github.com/ServiceWeaver/weaver/internal/files
     github.com/ServiceWeaver/weaver/internal/metrics
     github.com/ServiceWeaver/weaver/internal/must
     github.com/ServiceWeaver/weaver/internal/proxy
@@ -590,10 +589,9 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
 github.com/ServiceWeaver/weaver/internal/tool/single
     context
     fmt
-    github.com/ServiceWeaver/weaver/internal/files
     github.com/ServiceWeaver/weaver/internal/must
     github.com/ServiceWeaver/weaver/internal/status
-    github.com/ServiceWeaver/weaver/runtime/perfetto
+    github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/tool
     path/filepath
 github.com/ServiceWeaver/weaver/internal/tool/ssh
@@ -622,8 +620,8 @@ github.com/ServiceWeaver/weaver/internal/tool/ssh/impl
     context
     errors
     fmt
-    github.com/ServiceWeaver/weaver/internal/files
     github.com/ServiceWeaver/weaver/internal/metrics
+    github.com/ServiceWeaver/weaver/internal/must
     github.com/ServiceWeaver/weaver/internal/proto
     github.com/ServiceWeaver/weaver/internal/proxy
     github.com/ServiceWeaver/weaver/internal/routing
@@ -778,7 +776,6 @@ github.com/ServiceWeaver/weaver/runtime/perfetto
     encoding/json
     errors
     fmt
-    github.com/ServiceWeaver/weaver/internal/files
     github.com/ServiceWeaver/weaver/internal/traceio
     github.com/ServiceWeaver/weaver/runtime/retry
     github.com/hashicorp/golang-lru/v2

--- a/internal/files/file.go
+++ b/internal/files/file.go
@@ -100,24 +100,3 @@ func (w *Writer) Cleanup() {
 	w.tmp = nil
 	os.Remove(w.tmpName)
 }
-
-// DefaultDataDir returns the default directory for Service Weaver files:
-// $XDG_DATA_HOME/serviceweaver, or ~/.local/share/serviceweaver if
-// XDG_DATA_HOME is not set.
-func DefaultDataDir() (string, error) {
-	dataDir := os.Getenv("XDG_DATA_HOME")
-	if dataDir == "" {
-		// Default to ~/.local/share
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		dataDir = filepath.Join(home, ".local", "share")
-	}
-	regDir := filepath.Join(dataDir, "serviceweaver")
-	if err := os.MkdirAll(regDir, 0700); err != nil {
-		return "", err
-	}
-
-	return regDir, nil
-}

--- a/internal/status/dashboard.go
+++ b/internal/status/dashboard.go
@@ -88,10 +88,10 @@ type Command struct {
 
 // DashboardSpec configures the command returned by DashboardCommand.
 type DashboardSpec struct {
-	Tool     string                                   // tool name (e.g., "weaver single")
-	Mode     string                                   // tool mode (e.g. "single", "multi", "ssh")
-	Registry func(context.Context) (*Registry, error) // registry of deployments
-	Commands func(deploymentId string) []Command      // commands for a deployment
+	Tool         string                                   // tool name (e.g., "weaver single")
+	PerfettoFile string                                   // perfetto database file
+	Registry     func(context.Context) (*Registry, error) // registry of deployments
+	Commands     func(deploymentId string) []Command      // commands for a deployment
 }
 
 // DashboardCommand returns a "dashboard" subcommand that serves a dashboard
@@ -133,7 +133,7 @@ Flags:
 			}
 			url := "http://" + lis.Addr().String()
 
-			traceDB, err := perfetto.Open(ctx, spec.Mode)
+			traceDB, err := perfetto.Open(ctx, spec.PerfettoFile)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "cannot open Perfetto database: %v\n", err)
 			} else {

--- a/internal/tool/multi/deploy.go
+++ b/internal/tool/multi/deploy.go
@@ -24,10 +24,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 
-	"github.com/ServiceWeaver/weaver/internal/files"
 	"github.com/ServiceWeaver/weaver/internal/status"
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
@@ -145,7 +143,7 @@ func deploy(ctx context.Context, args []string) error {
 	}()
 
 	// Follow the logs.
-	source := logging.FileSource(logdir)
+	source := logging.FileSource(logDir)
 	query := fmt.Sprintf(`full_version == %q && !("serviceweaver/system" in attrs)`, deploymentId)
 	r, err := source.Query(ctx, query, true)
 	if err != nil {
@@ -163,21 +161,7 @@ func deploy(ctx context.Context, args []string) error {
 	}
 }
 
-// defaultRegistryDir() returns $XDG_DATA_HOME/serviceweaver/multi_registry, or
-// ~/.local/share/serviceweaver/multi_registry if XDG_DATA_HOME is not set.
-func defaultRegistryDir() (string, error) {
-	dir, err := files.DefaultDataDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "multi_registry"), nil
-}
-
 // defaultRegistry returns a registry in defaultRegistryDir().
 func defaultRegistry(ctx context.Context) (*status.Registry, error) {
-	dir, err := defaultRegistryDir()
-	if err != nil {
-		return nil, err
-	}
-	return status.NewRegistry(ctx, dir)
+	return status.NewRegistry(ctx, registryDir)
 }

--- a/internal/tool/multi/deployer.go
+++ b/internal/tool/multi/deployer.go
@@ -123,7 +123,7 @@ var _ envelope.EnvelopeHandler = &handler{}
 // time by canceling the passed-in context.
 func newDeployer(ctx context.Context, deploymentId string, config *protos.AppConfig) (*deployer, error) {
 	// Create the log saver.
-	logsDB, err := logging.NewFileStore(logdir)
+	logsDB, err := logging.NewFileStore(logDir)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create log storage: %w", err)
 	}
@@ -142,7 +142,7 @@ func newDeployer(ctx context.Context, deploymentId string, config *protos.AppCon
 	}
 
 	// Create the trace saver.
-	traceDB, err := perfetto.Open(ctx, "multi")
+	traceDB, err := perfetto.Open(ctx, perfettoFile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open Perfetto database: %w", err)
 	}

--- a/internal/tool/single/single.go
+++ b/internal/tool/single/single.go
@@ -19,18 +19,22 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/ServiceWeaver/weaver/internal/files"
 	"github.com/ServiceWeaver/weaver/internal/must"
 	"github.com/ServiceWeaver/weaver/internal/status"
-	"github.com/ServiceWeaver/weaver/runtime/perfetto"
+	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
 var (
+	// The directories and files where the single process deployer stores data.
+	dataDir      = filepath.Join(must.Must(runtime.DataDir()), "single")
+	RegistryDir  = filepath.Join(dataDir, "registry")
+	PerfettoFile = filepath.Join(dataDir, "perfetto.db")
+
 	dashboardSpec = &status.DashboardSpec{
-		Tool:     "weaver single",
-		Mode:     "single",
-		Registry: defaultRegistry,
+		Tool:         "weaver single",
+		PerfettoFile: PerfettoFile,
+		Registry:     defaultRegistry,
 		Commands: func(deploymentId string) []status.Command {
 			return []status.Command{
 				{Label: "status", Command: "weaver single status"},
@@ -39,12 +43,9 @@ var (
 		},
 	}
 	purgeSpec = &tool.PurgeSpec{
-		Tool: "weaver single",
-		Kill: "weaver single (dashboard|profile)",
-		Paths: []string{
-			filepath.Join(must.Must(files.DefaultDataDir()), "single_registry"),
-			must.Must(perfetto.DatabaseFilePath("single")),
-		},
+		Tool:  "weaver single",
+		Kill:  "weaver single (dashboard|profile)",
+		Paths: []string{dataDir},
 	}
 
 	Commands = map[string]*tool.Command{
@@ -58,9 +59,5 @@ var (
 )
 
 func defaultRegistry(ctx context.Context) (*status.Registry, error) {
-	dir, err := files.DefaultDataDir()
-	if err != nil {
-		return nil, err
-	}
-	return status.NewRegistry(ctx, filepath.Join(dir, "single_registry"))
+	return status.NewRegistry(ctx, RegistryDir)
 }

--- a/internal/tool/ssh/dashboard.go
+++ b/internal/tool/ssh/dashboard.go
@@ -23,9 +23,9 @@ import (
 )
 
 var dashboardSpec = &status.DashboardSpec{
-	Tool:     "weaver ssh",
-	Mode:     "ssh",
-	Registry: impl.DefaultRegistry,
+	Tool:         "weaver ssh",
+	PerfettoFile: impl.PerfettoFile,
+	Registry:     impl.DefaultRegistry,
 	Commands: func(deploymentId string) []status.Command {
 		return []status.Command{
 			{Label: "cat logs", Command: fmt.Sprintf("weaver ssh logs 'version==%q'", logging.Shorten(deploymentId))},

--- a/internal/tool/ssh/deploy.go
+++ b/internal/tool/ssh/deploy.go
@@ -92,7 +92,7 @@ func deploy(ctx context.Context, args []string) error {
 	}
 
 	// Run the manager.
-	stopFn, err := impl.RunManager(ctx, dep, locs, logDir)
+	stopFn, err := impl.RunManager(ctx, dep, locs)
 	if err != nil {
 		return fmt.Errorf("cannot instantiate the manager: %w", err)
 	}
@@ -113,7 +113,7 @@ func deploy(ctx context.Context, args []string) error {
 	}()
 
 	// Follow the logs.
-	source := logging.FileSource(logDir)
+	source := logging.FileSource(impl.LogDir)
 	query := fmt.Sprintf(`full_version == %q && !("serviceweaver/system" in attrs)`, dep.Id)
 	r, err := source.Query(ctx, query, true)
 	if err != nil {

--- a/internal/tool/ssh/logs.go
+++ b/internal/tool/ssh/logs.go
@@ -17,6 +17,7 @@ package ssh
 import (
 	"context"
 
+	"github.com/ServiceWeaver/weaver/internal/tool/ssh/impl"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
@@ -24,6 +25,6 @@ import (
 var logsSpec = tool.LogsSpec{
 	Tool: "weaver ssh",
 	Source: func(context.Context) (logging.Source, error) {
-		return logging.FileSource(logDir), nil
+		return logging.FileSource(impl.LogDir), nil
 	},
 }

--- a/internal/tool/ssh/ssh.go
+++ b/internal/tool/ssh/ssh.go
@@ -15,17 +15,11 @@
 package ssh
 
 import (
-	"path/filepath"
-
 	"github.com/ServiceWeaver/weaver/internal/status"
-	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
 var (
-	// logDir is where weaver ssh deployed applications store their logs.
-	logDir = filepath.Join(logging.DefaultLogDir, "weaver_ssh")
-
 	Commands = map[string]*tool.Command{
 		"deploy":    &deployCmd,
 		"logs":      tool.LogsCmd(&logsSpec),

--- a/runtime/dir.go
+++ b/runtime/dir.go
@@ -1,0 +1,45 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// DataDir returns the default directory for Service Weaver deployer data. The
+// returned directory is $XDG_DATA_HOME/serviceweaver, or
+// ~/.local/share/serviceweaver if XDG_DATA_HOME is not set.
+//
+// We recommend that deployers store their data in a directory within this
+// default directory. For example, the "weaver multi" deployer stores its data
+// in "DataDir()/multi".
+func DataDir() (string, error) {
+	dataDir := os.Getenv("XDG_DATA_HOME")
+	if dataDir == "" {
+		// Default to ~/.local/share
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dataDir = filepath.Join(home, ".local", "share")
+	}
+	regDir := filepath.Join(dataDir, "serviceweaver")
+	if err := os.MkdirAll(regDir, 0700); err != nil {
+		return "", err
+	}
+
+	return regDir, nil
+}

--- a/runtime/logging/files.go
+++ b/runtime/logging/files.go
@@ -38,9 +38,6 @@ import (
 
 // This file contains code to read and write log entries to and from files.
 
-// DefaultLogDir is the default directory where Service Weaver log files are stored.
-var DefaultLogDir = filepath.Join(os.TempDir(), "serviceweaver", "logs")
-
 // FileStore stores log entries in files.
 type FileStore struct {
 	dir string

--- a/runtime/perfetto/db_test.go
+++ b/runtime/perfetto/db_test.go
@@ -63,7 +63,7 @@ func TestStoreFetch(t *testing.T) {
 	// those application versions and validate they are as expected.
 	ctx := context.Background()
 	fname := filepath.Join(t.TempDir(), "tracedb.db_test.db")
-	db, err := open(ctx, fname)
+	db, err := Open(ctx, fname)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +129,7 @@ func TestReplicaNum(t *testing.T) {
 	// get assigned sequential replica numbers, starting with zero.
 	ctx := context.Background()
 	fname := filepath.Join(t.TempDir(), "tracedb.db_test.db")
-	db, err := open(ctx, fname)
+	db, err := Open(ctx, fname)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -29,9 +29,9 @@ import (
 	"time"
 
 	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
-	"github.com/ServiceWeaver/weaver/internal/files"
 	imetrics "github.com/ServiceWeaver/weaver/internal/metrics"
 	"github.com/ServiceWeaver/weaver/internal/status"
+	"github.com/ServiceWeaver/weaver/internal/tool/single"
 	"github.com/ServiceWeaver/weaver/internal/traceio"
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
@@ -109,7 +109,7 @@ func newSingleprocessEnv(bootstrap runtime.Bootstrap) (*singleprocessEnv, error)
 		return nil, err
 	}
 
-	traceDB, err := perfetto.Open(ctx, "single")
+	traceDB, err := perfetto.Open(ctx, single.PerfettoFile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open Perfetto database: %w", err)
 	}
@@ -194,12 +194,7 @@ func (e *singleprocessEnv) serveStatus(ctx context.Context) error {
 	}
 
 	// Register the deployment.
-	dir, err := files.DefaultDataDir()
-	if err != nil {
-		return err
-	}
-	dir = filepath.Join(dir, "single_registry")
-	registry, err := status.NewRegistry(ctx, dir)
+	registry, err := status.NewRegistry(ctx, single.RegistryDir)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
Recall that deployers often have to persist various data to the file system. The "weaver multi" deployer, for example, persists logs, registrations, and traces to files.

Before this PR, deployers would store logs in `/tmp` and everything else in `~/.local/share/serviceweaver`. Different deployers would sometimes store their data in the same directory. A `multi_perfetto.db` file would be right next to a `single_perfetto.db` file, for example.

This made purging data files annoying. It was like a scavenger hunt trying to track down the various places that data was stored. This PR changes deployers to store all their data in a single directly. For example, the "weaver multi" deployer now stores everything inside `~/.local/share/serviceweaver/multi`. The single process deployer stores everything inside `~/.local/share/serviceweaver/single`.

This makes purging much simpler. It also makes it clearer which files are being used by which deployers.

Note that this PR moves logs out of `/tmp`, which persists them longer. This means that logs won't be garbage collected automatically, but I think that's actually a good thing. We should implement a principled way of garbage collecting logs, rather than leaving it up to `/tmp`. I think it would be surprising and frustrating if an important log file was spuriously deleted by the OS.