### PR TITLE
[docs fix] Use query param as expected by the example

### DIFF
--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -47,7 +47,11 @@ func serve(ctx context.Context, app *app) error {
 	// Serve the /hello endpoint.
 	http.Handle("/hello", weaver.InstrumentHandlerFunc("hello",
 		func(w http.ResponseWriter, r *http.Request) {
-			reversed, err := app.reverser.Get().Reverse(ctx, "!dlroW ,olleH")
+			name := r.URL.Query().Get("name")
+			if name == "" {
+				name = "World"
+			}
+			reversed, err := app.reverser.Get().Reverse(ctx, name)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return

--- a/website/docs.md
+++ b/website/docs.md
@@ -297,7 +297,11 @@ func serve(ctx context.Context, app *app) error {
 
     // Serve the /hello endpoint.
     http.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-        reversed, err := app.reverser.Get().Reverse(ctx, "!dlroW ,olleH")
+        name := r.URL.Query().Get("name")
+        if name == "" {
+            name = "World"
+        }
+        reversed, err := app.reverser.Get().Reverse(ctx, name)
         if err != nil {
             http.Error(w, err.Error(), http.StatusInternalServerError)
             return


### PR DESCRIPTION
I've noticed that when following the docs and getting surprised by the result.

Current implementation uses static string, but subsequent examples expect the query param to be used and reversed instead.