### PR TITLE
weavertest tests can now run in a single process mode with RPCs.

### DIFF
--- a/examples/chat/sqlstore_test.go
+++ b/examples/chat/sqlstore_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestFeed(t *testing.T) {
-	weavertest.Run(t, weavertest.Options{SingleProcess: true}, func(store SQLStore) {
+	weavertest.Run(t, weavertest.Local, weavertest.Options{}, func(store SQLStore) {
 		ctx := context.Background()
 
 		// Run the test.
@@ -81,7 +81,7 @@ func TestFeed(t *testing.T) {
 }
 
 func TestImage(t *testing.T) {
-	weavertest.Run(t, weavertest.Options{SingleProcess: true}, func(store SQLStore) {
+	weavertest.Run(t, weavertest.Local, weavertest.Options{}, func(store SQLStore) {
 		ctx := context.Background()
 
 		// Create thread with an image in the initial post.

--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -339,7 +339,7 @@ func BenchmarkPing(b *testing.B) {
 		}
 		name := fmt.Sprintf("chain=%02d,size=%s", bm.numChainedComponents, size)
 		b.Run(name, func(b *testing.B) {
-			weavertest.Run(b, weavertest.Options{SingleProcess: true}, func(pObj Ping1) {
+			weavertest.Run(b, weavertest.Local, weavertest.Options{}, func(pObj Ping1) {
 				if bm.componentSize == complex {
 					payload := genWorkload(1)[0]
 					for i := 0; i < b.N; i++ {
@@ -370,7 +370,7 @@ func init() {
 func TestBenchmark(t *testing.T) {
 	// Test plan: Send a ping request from Component1 to Component10. Verify that
 	// the response is the same as the request when we send both simple and complex payloads.
-	weavertest.Run(t, weavertest.Options{SingleProcess: true}, func(ping Ping1) {
+	weavertest.Run(t, weavertest.Local, weavertest.Options{}, func(ping Ping1) {
 		ctx := context.Background()
 		depth := 10
 

--- a/runtime/protos/runtime.proto
+++ b/runtime/protos/runtime.proto
@@ -448,12 +448,12 @@ message ActivateComponentReply {}
 // are some examples of how different deployers may handle a
 // GetListenerAddressRequest.
 //
-// - The singleprocess deployer may instruct the weavelet to listen directly
-//   on localhost:9000.
-// - The multiprocess deployer may instruct the weavelet to listen on
-//   localhost:0. It will separately start a proxy on localhost:9000.
-// - The SSH deployer may instruct the weavelet to listen on
-//   $HOSTNAME:0. It will separately start a proxy on localhost:9000.
+//  - The singleprocess deployer may instruct the weavelet to listen directly
+//    on localhost:9000.
+//  - The multiprocess deployer may instruct the weavelet to listen on
+//    localhost:0. It will separately start a proxy on localhost:9000.
+//  - The SSH deployer may instruct the weavelet to listen on
+//    $HOSTNAME:0. It will separately start a proxy on localhost:9000.
 message GetListenerAddressRequest {
   string name = 1;           // listener name
   string local_address = 2;  // LocalAddress argument in ListenerOptions

--- a/weavertest/deployer.go
+++ b/weavertest/deployer.go
@@ -52,6 +52,7 @@ const DefaultReplication = 2
 type deployer struct {
 	ctx        context.Context
 	ctxCancel  context.CancelFunc
+	mode       Mode
 	wlet       *protos.EnvelopeInfo   // info for subprocesses
 	config     *protos.AppConfig      // application config
 	colocation map[string]string      // maps component to group
@@ -100,7 +101,7 @@ type connection struct {
 var _ envelope.EnvelopeHandler = &handler{}
 
 // newDeployer returns a new weavertest multiprocess deployer.
-func newDeployer(ctx context.Context, wlet *protos.EnvelopeInfo, config *protos.AppConfig, logWriter func(*protos.LogEntry)) *deployer {
+func newDeployer(ctx context.Context, wlet *protos.EnvelopeInfo, config *protos.AppConfig, mode Mode, logWriter func(*protos.LogEntry)) *deployer {
 	colocation := map[string]string{}
 	for _, group := range config.Colocate {
 		for _, c := range group.Components {
@@ -111,6 +112,7 @@ func newDeployer(ctx context.Context, wlet *protos.EnvelopeInfo, config *protos.
 	d := &deployer{
 		ctx:        ctx,
 		ctxCancel:  cancel,
+		mode:       mode,
 		wlet:       wlet,
 		config:     config,
 		colocation: colocation,
@@ -298,7 +300,7 @@ func (h *handler) ActivateComponent(_ context.Context, req *protos.ActivateCompo
 	if !h.subscribed[req.Component] {
 		h.subscribed[req.Component] = true
 
-		if h.group.name == target.name {
+		if h.mode != RPC && h.group.name == target.name {
 			// Route locally.
 			routing := &protos.RoutingInfo{Component: req.Component, Local: true}
 			if err := h.conn.UpdateRoutingInfo(routing); err != nil {
@@ -369,13 +371,15 @@ func (d *deployer) startGroup(g *group) error {
 //
 // REQUIRES: d.mu is held.
 func (d *deployer) group(component string) *group {
-	name, ok := d.colocation[component]
-	if !ok {
-		name = component
-	}
-	// Force testMain into main group
-	if component == "github.com/ServiceWeaver/weaver/weavertest/testMainInterface" {
-		name = "main"
+	var name string
+	if d.mode == RPC {
+		name = "main" // In RPC mode everything is in one group.
+	} else if component == "github.com/ServiceWeaver/weaver/weavertest/testMainInterface" {
+		name = "main" // Force testMain into main group
+	} else if x, ok := d.colocation[component]; ok {
+		name = x // Use specified group
+	} else {
+		name = component // A group of its own
 	}
 
 	g, ok := d.groups[name]

--- a/weavertest/doc.go
+++ b/weavertest/doc.go
@@ -49,8 +49,7 @@
 //
 //  3. RPC: Every component will be placed in a same process, but
 //     method calls will use RPCs. This mode is most useful when
-//     profiling or collecting
-//     coverage information.
+//     profiling or collecting coverage information.
 //
 // Example:
 //

--- a/weavertest/doc.go
+++ b/weavertest/doc.go
@@ -32,15 +32,31 @@
 //	}
 //
 // weavertest.Run is passed a weavertest.Options, which you can use to configure
-// the execution of the test. By default, weavertest.Run will run every
-// component in a different process. This is similar to what happens when you
-// run weaver multi deploy. If you set the SingleProcess option, weavertest.Run
-// will instead run every component in a single process, similar to what
-// happens when you "go run" a Service Weaver application.
+// the execution of the test.
+//
+// The mode argument to weavertest.Run controls whether or not components are
+// placed in different processes and whether or not RPCs are used for components
+// in the same process.
+//
+//  1. Local: all components are placed in a single process and method
+//     invocations are local procedure calls. This is similar to what
+//     happens when you run the Service Weaver binary directly or run
+//     the application using "go run".
+//
+//  2. Multi: Every component will be placed in a separate process,
+//     similar to what happens when you "weaver multi deploy" a
+//     Service Weaver application.
+//
+//  3. RPC: Every component will be placed in a same process, but
+//     method calls will use RPCs. This mode is most useful when
+//     profiling or collecting
+//     coverage information.
+//
+// Example:
 //
 //	func TestReverseSingle(t *testing.T) {
-//	    weavertest.Run(t, weavetest.Options{SingleProcess: true}, func(reverser Reverser) {
-//		// ...
-//	    })
+//	  weavertest.Run(t, weavertest.Multi, weavetest.Options{}, func(reverser Reverser) {
+//	    // ...
+//	  })
 //	}
 package weavertest

--- a/weavertest/init.go
+++ b/weavertest/init.go
@@ -37,13 +37,13 @@ const (
 	// This is the default value.
 	Local Mode = iota
 
+	// RPC places all components in the same process and uses RPCs for method invocations.
+	RPC
+
 	// Multi places all components in different process (unless explicitly colocated)
 	// and uses RPCs for method invocations on remote components and local procedure calls
 	// for method invocations on colocated components.
 	Multi
-
-	// RPC places all components in the same process and uses RPCs for method invocations.
-	RPC
 )
 
 // String returns a string representation of a Mode, suitable for using as sub-test names.

--- a/weavertest/internal/deploy/deploy_test.go
+++ b/weavertest/internal/deploy/deploy_test.go
@@ -31,7 +31,7 @@ func TestReplicated(t *testing.T) {
 
 	// Instruct the weavertest deployer to replicate each component. Note that each
 	// component should be replicated weavertest.DefaultReplication times.
-	weavertest.Run(t, weavertest.Options{}, func(w deploy.Widget) {
+	weavertest.Run(t, weavertest.Multi, weavertest.Options{}, func(w deploy.Widget) {
 		dir := t.TempDir()
 		w.Use(ctx, dir)
 		// Verify that deployed processes started.

--- a/weavertest/internal/diverge/diverge_test.go
+++ b/weavertest/internal/diverge/diverge_test.go
@@ -17,7 +17,6 @@ package diverge
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/ServiceWeaver/weaver/weavertest"
@@ -43,13 +42,14 @@ func (rec *errorRecorder) Fatal(args ...any) {
 }
 
 // TestFailer demonstrates that we only propagate constructor errors in
-// singleprocess mode. In multiprocess mode, if a constructor returns an error,
+// Local mode. In non-local mode, if a constructor returns an error,
 // the entire process crashes. This causes us to get a non-nil network error.
 func TestFailer(t *testing.T) {
-	for _, single := range []bool{true, false} {
-		t.Run(fmt.Sprintf("Single=%v", single), func(t *testing.T) {
+	for _, mode := range weavertest.AllModes() {
+		t.Run(mode.String(), func(t *testing.T) {
 			recorder := &errorRecorder{t, nil}
-			weavertest.Run(recorder, weavertest.Options{SingleProcess: single}, func(f Failer) {})
+			weavertest.Run(recorder, mode, weavertest.Options{}, func(f Failer) {})
+			single := (mode == weavertest.Local)
 			if want, got := single, errors.Is(recorder.err, ErrFailed); want != got {
 				t.Fatalf("expecting Is(ErrFailed) = %v, got %v for error %v", want, got, recorder.err)
 			}
@@ -57,15 +57,16 @@ func TestFailer(t *testing.T) {
 	}
 }
 
-// TestDealiasing demonstrates that pointers are only de-aliased in multiprocess mode.
+// TestDealiasing demonstrates that pointers are only de-aliased when we use RPCs.
 func TestDealiasing(t *testing.T) {
-	for _, single := range []bool{true, false} {
-		t.Run(fmt.Sprintf("Single=%v", single), func(t *testing.T) {
-			weavertest.Run(t, weavertest.Options{SingleProcess: single}, func(p Pointer) {
+	for _, mode := range weavertest.AllModes() {
+		t.Run(mode.String(), func(t *testing.T) {
+			weavertest.Run(t, mode, weavertest.Options{}, func(p Pointer) {
 				pair, err := p.Get(context.Background())
 				if err != nil {
 					t.Fatal(err)
 				}
+				single := (mode == weavertest.Local)
 				if want, got := single, (pair.X == pair.Y); want != got {
 					t.Fatalf("expecting aliasing = %v, got %v", want, got)
 				}
@@ -74,12 +75,13 @@ func TestDealiasing(t *testing.T) {
 	}
 }
 
-// TestCustomErrors* demonstrates that custom Is methods are ignored in multiprocess mode.
+// TestCustomErrors* demonstrates that custom Is methods are ignored when using RPCs.
 func TestCustomErrors(t *testing.T) {
-	for _, single := range []bool{true, false} {
-		t.Run(fmt.Sprintf("Single=%v", single), func(t *testing.T) {
-			weavertest.Run(t, weavertest.Options{SingleProcess: single}, func(e Errer) {
+	for _, mode := range weavertest.AllModes() {
+		t.Run(mode.String(), func(t *testing.T) {
+			weavertest.Run(t, mode, weavertest.Options{}, func(e Errer) {
 				err := e.Err(context.Background(), 1)
+				single := (mode == weavertest.Local)
 				if want, got := single, errors.Is(err, IntError{2}); want != got {
 					t.Fatalf("expecting Is(IntError{2}) = %v, got %v for error %v", want, got, err)
 				}

--- a/weavertest/internal/generate/app_test.go
+++ b/weavertest/internal/generate/app_test.go
@@ -17,7 +17,6 @@ package generate
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -28,7 +27,7 @@ import (
 // TODO(mwhittaker): Induce an error in the encoding, decoding, and RPC call.
 func TestErrors(t *testing.T) {
 	ctx := context.Background()
-	weavertest.Run(t, weavertest.Options{}, func(client testApp) {
+	weavertest.Run(t, weavertest.Multi, weavertest.Options{}, func(client testApp) {
 		// Trigger an application error. Verify that an application error
 		// is returned.
 		x, err := client.Get(ctx, "foo", appError)
@@ -57,10 +56,10 @@ func TestErrors(t *testing.T) {
 }
 
 func TestPointers(t *testing.T) {
-	for _, single := range []bool{true, false} {
-		t.Run(fmt.Sprintf("Single=%t", single), func(t *testing.T) {
+	for _, mode := range weavertest.AllModes() {
+		t.Run(mode.String(), func(t *testing.T) {
 			ctx := context.Background()
-			weavertest.Run(t, weavertest.Options{SingleProcess: single}, func(client testApp) {
+			weavertest.Run(t, mode, weavertest.Options{}, func(client testApp) {
 				// Check pointer passing for nil pointer.
 				got, err := client.IncPointer(ctx, nil)
 				if err != nil {

--- a/weavertest/internal/protos/ping_test.go
+++ b/weavertest/internal/protos/ping_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestPingPong(t *testing.T) {
 	ctx := context.Background()
-	weavertest.Run(t, weavertest.Options{}, func(pingponger PingPonger) {
+	weavertest.Run(t, weavertest.Local, weavertest.Options{}, func(pingponger PingPonger) {
 		pong, err := pingponger.Ping(ctx, &Ping{Id: 42})
 		if err != nil {
 			t.Fatal(err)

--- a/weavertest/internal/protos/ping_test.go
+++ b/weavertest/internal/protos/ping_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestPingPong(t *testing.T) {
 	ctx := context.Background()
-	weavertest.Run(t, weavertest.Local, weavertest.Options{}, func(pingponger PingPonger) {
+	weavertest.Run(t, weavertest.Multi, weavertest.Options{}, func(pingponger PingPonger) {
 		pong, err := pingponger.Ping(ctx, &Ping{Id: 42})
 		if err != nil {
 			t.Fatal(err)

--- a/weavertest/multi.go
+++ b/weavertest/multi.go
@@ -40,7 +40,7 @@ const matchNothingRE = "a^" // Regular expression that never matches
 // component level configs. config is allowed to be empty.
 //
 // Future extension: allow options so the user can control collocation/replication/etc.
-func initMultiProcess(ctx context.Context, name string, isBench bool, config string, logWriter func(*protos.LogEntry)) (context.Context, func() error, error) {
+func initMultiProcess(ctx context.Context, name string, isBench bool, mode Mode, config string, logWriter func(*protos.LogEntry)) (context.Context, func() error, error) {
 	bootstrap, err := runtime.GetBootstrap(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -95,7 +95,7 @@ func initMultiProcess(ctx context.Context, name string, isBench bool, config str
 	}
 
 	// Launch the deployer.
-	d := newDeployer(ctx, wlet, appConfig, logWriter)
+	d := newDeployer(ctx, wlet, appConfig, mode, logWriter)
 	if err := d.start(config); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
The "SingleProcess bool" option has been replaced by a mode that can be either Local or Multi or RPC. The RPC mode places every component in the testing process, but uses RPCs for method calls. This mode is typically useful when collecting profiles or coverage data that should include RPC costs. (Multi runs will also contain RPC costs, but are harder to profile since their execution is split across multiple processes.)

The mode argument has also been moved out of weavertest.Options{} so it no longer has a default value and the caller is forced to specify whether they want a Local or Multi run.