### PR TITLE
Change simple_test Getpid() to use cached pid value.

### DIFF
--- a/weavertest/internal/simple/simple.go
+++ b/weavertest/internal/simple/simple.go
@@ -64,8 +64,10 @@ type destination struct {
 	mu sync.Mutex
 }
 
+var pid = os.Getpid()
+
 func (d *destination) Getpid(_ context.Context) (int, error) {
-	return os.Getpid(), nil
+	return pid, nil
 }
 
 // Record adds a message.


### PR DESCRIPTION
Previously we called os.Getpid() every time a component was asked to report its pid. We now cache this value in a global variable which makes the component method much faster (from ~750ns to ~16ns) and allows us to focus on runtime overheads when profiling a component call.