### PR TITLE
Removed logging package's dependency on testing.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -772,7 +772,6 @@ github.com/ServiceWeaver/weaver/runtime/logging
     strconv
     strings
     sync
-    testing
     time
 github.com/ServiceWeaver/weaver/runtime/metrics
     encoding/binary

--- a/internal/net/benchmarks/net_test.go
+++ b/internal/net/benchmarks/net_test.go
@@ -246,7 +246,7 @@ func serve(b *testing.B, config config) {
 	// Launch the server.
 	go func() {
 		opts := config.serverOpts()
-		opts.Logger = logging.NewTestSlogger(b)
+		opts.Logger = logging.NewTestSlogger(b, testing.Verbose())
 		switch err := call.Serve(ctx, config.listen(), opts); err {
 		case nil, ctx.Err():
 		case err:
@@ -340,12 +340,12 @@ func BenchmarkPipeRPC(b *testing.B) {
 	c, s := net.Pipe()
 	defer c.Close()
 	defer s.Close()
-	sopts := call.ServerOptions{Logger: logging.NewTestSlogger(b)}
+	sopts := call.ServerOptions{Logger: logging.NewTestSlogger(b, testing.Verbose())}
 	call.ServeOn(ctx, s, &handlers, sopts)
 
 	// Create the client.
 	resolver := call.NewConstantResolver(&connEndpoint{"client", c})
-	copts := call.ClientOptions{Logger: logging.NewTestSlogger(b)}
+	copts := call.ClientOptions{Logger: logging.NewTestSlogger(b, testing.Verbose())}
 	client, err := call.Connect(ctx, resolver, copts)
 	if err != nil {
 		b.Fatal(err)
@@ -361,7 +361,7 @@ func BenchmarkLocalRPC(b *testing.B) {
 			serve(b, config)
 			resolver := call.NewConstantResolver(config.endpoint())
 			opts := config.clientOpts()
-			opts.Logger = logging.NewTestSlogger(b)
+			opts.Logger = logging.NewTestSlogger(b, testing.Verbose())
 			client, err := call.Connect(context.Background(), resolver, opts)
 			if err != nil {
 				b.Fatal(err)
@@ -379,7 +379,7 @@ func BenchmarkMultiprocRPC(b *testing.B) {
 			serveSubprocess(b, config)
 			resolver := call.NewConstantResolver(config.endpoint())
 			opts := config.clientOpts()
-			opts.Logger = logging.NewTestSlogger(b)
+			opts.Logger = logging.NewTestSlogger(b, testing.Verbose())
 			client, err := call.Connect(context.Background(), resolver, opts)
 			if err != nil {
 				b.Fatal(err)

--- a/internal/net/call/call_test.go
+++ b/internal/net/call/call_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/exp/slog"
 )
 
 type resolverMaker func(...call.Endpoint) call.Resolver
@@ -258,7 +259,7 @@ func getClientConn(t testing.TB, protocol string, endpoint call.Endpoint, maker 
 	t.Helper()
 	ctx := context.Background()
 
-	opts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	opts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(ctx, maker(endpoint), opts)
 	if err != nil {
 		t.Fatalf("connect: %v", err)
@@ -311,7 +312,7 @@ func (p *pipeEndpoint) Dial(context.Context) (net.Conn, error) {
 	client, server := pipe(p.t)
 	// Note: do not use passed in context since we want the server to
 	// be independent of the context in which the client is running.
-	opts := call.ServerOptions{Logger: logging.NewTestSlogger(p.t)}
+	opts := call.ServerOptions{Logger: logger(p.t)}
 	call.ServeOn(context.Background(), server, p.handlers, opts)
 	return client, nil
 }
@@ -551,7 +552,7 @@ func TestSingleTCPServer(t *testing.T) {
 	protocols := []string{"tcp", "mtls"}
 
 	ctx := context.Background()
-	opts := call.ServerOptions{Logger: logging.NewTestSlogger(t)}
+	opts := call.ServerOptions{Logger: logger(t)}
 	endpoints := startServers(ctx, opts)
 
 	// Run all of the subtests on a single connection.
@@ -587,7 +588,7 @@ func TestTracePropagation(t *testing.T) {
 	h := &call.HandlerMap{}
 	h.Set("", "trace", traceHandler(span.SpanContext()))
 	ep := pipeEndpoint{t: t, handlers: h}
-	opts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	opts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(context.Background(), call.NewConstantResolver(&ep), opts)
 	if err != nil {
 		t.Fatal(err)
@@ -607,7 +608,7 @@ func TestMultipleEndpoints(t *testing.T) {
 			resolver := maker(server(t, "0"), server(t, "1"), server(t, "2"))
 			options := call.ClientOptions{
 				Balancer: call.RoundRobin(),
-				Logger:   logging.NewTestSlogger(t),
+				Logger:   logger(t),
 			}
 			client, err := call.Connect(ctx, resolver, options)
 			if err != nil {
@@ -633,7 +634,7 @@ func TestChangingEndpoints(t *testing.T) {
 	n := 3
 	ctx := context.Background()
 	resolver := newDynamicResolver()
-	opts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	opts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(ctx, resolver, opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -661,7 +662,7 @@ func TestShardedBalancer(t *testing.T) {
 	resolver := call.NewConstantResolver(s1, s2, s3)
 	opts := call.ClientOptions{
 		Balancer: call.Sharded(),
-		Logger:   logging.NewTestSlogger(t),
+		Logger:   logger(t),
 	}
 	client, err := call.Connect(ctx, resolver, opts)
 	if err != nil {
@@ -706,7 +707,7 @@ func TestCallOptionsBalancer(t *testing.T) {
 	ctx := context.Background()
 	s1, s2, s3 := server(t, "1"), server(t, "2"), server(t, "3")
 	resolver := call.NewConstantResolver(s1, s2, s3)
-	opts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	opts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(ctx, resolver, opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -753,7 +754,7 @@ func TestCallOptionsBalancer(t *testing.T) {
 // constant resolver that returns no endpoints.
 func TestNoEndpointsConstant(t *testing.T) {
 	ctx := context.Background()
-	opts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	opts := call.ClientOptions{Logger: logger(t)}
 	_, err := call.Connect(ctx, call.NewConstantResolver(), opts)
 	if err == nil {
 		t.Fatal("unexpected success when expecting error")
@@ -772,7 +773,7 @@ func TestNoEndpointsNonConstant(t *testing.T) {
 
 	// Connecting with a non-constant resolver isn't an error because the
 	// resolver may return endpoints later.
-	opts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	opts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(ctx, resolver, opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -811,7 +812,7 @@ func TestEndpointsRetained(t *testing.T) {
 
 	// Construct the network.
 	c, s := pipe(t)
-	sopts := call.ServerOptions{Logger: logging.NewTestSlogger(t)}
+	sopts := call.ServerOptions{Logger: logger(t)}
 	call.ServeOn(ctx, s, handlersFor("1"), sopts)
 	m := &closeMock{connWrapper: connWrapper{c}}
 	server1 := &connEndpoint{"1", m}
@@ -819,7 +820,7 @@ func TestEndpointsRetained(t *testing.T) {
 
 	// Construct the client.
 	resolver := newDynamicResolver(server1)
-	copts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	copts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(ctx, resolver, copts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -853,7 +854,7 @@ func TestDraining(t *testing.T) {
 
 	// Construct the network.
 	c, s := pipe(t)
-	sopts := call.ServerOptions{Logger: logging.NewTestSlogger(t)}
+	sopts := call.ServerOptions{Logger: logger(t)}
 	call.ServeOn(ctx, s, handlersFor("1"), sopts)
 	m := &closeMock{connWrapper: connWrapper{c}}
 	server1 := &connEndpoint{"1", m}
@@ -861,7 +862,7 @@ func TestDraining(t *testing.T) {
 
 	// Construct the client.
 	resolver := newDynamicResolver(server1)
-	copts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	copts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(ctx, resolver, copts)
 	if err != nil {
 		t.Fatal(err)
@@ -916,7 +917,7 @@ func TestNoActiveDraining(t *testing.T) {
 
 	// Construct the network.
 	c, s := pipe(t)
-	sopts := call.ServerOptions{Logger: logging.NewTestSlogger(t)}
+	sopts := call.ServerOptions{Logger: logger(t)}
 	call.ServeOn(ctx, s, handlersFor("1"), sopts)
 	m := &closeMock{connWrapper: connWrapper{c}}
 	server1 := &connEndpoint{"1", m}
@@ -924,7 +925,7 @@ func TestNoActiveDraining(t *testing.T) {
 
 	// Construct the client.
 	resolver := newDynamicResolver(server1)
-	copts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	copts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(ctx, resolver, copts)
 	if err != nil {
 		t.Fatal(err)
@@ -960,7 +961,7 @@ func TestCloseDraining(t *testing.T) {
 
 	// Construct the network.
 	c, s := pipe(t)
-	sopts := call.ServerOptions{Logger: logging.NewTestSlogger(t)}
+	sopts := call.ServerOptions{Logger: logger(t)}
 	call.ServeOn(ctx, s, handlersFor("1"), sopts)
 	m := &closeMock{connWrapper: connWrapper{c}}
 	server1 := &connEndpoint{"1", m}
@@ -968,7 +969,7 @@ func TestCloseDraining(t *testing.T) {
 
 	// Construct the client.
 	resolver := newDynamicResolver(server1)
-	copts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	copts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(ctx, resolver, copts)
 	if err != nil {
 		t.Fatal(err)
@@ -1005,7 +1006,7 @@ func TestRememberDraining(t *testing.T) {
 
 	// Construct the network.
 	c, s := pipe(t)
-	sopts := call.ServerOptions{Logger: logging.NewTestSlogger(t)}
+	sopts := call.ServerOptions{Logger: logger(t)}
 	call.ServeOn(ctx, s, handlers, sopts)
 	m := &closeMock{connWrapper: connWrapper{c}}
 	server1 := &connEndpoint{"1", m}
@@ -1014,7 +1015,7 @@ func TestRememberDraining(t *testing.T) {
 
 	// Construct the client.
 	resolver := newDynamicResolver(server1)
-	copts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	copts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(ctx, resolver, copts)
 	if err != nil {
 		t.Fatal(err)
@@ -1053,7 +1054,7 @@ func TestRefreshDraining(t *testing.T) {
 
 	// Construct the network.
 	c, s := pipe(t)
-	sopts := call.ServerOptions{Logger: logging.NewTestSlogger(t)}
+	sopts := call.ServerOptions{Logger: logger(t)}
 	call.ServeOn(ctx, s, handlersFor("1"), sopts)
 	m := &closeMock{connWrapper: connWrapper{c}}
 	server1 := &connEndpoint{"1", m}
@@ -1061,7 +1062,7 @@ func TestRefreshDraining(t *testing.T) {
 
 	// Construct the client.
 	resolver := newDynamicResolver(server1)
-	copts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	copts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(ctx, resolver, copts)
 	if err != nil {
 		t.Fatal(err)
@@ -1099,10 +1100,10 @@ func TestCommunicationErrors(t *testing.T) {
 			defer cancelFunc()
 
 			c, s := pipe(t)
-			sopts := call.ServerOptions{Logger: logging.NewTestSlogger(t)}
+			sopts := call.ServerOptions{Logger: logger(t)}
 			call.ServeOn(ctx, s, handlers, sopts)
 			endpoint := &connEndpoint{"server", c}
-			copts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+			copts := call.ClientOptions{Logger: logger(t)}
 			client, err := call.Connect(ctx, maker(endpoint), copts)
 			if err != nil {
 				t.Fatal(err)
@@ -1163,10 +1164,10 @@ func TestWriteError(t *testing.T) {
 				c = &readErrorInjector{connWrapper: connWrapper{c}, limit: limit}
 			}
 
-			sopts := call.ServerOptions{Logger: logging.NewTestSlogger(t)}
+			sopts := call.ServerOptions{Logger: logger(t)}
 			call.ServeOn(ctx, s, handlers, sopts)
 			endpoint := &connEndpoint{"server", c}
-			copts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+			copts := call.ClientOptions{Logger: logger(t)}
 			client, err := call.Connect(ctx, test.maker(endpoint), copts)
 			if err != nil {
 				t.Fatal(err)
@@ -1212,13 +1213,13 @@ func TestReconnect(t *testing.T) {
 			for i := range conns {
 				c, s := pipe(t)
 				conns[i] = &writeErrorInjector{connWrapper: connWrapper{c}, limit: limit}
-				sopts := call.ServerOptions{Logger: logging.NewTestSlogger(t)}
+				sopts := call.ServerOptions{Logger: logger(t)}
 				call.ServeOn(ctx, s, handlers, sopts)
 			}
 
 			// Make a client that uses the created connections in order.
 			endpoint := &connsEndpoint{name: "server", conns: conns}
-			copts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+			copts := call.ClientOptions{Logger: logger(t)}
 			client, err := call.Connect(ctx, maker(endpoint), copts)
 			if err != nil {
 				t.Fatal(err)
@@ -1258,7 +1259,7 @@ func TestPartialFailure(t *testing.T) {
 			resolver := maker(server1, server2)
 			options := call.ClientOptions{
 				Balancer: call.RoundRobin(),
-				Logger:   logging.NewTestSlogger(t),
+				Logger:   logger(t),
 			}
 			client, err := call.Connect(ctx, resolver, options)
 			if err != nil {
@@ -1293,7 +1294,7 @@ func TestManyEndpointChanges(t *testing.T) {
 	numChanges := 25
 	numCallers := 5
 	resolver := newDynamicResolver(servers(t, numServers)...)
-	opts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	opts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(ctx, resolver, opts)
 	if err != nil {
 		t.Fatal(err)
@@ -1360,7 +1361,7 @@ func TestResolverError(t *testing.T) {
 	// Create the client.
 	ctx := context.Background()
 	resolver := &failResolver{}
-	opts := call.ClientOptions{Logger: logging.NewTestSlogger(t)}
+	opts := call.ClientOptions{Logger: logger(t)}
 	client, err := call.Connect(ctx, resolver, opts)
 	if err != nil {
 		t.Fatal(err)
@@ -1376,7 +1377,7 @@ func TestResolverError(t *testing.T) {
 
 func BenchmarkCall(b *testing.B) {
 	ctx := context.Background()
-	opts := call.ServerOptions{Logger: logging.NewTestSlogger(b)}
+	opts := call.ServerOptions{Logger: logger(b)}
 	endpoints := startServers(ctx, opts)
 
 	for resolverName, maker := range resolverMakers {
@@ -1415,7 +1416,7 @@ func TestCancelServe(t *testing.T) {
 	}
 	done := make(chan struct{})
 	go func() {
-		opts := call.ServerOptions{Logger: logging.NewTestSlogger(t)}
+		opts := call.ServerOptions{Logger: logger(t)}
 		err := call.Serve(ctx, testListener{Listener: lis}, opts)
 		if err != ctx.Err() {
 			t.Errorf("unexpected error from Serve: %v", err)
@@ -1612,4 +1613,8 @@ func sizeString(s int) string {
 		return fmt.Sprintf("%gK", float64(s)/1024)
 	}
 	return fmt.Sprint(s)
+}
+
+func logger(t testing.TB) *slog.Logger {
+	return logging.NewTestSlogger(t, testing.Verbose())
 }

--- a/runtime/logging/logger_test.go
+++ b/runtime/logging/logger_test.go
@@ -32,7 +32,7 @@ func TestTestLogger(t *testing.T) {
 	// Test plan: Launch a goroutine that continues to write to a TestLogger
 	// after the test ends. The logger should stop logging when the test ends.
 	t.Run("sub", func(t *testing.T) {
-		logger := NewTestSlogger(t)
+		logger := NewTestSlogger(t, testing.Verbose())
 		go func() {
 			for {
 				logger.Debug("Ping")

--- a/weavertest/init.go
+++ b/weavertest/init.go
@@ -100,7 +100,7 @@ func Run(t testing.TB, opts Options, testBody any) {
 	if opts.SingleProcess {
 		ctx = initSingleProcess(ctx, opts.Config)
 	} else {
-		logger := logging.NewTestLogger(t)
+		logger := logging.NewTestLogger(t, testing.Verbose())
 		multiCtx, multiCleanup, err := initMultiProcess(ctx, t.Name(), isBench, opts.Config, logger.Log)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
As suggested by Sanjay in #330, this PR removes the logging package's dependency on the testing package. It does so by replacing `testing.TB` with a smaller `logging.TB` interface that includes the `Log` and `Cleanup` methods. It also receives the result of `testing.Verbose` as an argument, rather than calling `testing.Verbose` directly.

The weavertest package is now the only package with a dependency on the testing package.