### PR TITLE
Disable mTLS in multi deployer by default.

### DIFF
--- a/internal/tool/multi/deployer.go
+++ b/internal/tool/multi/deployer.go
@@ -57,6 +57,7 @@ type deployer struct {
 	ctxCancel    context.CancelFunc
 	deploymentId string
 	config       *protos.AppConfig
+	multiConfig  *config
 	started      time.Time
 	logger       *slog.Logger
 	caCert       *x509.Certificate
@@ -122,7 +123,7 @@ var _ envelope.EnvelopeHandler = &handler{}
 
 // newDeployer creates a new deployer. The deployer can be stopped at any
 // time by canceling the passed-in context.
-func newDeployer(ctx context.Context, deploymentId string, config *protos.AppConfig) (*deployer, error) {
+func newDeployer(ctx context.Context, deploymentId string, config *protos.AppConfig, multiConfig *config) (*deployer, error) {
 	// Create the log saver.
 	logsDB, err := logging.NewFileStore(logDir)
 	if err != nil {
@@ -137,9 +138,13 @@ func newDeployer(ctx context.Context, deploymentId string, config *protos.AppCon
 		},
 		Write: logsDB.Add,
 	})
-	caCert, caKey, err := certs.GenerateCACert()
-	if err != nil {
-		return nil, fmt.Errorf("cannot generate signing certificate: %w", err)
+	var caCert *x509.Certificate
+	var caKey crypto.PrivateKey
+	if multiConfig.MTLS {
+		caCert, caKey, err = certs.GenerateCACert()
+		if err != nil {
+			return nil, fmt.Errorf("cannot generate signing certificate: %w", err)
+		}
 	}
 
 	// Create the trace saver.
@@ -168,6 +173,7 @@ func newDeployer(ctx context.Context, deploymentId string, config *protos.AppCon
 		statsProcessor: imetrics.NewStatsProcessor(),
 		deploymentId:   deploymentId,
 		config:         config,
+		multiConfig:    multiConfig,
 		started:        time.Now(),
 		colocation:     colocation,
 		groups:         map[string]*group{},
@@ -271,13 +277,20 @@ func (d *deployer) startColocationGroup(g *group) error {
 	components := maps.Keys(g.components)
 	for r := 0; r < defaultReplication; r++ {
 		// Generate a signed certificate that encodes the group name.
-		cert, key, err := certs.GenerateSignedCert(d.caCert, d.caKey, g.name)
-		if err != nil {
-			return fmt.Errorf("cannot generate cert: %w", err)
-		}
-		certPEM, keyPEM, err := certs.PEMEncode(cert, key)
-		if err != nil {
-			return fmt.Errorf("cannot PEM-encode cert: %w", err)
+		//
+		// TODO(spetrovic): Create one cert per group rather than per replica?
+		// If you increase the default replication from 2 to something like 10,
+		// this takes a long long time.
+		var certPEM, keyPEM []byte
+		if d.multiConfig.MTLS {
+			cert, key, err := certs.GenerateSignedCert(d.caCert, d.caKey, g.name)
+			if err != nil {
+				return fmt.Errorf("cannot generate cert: %w", err)
+			}
+			certPEM, keyPEM, err = certs.PEMEncode(cert, key)
+			if err != nil {
+				return fmt.Errorf("cannot PEM-encode cert: %w", err)
+			}
 		}
 
 		// Start the weavelet and capture its logs, traces, and metrics.


### PR DESCRIPTION
I noticed the multi deployer was slow to start applications. Before, it started apps almost instantly. Recently, it's been taking about 8 seconds. I profiled the deployer (results below for reference) and found that the slowdown was from generating certificates and keys for mTLS.

Since mTLS is not particularly useful for the multiprocess deployer, I disabled it by default. I think people playing with the multiprocess deployer for the first time will think that the deployer itself is slow. I added a new [multi] section to config files with an mtls option to enable it. The multi deployer is fast again :)

```
File: weaver
Type: cpu
Time: May 8, 2023 at 2:13pm (PDT)
Duration: 6.52s, Total samples = 6.31s (96.81%)
Showing nodes accounting for 6.21s, 98.42% of 6.31s total
Dropped 71 nodes (cum <= 0.03s)
      flat  flat%   sum%        cum   cum%
     5.08s 80.51% 80.51%      5.08s 80.51%  math/big.addMulVVW
     0.89s 14.10% 94.61%      6.11s 96.83%  math/big.nat.montgomery
     0.08s  1.27% 95.88%      0.08s  1.27%  runtime.memclrNoHeapPointers
     0.06s  0.95% 96.83%      0.06s  0.95%  runtime.memmove
     0.04s  0.63% 97.46%      0.04s  0.63%  crypto/internal/bigmod.montgomeryLoop
     0.04s  0.63% 98.10%      0.04s  0.63%  math/big.subVV
     0.01s  0.16% 98.26%      0.05s  0.79%  crypto/internal/bigmod.(*Nat).montgomeryMul
     0.01s  0.16% 98.42%      6.12s 96.99%  math/big.nat.expNNMontgomery
         0     0% 98.42%      0.05s  0.79%  crypto/internal/bigmod.(*Nat).Exp
         0     0% 98.42%      6.22s 98.57%  crypto/rand.Prime
         0     0% 98.42%      0.06s  0.95%  crypto/rsa.(*PrivateKey).Sign
         0     0% 98.42%      6.22s 98.57%  crypto/rsa.GenerateKey (inline)
         0     0% 98.42%      6.22s 98.57%  crypto/rsa.GenerateMultiPrimeKey
         0     0% 98.42%      0.06s  0.95%  crypto/rsa.SignPKCS1v15
         0     0% 98.42%      0.06s  0.95%  crypto/rsa.decrypt
         0     0% 98.42%      0.06s  0.95%  crypto/x509.CreateCertificate
         0     0% 98.42%      3.90s 61.81%  github.com/ServiceWeaver/weaver/internal/envelope/conn.(*EnvelopeConn).Serve.func1
         0     0% 98.42%      3.90s 61.81%  github.com/ServiceWeaver/weaver/internal/envelope/conn.(*EnvelopeConn).handleMessage
         0     0% 98.42%      0.91s 14.42%  github.com/ServiceWeaver/weaver/internal/tool/certs.GenerateCACert (inline)
         0     0% 98.42%      5.37s 85.10%  github.com/ServiceWeaver/weaver/internal/tool/certs.GenerateSignedCert
         0     0% 98.42%      6.26s 99.21%  github.com/ServiceWeaver/weaver/internal/tool/certs.generateLeafCert
         0     0% 98.42%      5.37s 85.10%  github.com/ServiceWeaver/weaver/internal/tool/multi.(*deployer).activateComponent
         0     0% 98.42%      5.37s 85.10%  github.com/ServiceWeaver/weaver/internal/tool/multi.(*deployer).startColocationGroup
         0     0% 98.42%      1.48s 23.45%  github.com/ServiceWeaver/weaver/internal/tool/multi.(*deployer).startMain (inline)
         0     0% 98.42%      3.89s 61.65%  github.com/ServiceWeaver/weaver/internal/tool/multi.(*handler).ActivateComponent
         0     0% 98.42%      2.40s 38.03%  github.com/ServiceWeaver/weaver/internal/tool/multi.deploy
         0     0% 98.42%      0.92s 14.58%  github.com/ServiceWeaver/weaver/internal/tool/multi.newDeployer
         0     0% 98.42%      2.40s 38.03%  github.com/ServiceWeaver/weaver/runtime/tool.Run
         0     0% 98.42%      3.91s 61.97%  golang.org/x/sync/errgroup.(*Group).Go.func1
         0     0% 98.42%      2.40s 38.03%  main.main
         0     0% 98.42%      6.20s 98.26%  math/big.(*Int).ProbablyPrime
         0     0% 98.42%      0.08s  1.27%  math/big.nat.clear (inline)
         0     0% 98.42%      0.05s  0.79%  math/big.nat.div
         0     0% 98.42%      0.05s  0.79%  math/big.nat.divBasic
         0     0% 98.42%      0.05s  0.79%  math/big.nat.divLarge
         0     0% 98.42%      6.12s 96.99%  math/big.nat.expNN
         0     0% 98.42%      0.05s  0.79%  math/big.nat.probablyPrimeLucas
         0     0% 98.42%      6.15s 97.46%  math/big.nat.probablyPrimeMillerRabin
         0     0% 98.42%      2.40s 38.03%  runtime.main
         0     0% 98.42%      0.04s  0.63%  syscall.Syscall
```