### PR TITLE
Upgrade to `golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.7.0
 	go.opentelemetry.io/otel/sdk v1.11.1
 	go.opentelemetry.io/otel/trace v1.13.0
-	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
+	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
 	golang.org/x/image v0.5.0
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ go.opentelemetry.io/otel/trace v1.13.0 h1:CBgRZ6ntv+Amuj1jDsMhZtlAPT6gbyIRdaIzFh
 go.opentelemetry.io/otel/trace v1.13.0/go.mod h1:muCvmmO9KKpvuXSf3KKAXXB2ygNYHQ+ZfI5X08d3tds=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 h1:5llv2sWeaMSnA3w2kS57ouQQ4pudlXrR0dCgw51QK9o=
-golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea h1:vLCWI/yYrdEHyN2JzIzPO3aaQJHQdp89IZBA/+azVC4=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.5.0 h1:5JMiNunQeQw++mMOz48/ISeNu3Iweh/JaZU8ZLqHRrI=
 golang.org/x/image v0.5.0/go.mod h1:FVC7BI/5Ym8R25iw5OLsgshdUBbT1h5jZTpA+mvAdZ4=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/runtime/protomsg/handler_test.go
+++ b/runtime/protomsg/handler_test.go
@@ -30,7 +30,7 @@ func TestPanicHandler(t *testing.T) {
 	const msg = "zardoz"
 	server := httptest.NewServer(panicHandler(
 		// Discard logs.
-		slog.New(slog.HandlerOptions{Level: slog.LevelError + 1}.NewTextHandler(os.Stdout)),
+		slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError + 1})),
 		func(http.ResponseWriter, *http.Request) {
 			panic(msg)
 		}),

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -324,7 +324,7 @@ func (e *singleprocessEnv) CreateTraceExporter() sdktrace.SpanExporter {
 
 func (e *singleprocessEnv) SystemLogger() *slog.Logger {
 	// In single process execution, system logs are hidden.
-	return slog.New(slog.HandlerOptions{Level: slog.LevelError + 1}.NewTextHandler(os.Stdout))
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError + 1}))
 }
 
 // serveHTTP serves HTTP traffic on the provided listener using the provided

--- a/weavelet.go
+++ b/weavelet.go
@@ -109,7 +109,7 @@ func newWeavelet(ctx context.Context, componentInfos []*codegen.Registration) (*
 			info: info,
 			// May be remote, so start with no-op logger. May set real logger later.
 			// Discard all log entries.
-			logger: slog.New(slog.HandlerOptions{Level: slog.LevelError + 1}.NewTextHandler(os.Stdout)),
+			logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError + 1})),
 		}
 		w.componentsByName[info.Name] = c
 		w.componentsByType[info.Iface] = c


### PR DESCRIPTION
- Update `go.mod` to use a newer version of `golang.org/x/exp`
- Refactor `singleprocess.go` to use a different `slog` handler initialization
- Refactor `weavelet.go` to use a different `slog` handler initialization
- Refactor `handler_test.go` to use a different `slog` handler initialization