### PR TITLE
SSH and multiprocess deployers check API version.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -572,6 +572,7 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/retry
     github.com/ServiceWeaver/weaver/runtime/tool
+    github.com/ServiceWeaver/weaver/runtime/version
     github.com/google/uuid
     go.opentelemetry.io/otel/sdk/trace
     golang.org/x/exp/maps
@@ -610,6 +611,7 @@ github.com/ServiceWeaver/weaver/internal/tool/ssh
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/tool
+    github.com/ServiceWeaver/weaver/runtime/version
     github.com/google/uuid
     golang.org/x/exp/maps
     io

--- a/internal/tool/multi/deploy.go
+++ b/internal/tool/multi/deploy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/retry"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
+	"github.com/ServiceWeaver/weaver/runtime/version"
 	"github.com/google/uuid"
 )
 
@@ -85,6 +86,17 @@ func deploy(ctx context.Context, args []string) error {
 	multiConfig := config{}
 	if err := runtime.ParseConfigSection(configKey, shortConfigKey, appConfig.Sections, &multiConfig); err != nil {
 		return fmt.Errorf("parse multi config: %w", err)
+	}
+	major, minor, patch, err := version.ReadVersion(appConfig.Binary)
+	if err != nil {
+		return fmt.Errorf("read binary version: %w", err)
+	}
+	if major != version.Major || minor != version.Minor || patch != version.Patch {
+		return fmt.Errorf(
+			"version mismatch: deployer version %d.%d.%d is incompatible with app version %d.%d.%d",
+			version.Major, version.Minor, version.Patch,
+			major, minor, patch,
+		)
 	}
 
 	// Create the deployer.

--- a/internal/tool/ssh/deploy.go
+++ b/internal/tool/ssh/deploy.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
+	"github.com/ServiceWeaver/weaver/runtime/version"
 )
 
 var deployCmd = tool.Command{
@@ -74,6 +75,17 @@ func deploy(ctx context.Context, args []string) error {
 	// Sanity check the config.
 	if _, err := os.Stat(app.Binary); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("binary %q doesn't exist", app.Binary)
+	}
+	major, minor, patch, err := version.ReadVersion(app.Binary)
+	if err != nil {
+		return fmt.Errorf("read binary version: %w", err)
+	}
+	if major != version.Major || minor != version.Minor || patch != version.Patch {
+		return fmt.Errorf(
+			"version mismatch: deployer version %d.%d.%d is incompatible with app version %d.%d.%d",
+			version.Major, version.Minor, version.Patch,
+			major, minor, patch,
+		)
 	}
 
 	// Retrieve the list of locations to deploy.


### PR DESCRIPTION
This PR changes the SSH and multiprocess deployers to check the deployer API version embedded in a Service Weaver binary.

A question for reviewers. Weavelets still report their deployer API version via the pipe. Should we get rid of this?