### PR TITLE
Moved logs back to /tmp/serviceweaver.

### DIFF
--- a/internal/tool/multi/multi.go
+++ b/internal/tool/multi/multi.go
@@ -28,8 +28,8 @@ import (
 
 var (
 	// The directories and files where "weaver multi" stores data.
+	logDir       = filepath.Join(runtime.LogsDir(), "multi")
 	dataDir      = filepath.Join(must.Must(runtime.DataDir()), "multi")
-	logDir       = filepath.Join(dataDir, "logs")
 	registryDir  = filepath.Join(dataDir, "registry")
 	perfettoFile = filepath.Join(dataDir, "perfetto.db")
 
@@ -50,7 +50,7 @@ var (
 	purgeSpec = &tool.PurgeSpec{
 		Tool:  "weaver multi",
 		Kill:  "weaver multi (dashboard|deploy|logs|profile)",
-		Paths: []string{dataDir},
+		Paths: []string{logDir, dataDir},
 	}
 
 	Commands = map[string]*tool.Command{

--- a/internal/tool/ssh/impl/manager.go
+++ b/internal/tool/ssh/impl/manager.go
@@ -71,8 +71,8 @@ var (
 	// The directories and files where "weaver ssh" stores data.
 	//
 	// TODO(mwhittaker): Take these as arguments and move them to ssh.go.
+	LogDir       = filepath.Join(runtime.LogsDir(), "ssh")
 	dataDir      = filepath.Join(must.Must(runtime.DataDir()), "ssh")
-	LogDir       = filepath.Join(dataDir, "logs")
 	registryDir  = filepath.Join(dataDir, "registry")
 	PerfettoFile = filepath.Join(dataDir, "perfetto.db")
 )

--- a/runtime/dir.go
+++ b/runtime/dir.go
@@ -19,6 +19,16 @@ import (
 	"path/filepath"
 )
 
+// LogsDir returns the default directory for Service Weaver logs,
+// $DIR/tmp/serviceweaver/logs where $DIR is the default directory used for
+// temporary files (see [os.TempDir] for details). We recommend that deployers
+// store their logs in a directory within this default directory. For example,
+// on Unix systems, the "weaver multi" deployer stores its data in
+// /tmp/serviceweaver/logs/multi.
+func LogsDir() string {
+	return filepath.Join(os.TempDir(), "serviceweaver", "logs")
+}
+
 // DataDir returns the default directory for Service Weaver deployer data. The
 // returned directory is $XDG_DATA_HOME/serviceweaver, or
 // ~/.local/share/serviceweaver if XDG_DATA_HOME is not set.


### PR DESCRIPTION
This PR reverts some of the behavior introduced in #309 by moving logs back to `/tmp`, rather than `~/.local/share/serviceweaver`. Thanks Sanjay for the recommendation.