### PR TITLE
Made weavertest respect the -test.v flag.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -882,7 +882,6 @@ github.com/ServiceWeaver/weaver/weavertest
     github.com/ServiceWeaver/weaver/internal/private
     github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/codegen
-    github.com/ServiceWeaver/weaver/runtime/colors
     github.com/ServiceWeaver/weaver/runtime/envelope
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/protos

--- a/internal/net/benchmarks/net_test.go
+++ b/internal/net/benchmarks/net_test.go
@@ -246,7 +246,7 @@ func serve(b *testing.B, config config) {
 	// Launch the server.
 	go func() {
 		opts := config.serverOpts()
-		opts.Logger = logging.NewTestLogger(b)
+		opts.Logger = logging.NewTestSlogger(b)
 		switch err := call.Serve(ctx, config.listen(), opts); err {
 		case nil, ctx.Err():
 		case err:
@@ -340,12 +340,12 @@ func BenchmarkPipeRPC(b *testing.B) {
 	c, s := net.Pipe()
 	defer c.Close()
 	defer s.Close()
-	sopts := call.ServerOptions{Logger: logging.NewTestLogger(b)}
+	sopts := call.ServerOptions{Logger: logging.NewTestSlogger(b)}
 	call.ServeOn(ctx, s, &handlers, sopts)
 
 	// Create the client.
 	resolver := call.NewConstantResolver(&connEndpoint{"client", c})
-	copts := call.ClientOptions{Logger: logging.NewTestLogger(b)}
+	copts := call.ClientOptions{Logger: logging.NewTestSlogger(b)}
 	client, err := call.Connect(ctx, resolver, copts)
 	if err != nil {
 		b.Fatal(err)
@@ -361,7 +361,7 @@ func BenchmarkLocalRPC(b *testing.B) {
 			serve(b, config)
 			resolver := call.NewConstantResolver(config.endpoint())
 			opts := config.clientOpts()
-			opts.Logger = logging.NewTestLogger(b)
+			opts.Logger = logging.NewTestSlogger(b)
 			client, err := call.Connect(context.Background(), resolver, opts)
 			if err != nil {
 				b.Fatal(err)
@@ -379,7 +379,7 @@ func BenchmarkMultiprocRPC(b *testing.B) {
 			serveSubprocess(b, config)
 			resolver := call.NewConstantResolver(config.endpoint())
 			opts := config.clientOpts()
-			opts.Logger = logging.NewTestLogger(b)
+			opts.Logger = logging.NewTestSlogger(b)
 			client, err := call.Connect(context.Background(), resolver, opts)
 			if err != nil {
 				b.Fatal(err)

--- a/runtime/bootstrap.go
+++ b/runtime/bootstrap.go
@@ -43,6 +43,7 @@ type Bootstrap struct {
 	ToWeaveletFile *os.File // Pipe to send to weavelet (weavertest only).
 	ToEnvelopeFile *os.File // Pipe to send to envelope (weavertest only).
 	TestConfig     string   // Config file contents (weavertest only).
+	Quiet          bool     // Don't log or print anything.
 }
 
 // BootstrapKey is the Context key used by weavertest to pass Bootstrap to [weaver.Run].

--- a/runtime/logging/logger_test.go
+++ b/runtime/logging/logger_test.go
@@ -32,7 +32,7 @@ func TestTestLogger(t *testing.T) {
 	// Test plan: Launch a goroutine that continues to write to a TestLogger
 	// after the test ends. The logger should stop logging when the test ends.
 	t.Run("sub", func(t *testing.T) {
-		logger := NewTestLogger(t)
+		logger := NewTestSlogger(t)
 		go func() {
 			for {
 				logger.Debug("Ping")

--- a/weavertest/multi.go
+++ b/weavertest/multi.go
@@ -40,7 +40,7 @@ const matchNothingRE = "a^" // Regular expression that never matches
 // component level configs. config is allowed to be empty.
 //
 // Future extension: allow options so the user can control collocation/replication/etc.
-func initMultiProcess(ctx context.Context, name string, isBench bool, config string, logWriter func(string)) (context.Context, func() error, error) {
+func initMultiProcess(ctx context.Context, name string, isBench bool, config string, logWriter func(*protos.LogEntry)) (context.Context, func() error, error) {
 	bootstrap, err := runtime.GetBootstrap(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/weavertest/single.go
+++ b/weavertest/single.go
@@ -16,6 +16,7 @@ package weavertest
 
 import (
 	"context"
+	"testing"
 
 	"github.com/ServiceWeaver/weaver/runtime"
 )
@@ -28,5 +29,6 @@ import (
 func initSingleProcess(ctx context.Context, config string) context.Context {
 	return context.WithValue(ctx, runtime.BootstrapKey{}, runtime.Bootstrap{
 		TestConfig: config,
+		Quiet:      !testing.Verbose(),
 	})
 }


### PR DESCRIPTION
Currently, weavertest logs do not respect the `-test.v` flag. For example, a single process weavertest logs to stdout whether or not the `-test.v` flag is present. Similarly, benchmarks logs are always shown, which makes it very hard to read the benchmark results. This PR fixes these bugs. Thanks Sanjay for pointing them out. 

**For reviewers**:

- I recommend reading the PR commit-by-commit. 
- Should I delete the `weavertest/internal/logging` tests I added? I'm not sure how useful they are.