### PR TITLE
Change component registration to hold implementation type.

### DIFF
--- a/examples/chat/weaver_gen.go
+++ b/examples/chat/weaver_gen.go
@@ -19,7 +19,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/examples/chat/ImageScaler",
 		Iface: reflect.TypeOf((*ImageScaler)(nil)).Elem(),
-		New:   func() any { return &scaler{} },
+		Impl:  reflect.TypeOf(scaler{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return imageScaler_local_stub{impl: impl.(ImageScaler), tracer: tracer}
 		},
@@ -33,7 +33,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/examples/chat/LocalCache",
 		Iface: reflect.TypeOf((*LocalCache)(nil)).Elem(),
-		New:   func() any { return &localCache{} },
+		Impl:  reflect.TypeOf(localCache{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return localCache_local_stub{impl: impl.(LocalCache), tracer: tracer}
 		},
@@ -47,7 +47,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/Main",
 		Iface: reflect.TypeOf((*weaver.Main)(nil)).Elem(),
-		New:   func() any { return &server{} },
+		Impl:  reflect.TypeOf(server{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return main_local_stub{impl: impl.(weaver.Main), tracer: tracer}
 		},
@@ -59,7 +59,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:     "github.com/ServiceWeaver/weaver/examples/chat/SQLStore",
 		Iface:    reflect.TypeOf((*SQLStore)(nil)).Elem(),
-		New:      func() any { return &sqlStore{} },
+		Impl:     reflect.TypeOf(sqlStore{}),
 		ConfigFn: func(i any) any { return i.(*sqlStore).WithConfig.Config() },
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return sQLStore_local_stub{impl: impl.(SQLStore), tracer: tracer}

--- a/examples/collatz/weaver_gen.go
+++ b/examples/collatz/weaver_gen.go
@@ -18,7 +18,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/examples/collatz/Even",
 		Iface:       reflect.TypeOf((*Even)(nil)).Elem(),
-		New:         func() any { return &even{} },
+		Impl:        reflect.TypeOf(even{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return even_local_stub{impl: impl.(Even), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return even_client_stub{stub: stub, doMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/collatz/Even", Method: "Do"})}
@@ -30,7 +30,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/Main",
 		Iface: reflect.TypeOf((*weaver.Main)(nil)).Elem(),
-		New:   func() any { return &server{} },
+		Impl:  reflect.TypeOf(server{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return main_local_stub{impl: impl.(weaver.Main), tracer: tracer}
 		},
@@ -42,7 +42,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/examples/collatz/Odd",
 		Iface:       reflect.TypeOf((*Odd)(nil)).Elem(),
-		New:         func() any { return &odd{} },
+		Impl:        reflect.TypeOf(odd{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return odd_local_stub{impl: impl.(Odd), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return odd_client_stub{stub: stub, doMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/collatz/Odd", Method: "Do"})}

--- a/examples/factors/weaver_gen.go
+++ b/examples/factors/weaver_gen.go
@@ -18,7 +18,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:   "github.com/ServiceWeaver/weaver/examples/factors/Factorer",
 		Iface:  reflect.TypeOf((*Factorer)(nil)).Elem(),
-		New:    func() any { return &factorer{} },
+		Impl:   reflect.TypeOf(factorer{}),
 		Routed: true,
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return factorer_local_stub{impl: impl.(Factorer), tracer: tracer}
@@ -33,7 +33,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/Main",
 		Iface: reflect.TypeOf((*weaver.Main)(nil)).Elem(),
-		New:   func() any { return &server{} },
+		Impl:  reflect.TypeOf(server{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return main_local_stub{impl: impl.(weaver.Main), tracer: tracer}
 		},

--- a/examples/hello/weaver_gen.go
+++ b/examples/hello/weaver_gen.go
@@ -18,7 +18,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/Main",
 		Iface: reflect.TypeOf((*weaver.Main)(nil)).Elem(),
-		New:   func() any { return &app{} },
+		Impl:  reflect.TypeOf(app{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return main_local_stub{impl: impl.(weaver.Main), tracer: tracer}
 		},
@@ -30,7 +30,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/examples/hello/Reverser",
 		Iface: reflect.TypeOf((*Reverser)(nil)).Elem(),
-		New:   func() any { return &reverser{} },
+		Impl:  reflect.TypeOf(reverser{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return reverser_local_stub{impl: impl.(Reverser), tracer: tracer}
 		},

--- a/examples/onlineboutique/adservice/weaver_gen.go
+++ b/examples/onlineboutique/adservice/weaver_gen.go
@@ -19,7 +19,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice/T",
 		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		New:         func() any { return &impl{} },
+		Impl:        reflect.TypeOf(impl{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return t_client_stub{stub: stub, getAdsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice/T", Method: "GetAds"})}

--- a/examples/onlineboutique/cartservice/weaver_gen.go
+++ b/examples/onlineboutique/cartservice/weaver_gen.go
@@ -19,7 +19,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T",
 		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		New:         func() any { return &impl{} },
+		Impl:        reflect.TypeOf(impl{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return t_client_stub{stub: stub, addItemMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "AddItem"}), emptyCartMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "EmptyCart"}), getCartMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "GetCart"})}
@@ -31,7 +31,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:   "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/cartCache",
 		Iface:  reflect.TypeOf((*cartCache)(nil)).Elem(),
-		New:    func() any { return &cartCacheImpl{} },
+		Impl:   reflect.TypeOf(cartCacheImpl{}),
 		Routed: true,
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return cartCache_local_stub{impl: impl.(cartCache), tracer: tracer}

--- a/examples/onlineboutique/checkoutservice/weaver_gen.go
+++ b/examples/onlineboutique/checkoutservice/weaver_gen.go
@@ -20,7 +20,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice/T",
 		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		New:         func() any { return &impl{} },
+		Impl:        reflect.TypeOf(impl{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return t_client_stub{stub: stub, placeOrderMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice/T", Method: "PlaceOrder"})}

--- a/examples/onlineboutique/currencyservice/weaver_gen.go
+++ b/examples/onlineboutique/currencyservice/weaver_gen.go
@@ -19,7 +19,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T",
 		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		New:         func() any { return &impl{} },
+		Impl:        reflect.TypeOf(impl{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return t_client_stub{stub: stub, convertMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T", Method: "Convert"}), getSupportedCurrenciesMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T", Method: "GetSupportedCurrencies"})}

--- a/examples/onlineboutique/emailservice/weaver_gen.go
+++ b/examples/onlineboutique/emailservice/weaver_gen.go
@@ -19,7 +19,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/emailservice/T",
 		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		New:         func() any { return &impl{} },
+		Impl:        reflect.TypeOf(impl{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return t_client_stub{stub: stub, sendOrderConfirmationMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/emailservice/T", Method: "SendOrderConfirmation"})}

--- a/examples/onlineboutique/frontend/weaver_gen.go
+++ b/examples/onlineboutique/frontend/weaver_gen.go
@@ -15,7 +15,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/Main",
 		Iface: reflect.TypeOf((*weaver.Main)(nil)).Elem(),
-		New:   func() any { return &Server{} },
+		Impl:  reflect.TypeOf(Server{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return main_local_stub{impl: impl.(weaver.Main), tracer: tracer}
 		},

--- a/examples/onlineboutique/paymentservice/weaver_gen.go
+++ b/examples/onlineboutique/paymentservice/weaver_gen.go
@@ -20,7 +20,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/paymentservice/T",
 		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		New:         func() any { return &impl{} },
+		Impl:        reflect.TypeOf(impl{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return t_client_stub{stub: stub, chargeMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/paymentservice/T", Method: "Charge"})}

--- a/examples/onlineboutique/productcatalogservice/weaver_gen.go
+++ b/examples/onlineboutique/productcatalogservice/weaver_gen.go
@@ -19,7 +19,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T",
 		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		New:         func() any { return &impl{} },
+		Impl:        reflect.TypeOf(impl{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return t_client_stub{stub: stub, getProductMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "GetProduct"}), listProductsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "ListProducts"}), searchProductsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "SearchProducts"})}

--- a/examples/onlineboutique/recommendationservice/weaver_gen.go
+++ b/examples/onlineboutique/recommendationservice/weaver_gen.go
@@ -18,7 +18,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/recommendationservice/T",
 		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		New:         func() any { return &impl{} },
+		Impl:        reflect.TypeOf(impl{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return t_client_stub{stub: stub, listRecommendationsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/recommendationservice/T", Method: "ListRecommendations"})}

--- a/examples/onlineboutique/shippingservice/weaver_gen.go
+++ b/examples/onlineboutique/shippingservice/weaver_gen.go
@@ -21,7 +21,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T",
 		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		New:         func() any { return &impl{} },
+		Impl:        reflect.TypeOf(impl{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return t_client_stub{stub: stub, getQuoteMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T", Method: "GetQuote"}), shipOrderMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T", Method: "ShipOrder"})}

--- a/examples/reverser/weaver_gen.go
+++ b/examples/reverser/weaver_gen.go
@@ -18,7 +18,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/Main",
 		Iface: reflect.TypeOf((*weaver.Main)(nil)).Elem(),
-		New:   func() any { return &server{} },
+		Impl:  reflect.TypeOf(server{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return main_local_stub{impl: impl.(weaver.Main), tracer: tracer}
 		},
@@ -30,7 +30,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/examples/reverser/Reverser",
 		Iface: reflect.TypeOf((*Reverser)(nil)).Elem(),
-		New:   func() any { return &reverser{} },
+		Impl:  reflect.TypeOf(reverser{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return reverser_local_stub{impl: impl.(Reverser), tracer: tracer}
 		},

--- a/internal/benchmarks/weaver_gen.go
+++ b/internal/benchmarks/weaver_gen.go
@@ -19,7 +19,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping1",
 		Iface:       reflect.TypeOf((*Ping1)(nil)).Elem(),
-		New:         func() any { return &ping1{} },
+		Impl:        reflect.TypeOf(ping1{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping1_local_stub{impl: impl.(Ping1), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return ping1_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping1", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping1", Method: "PingS"})}
@@ -31,7 +31,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping10",
 		Iface:       reflect.TypeOf((*Ping10)(nil)).Elem(),
-		New:         func() any { return &ping10{} },
+		Impl:        reflect.TypeOf(ping10{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping10_local_stub{impl: impl.(Ping10), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return ping10_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping10", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping10", Method: "PingS"})}
@@ -43,7 +43,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2",
 		Iface:       reflect.TypeOf((*Ping2)(nil)).Elem(),
-		New:         func() any { return &ping2{} },
+		Impl:        reflect.TypeOf(ping2{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping2_local_stub{impl: impl.(Ping2), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return ping2_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2", Method: "PingS"})}
@@ -55,7 +55,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3",
 		Iface:       reflect.TypeOf((*Ping3)(nil)).Elem(),
-		New:         func() any { return &ping3{} },
+		Impl:        reflect.TypeOf(ping3{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping3_local_stub{impl: impl.(Ping3), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return ping3_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3", Method: "PingS"})}
@@ -67,7 +67,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4",
 		Iface:       reflect.TypeOf((*Ping4)(nil)).Elem(),
-		New:         func() any { return &ping4{} },
+		Impl:        reflect.TypeOf(ping4{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping4_local_stub{impl: impl.(Ping4), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return ping4_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4", Method: "PingS"})}
@@ -79,7 +79,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5",
 		Iface:       reflect.TypeOf((*Ping5)(nil)).Elem(),
-		New:         func() any { return &ping5{} },
+		Impl:        reflect.TypeOf(ping5{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping5_local_stub{impl: impl.(Ping5), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return ping5_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5", Method: "PingS"})}
@@ -91,7 +91,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6",
 		Iface:       reflect.TypeOf((*Ping6)(nil)).Elem(),
-		New:         func() any { return &ping6{} },
+		Impl:        reflect.TypeOf(ping6{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping6_local_stub{impl: impl.(Ping6), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return ping6_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6", Method: "PingS"})}
@@ -103,7 +103,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7",
 		Iface:       reflect.TypeOf((*Ping7)(nil)).Elem(),
-		New:         func() any { return &ping7{} },
+		Impl:        reflect.TypeOf(ping7{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping7_local_stub{impl: impl.(Ping7), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return ping7_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7", Method: "PingS"})}
@@ -115,7 +115,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8",
 		Iface:       reflect.TypeOf((*Ping8)(nil)).Elem(),
-		New:         func() any { return &ping8{} },
+		Impl:        reflect.TypeOf(ping8{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping8_local_stub{impl: impl.(Ping8), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return ping8_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8", Method: "PingS"})}
@@ -127,7 +127,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping9",
 		Iface:       reflect.TypeOf((*Ping9)(nil)).Elem(),
-		New:         func() any { return &ping9{} },
+		Impl:        reflect.TypeOf(ping9{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping9_local_stub{impl: impl.(Ping9), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return ping9_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping9", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping9", Method: "PingS"})}

--- a/internal/tool/generate/generator.go
+++ b/internal/tool/generate/generator.go
@@ -906,7 +906,7 @@ func (g *generator) generateRegisteredComponents(p printFn) {
 		// of its pointer and then resolve the underlying type. See:
 		//   https://pkg.go.dev/reflect#example-TypeOf
 		p(`		Iface: %s((*%s)(nil)).Elem(),`, reflect.qualify("TypeOf"), g.componentRef(comp))
-		p(`		New: func() any { return &%s{} },`, comp.implName())
+		p(`		Impl: %s(%s{}),`, reflect.qualify("TypeOf"), comp.implName())
 		if comp.hasConfig {
 			p(`		ConfigFn: func(i any) any { return i.(*%s).WithConfig.Config() },`, comp.implName())
 		}

--- a/internal/tool/generate/testdata/multiargs.go
+++ b/internal/tool/generate/testdata/multiargs.go
@@ -23,7 +23,7 @@
 // func (x *Bar) WeaverMarshal(enc *codegen.Encoder)
 // func (x *Bar) WeaverUnmarshal(dec *codegen.Decoder)
 // EncodeBinaryMarshaler
-// &impl{}
+// impl{}
 
 // UNEXPECTED
 // c.Args.Encode(a3)

--- a/internal/tool/generate/testdata/simple.go
+++ b/internal/tool/generate/testdata/simple.go
@@ -16,7 +16,7 @@
 // package foo
 // func init() {
 // codegen.Register(codegen.Registration{
-// &impl{}
+// impl{}
 // return foo_local_stub{impl: impl.(foo),
 // return foo_client_stub{stub: stub,
 // type foo_local_stub struct

--- a/runtime/codegen/registry_test.go
+++ b/runtime/codegen/registry_test.go
@@ -117,10 +117,11 @@ type bimpl struct {
 }
 
 func register[Intf, Impl any](name string, configFn func(any) any) {
+	var zero Impl
 	codegen.Register(codegen.Registration{
 		Name:         name,
 		Iface:        reflect.TypeOf((*Intf)(nil)).Elem(),
-		New:          func() any { var zero Impl; return &zero },
+		Impl:         reflect.TypeOf(zero),
 		ConfigFn:     configFn,
 		LocalStubFn:  func(any, trace.Tracer) any { return nil },
 		ClientStubFn: func(codegen.Stub, string) any { return nil },

--- a/weavelet.go
+++ b/weavelet.go
@@ -551,7 +551,7 @@ func (w *weavelet) getImpl(c *component) (*componentImpl, error) {
 
 func (w *weavelet) createComponent(ctx context.Context, c *component) error {
 	// Create the implementation object.
-	obj := c.info.New()
+	obj := reflect.New(c.info.Impl).Interface()
 
 	// Fill config if necessary.
 	if c.info.ConfigFn != nil {

--- a/weavertest/internal/deploy/weaver_gen.go
+++ b/weavertest/internal/deploy/weaver_gen.go
@@ -18,7 +18,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/weavertest/internal/deploy/Started",
 		Iface: reflect.TypeOf((*Started)(nil)).Elem(),
-		New:   func() any { return &started{} },
+		Impl:  reflect.TypeOf(started{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return started_local_stub{impl: impl.(Started), tracer: tracer}
 		},
@@ -32,7 +32,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/weavertest/internal/deploy/Widget",
 		Iface:       reflect.TypeOf((*Widget)(nil)).Elem(),
-		New:         func() any { return &widget{} },
+		Impl:        reflect.TypeOf(widget{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return widget_local_stub{impl: impl.(Widget), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return widget_client_stub{stub: stub, useMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/deploy/Widget", Method: "Use"})}

--- a/weavertest/internal/diverge/weaver_gen.go
+++ b/weavertest/internal/diverge/weaver_gen.go
@@ -19,7 +19,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/weavertest/internal/diverge/Errer",
 		Iface:       reflect.TypeOf((*Errer)(nil)).Elem(),
-		New:         func() any { return &errer{} },
+		Impl:        reflect.TypeOf(errer{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return errer_local_stub{impl: impl.(Errer), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return errer_client_stub{stub: stub, errMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/diverge/Errer", Method: "Err"})}
@@ -31,7 +31,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/weavertest/internal/diverge/Failer",
 		Iface:       reflect.TypeOf((*Failer)(nil)).Elem(),
-		New:         func() any { return &failer{} },
+		Impl:        reflect.TypeOf(failer{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return failer_local_stub{impl: impl.(Failer), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return failer_client_stub{stub: stub, imJustHereSoWeaverGenerateDoesntComplainMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/diverge/Failer", Method: "ImJustHereSoWeaverGenerateDoesntComplain"})}
@@ -43,7 +43,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/weavertest/internal/diverge/Pointer",
 		Iface: reflect.TypeOf((*Pointer)(nil)).Elem(),
-		New:   func() any { return &pointer{} },
+		Impl:  reflect.TypeOf(pointer{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return pointer_local_stub{impl: impl.(Pointer), tracer: tracer}
 		},

--- a/weavertest/internal/generate/weaver_gen.go
+++ b/weavertest/internal/generate/weaver_gen.go
@@ -18,7 +18,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/weavertest/internal/generate/testApp",
 		Iface: reflect.TypeOf((*testApp)(nil)).Elem(),
-		New:   func() any { return &impl{} },
+		Impl:  reflect.TypeOf(impl{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return testApp_local_stub{impl: impl.(testApp), tracer: tracer}
 		},

--- a/weavertest/internal/protos/weaver_gen.go
+++ b/weavertest/internal/protos/weaver_gen.go
@@ -18,7 +18,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/weavertest/internal/protos/PingPonger",
 		Iface: reflect.TypeOf((*PingPonger)(nil)).Elem(),
-		New:   func() any { return &impl{} },
+		Impl:  reflect.TypeOf(impl{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return pingPonger_local_stub{impl: impl.(PingPonger), tracer: tracer}
 		},

--- a/weavertest/internal/simple/weaver_gen.go
+++ b/weavertest/internal/simple/weaver_gen.go
@@ -18,7 +18,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:   "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination",
 		Iface:  reflect.TypeOf((*Destination)(nil)).Elem(),
-		New:    func() any { return &destination{} },
+		Impl:   reflect.TypeOf(destination{}),
 		Routed: true,
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return destination_local_stub{impl: impl.(Destination), tracer: tracer}
@@ -33,7 +33,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server",
 		Iface:       reflect.TypeOf((*Server)(nil)).Elem(),
-		New:         func() any { return &server{} },
+		Impl:        reflect.TypeOf(server{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return server_local_stub{impl: impl.(Server), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return server_client_stub{stub: stub, addressMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server", Method: "Address"}), proxyAddressMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server", Method: "ProxyAddress"}), shutdownMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server", Method: "Shutdown"})}
@@ -45,7 +45,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:        "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Source",
 		Iface:       reflect.TypeOf((*Source)(nil)).Elem(),
-		New:         func() any { return &source{} },
+		Impl:        reflect.TypeOf(source{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any { return source_local_stub{impl: impl.(Source), tracer: tracer} },
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
 			return source_client_stub{stub: stub, emitMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Source", Method: "Emit"})}

--- a/weavertest/weaver_gen.go
+++ b/weavertest/weaver_gen.go
@@ -14,7 +14,7 @@ func init() {
 	codegen.Register(codegen.Registration{
 		Name:  "github.com/ServiceWeaver/weaver/weavertest/testMainInterface",
 		Iface: reflect.TypeOf((*testMainInterface)(nil)).Elem(),
-		New:   func() any { return &testMain{} },
+		Impl:  reflect.TypeOf(testMain{}),
 		LocalStubFn: func(impl any, tracer trace.Tracer) any {
 			return testMainInterface_local_stub{impl: impl.(testMainInterface), tracer: tracer}
 		},


### PR DESCRIPTION
Previously, codegen.Registration contained a function that created the implementation object and returned a pointer to it. We now store the reflect.Type for the implementation object instead.  This allows us to examine type properties without having to create an unnecessary object.