### PR TITLE
Make weavertest handle benchmarks.

### DIFF
--- a/weavertest/init.go
+++ b/weavertest/init.go
@@ -69,6 +69,7 @@ type testMainInterface interface{}
 //	func(ComponentType, ComponentType2)
 //	...
 func Run(t testing.TB, opts Options, testBody any) {
+	_, isBench := t.(*testing.B)
 	t.Helper()
 	runner, err := checkRunFunc(testBody)
 	if err != nil {
@@ -119,7 +120,7 @@ func Run(t testing.TB, opts Options, testBody any) {
 	if opts.SingleProcess {
 		ctx = initSingleProcess(ctx, opts.Config)
 	} else {
-		multiCtx, multiCleanup, err := initMultiProcess(ctx, t.Name(), opts.Config, logWriter)
+		multiCtx, multiCleanup, err := initMultiProcess(ctx, t.Name(), isBench, opts.Config, logWriter)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/weavertest/internal/simple/simple_test.go
+++ b/weavertest/internal/simple/simple_test.go
@@ -180,3 +180,19 @@ func TestRoutedCall(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkCall(b *testing.B) {
+	for _, single := range []bool{true, false} {
+		opt := weavertest.Options{SingleProcess: single}
+		b.Run(fmt.Sprintf("Single=%t", single), func(b *testing.B) {
+			weavertest.Run(b, opt, func(dst simple.Destination) {
+				for i := 0; i < b.N; i++ {
+					_, err := dst.Getpid(context.Background())
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
weavertest.Run expects either *testing.T or *testing.B which indicates that it should work for benchmarking components. However, the weavertest implementation was always passing a -test.run argument. We now set the -test.bench argument instead (and disable all tests) if we detect that the argument passed to weavetest.Run is a *testing.B.