### PR TITLE
Fold weavertest Mode and Options into a single Runner object.

### DIFF
--- a/examples/chat/sqlstore_test.go
+++ b/examples/chat/sqlstore_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestFeed(t *testing.T) {
-	weavertest.Run(t, weavertest.Local, weavertest.Options{}, func(store SQLStore) {
+	weavertest.Local.Run(t, func(store SQLStore) {
 		ctx := context.Background()
 
 		// Run the test.
@@ -81,7 +81,7 @@ func TestFeed(t *testing.T) {
 }
 
 func TestImage(t *testing.T) {
-	weavertest.Run(t, weavertest.Local, weavertest.Options{}, func(store SQLStore) {
+	weavertest.Local.Run(t, func(store SQLStore) {
 		ctx := context.Background()
 
 		// Create thread with an image in the initial post.

--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -339,7 +339,7 @@ func BenchmarkPing(b *testing.B) {
 		}
 		name := fmt.Sprintf("chain=%02d,size=%s", bm.numChainedComponents, size)
 		b.Run(name, func(b *testing.B) {
-			weavertest.Run(b, weavertest.Local, weavertest.Options{}, func(pObj Ping1) {
+			weavertest.Local.Run(b, func(pObj Ping1) {
 				if bm.componentSize == complex {
 					payload := genWorkload(1)[0]
 					for i := 0; i < b.N; i++ {
@@ -370,7 +370,7 @@ func init() {
 func TestBenchmark(t *testing.T) {
 	// Test plan: Send a ping request from Component1 to Component10. Verify that
 	// the response is the same as the request when we send both simple and complex payloads.
-	weavertest.Run(t, weavertest.Local, weavertest.Options{}, func(ping Ping1) {
+	weavertest.Local.Run(t, func(ping Ping1) {
 		ctx := context.Background()
 		depth := 10
 

--- a/weavertest/deployer.go
+++ b/weavertest/deployer.go
@@ -52,7 +52,7 @@ const DefaultReplication = 2
 type deployer struct {
 	ctx        context.Context
 	ctxCancel  context.CancelFunc
-	runner     Runner
+	runner     Runner                 // holds runner-specific info like config
 	wlet       *protos.EnvelopeInfo   // info for subprocesses
 	config     *protos.AppConfig      // application config
 	colocation map[string]string      // maps component to group

--- a/weavertest/init.go
+++ b/weavertest/init.go
@@ -74,12 +74,6 @@ func (r Runner) Name() string {
 	return r.name
 }
 
-// SingleProcess returns true iff the runner will run all components in a single process.
-func (r Runner) SingleProcess() bool { return !r.multi }
-
-// UsesRPC returns true iff the runner uses RPCs for communication.
-func (r Runner) UsesRPC() bool { return r.multi || r.forceRPC }
-
 //go:generate ../cmd/weaver/weaver generate
 
 // testMain is the component implementation used in tests.

--- a/weavertest/init.go
+++ b/weavertest/init.go
@@ -138,7 +138,7 @@ func (r Runner) Run(t testing.TB, testBody any) {
 	}()
 
 	if !r.multi && !r.forceRPC {
-		ctx = initSingleProcess(ctx, r.config)
+		ctx = initSingleProcessLocal(ctx, r.config)
 	} else {
 		logger := logging.NewTestLogger(t, testing.Verbose())
 		multiCtx, multiCleanup, err := initMultiProcess(ctx, t.Name(), isBench, r, logger.Log)

--- a/weavertest/init.go
+++ b/weavertest/init.go
@@ -28,48 +28,57 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 )
 
-// Mode controls where components live and how their methods are invoked.
-type Mode uint8
+// Runner runs user-supplied testing code as a weaver application.
+type Runner struct {
+	multi    bool // Use multiple processes
+	forceRPC bool // Use RPCs even for local calls
+	name     string
+	config   string
+}
 
-const (
-	// Local places all components in the same process and uses local procedure calls
-	// for method invocations.
-	// This is the default value.
-	Local Mode = iota
+var (
+	// Local is a Runner that places all components in the same process
+	// and uses local procedure calls for method invocations.
+	Local = Runner{name: "Local"}
 
-	// RPC places all components in the same process and uses RPCs for method invocations.
-	RPC
+	// RPC is a Runner that places all components in the same process
+	// and uses RPCs for method invocations.
+	RPC = Runner{multi: false, forceRPC: true, name: "RPC"}
 
-	// Multi places all components in different process (unless explicitly colocated)
-	// and uses RPCs for method invocations on remote components and local procedure calls
-	// for method invocations on colocated components.
-	Multi
+	// Multi is a Runner that places all components in different
+	// process (unless explicitly colocated) and uses RPCs for method
+	// invocations on remote components and local procedure calls for
+	// method invocations on colocated components.
+	Multi = Runner{multi: true, name: "Multi"}
 )
 
-// String returns a string representation of a Mode, suitable for using as sub-test names.
-func (m Mode) String() string {
-	switch m {
-	case RPC:
-		return "RPC"
-	case Local:
-		return "Local"
-	case Multi:
-		return "Multi"
-	default:
-		panic(fmt.Sprintf("unknown mode %d", m))
+// AllRunners returns a slice of all builtin weavertest runners.
+func AllRunners() []Runner { return []Runner{Local, RPC, Multi} }
+
+// WithName returns a new Runner with the specified name. It is useful
+// when the runner has been adjusted and is no longer identical to one
+// of the predefined runners.
+func (r Runner) WithName(name string) Runner { r.name = name; return r }
+
+// WithConfig returns a new Runner with the specified Service Weaver
+// configuration. The config value passed here is identical to what
+// might be found in a Service Weaver config file. It can contain
+// application level as well as component level configuration.
+func (r Runner) WithConfig(config string) Runner { r.config = config; return r }
+
+// Name returns the runner name. It is suitable for use as a sub-test or sub-benchmark name.
+func (r Runner) Name() string {
+	if r.name == "" {
+		return "Default"
 	}
+	return r.name
 }
 
-// AllModes returns a slice of all supported weavertest modes.
-func AllModes() []Mode { return []Mode{Local, RPC, Multi} }
+// SingleProcess returns true iff the runner will run all components in a single process.
+func (r Runner) SingleProcess() bool { return !r.multi }
 
-// Options configure weavertest.Init.
-type Options struct {
-	// Config contains configuration identical to what might be found in a
-	// Service Weaver config file. It can contain application level as well as component
-	// level configuration. Config is allowed to be empty.
-	Config string
-}
+// UsesRPC returns true iff the runner uses RPCs for communication.
+func (r Runner) UsesRPC() bool { return r.multi || r.forceRPC }
 
 //go:generate ../cmd/weaver/weaver generate
 
@@ -89,7 +98,7 @@ type testMainInterface interface{}
 // and callTestBody with these components.
 //
 //	func TestFoo(t *testing.T) {
-//	    weavertest.Run(t, weavertest.Local, weavertest.Options{}, func(foo Foo, bar Bar) {
+//	    weavertest.Local.Run(t, func(foo Foo, bar Bar) {
 //		// Test foo and bar ...
 //	    })
 //	}
@@ -99,10 +108,7 @@ type testMainInterface interface{}
 //	func(ComponentType1)
 //	func(ComponentType, ComponentType2)
 //	...
-//
-// mode controls which processes host which components and how the
-// components communicate.
-func Run(t testing.TB, mode Mode, opts Options, testBody any) {
+func (r Runner) Run(t testing.TB, testBody any) {
 	_, isBench := t.(*testing.B)
 	t.Helper()
 	runner, err := checkRunFunc(testBody)
@@ -131,11 +137,11 @@ func Run(t testing.TB, mode Mode, opts Options, testBody any) {
 		}
 	}()
 
-	if mode == Local {
-		ctx = initSingleProcess(ctx, opts.Config)
+	if !r.multi && !r.forceRPC {
+		ctx = initSingleProcess(ctx, r.config)
 	} else {
 		logger := logging.NewTestLogger(t, testing.Verbose())
-		multiCtx, multiCleanup, err := initMultiProcess(ctx, t.Name(), isBench, mode, opts.Config, logger.Log)
+		multiCtx, multiCleanup, err := initMultiProcess(ctx, t.Name(), isBench, r, logger.Log)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/weavertest/internal/deploy/deploy_test.go
+++ b/weavertest/internal/deploy/deploy_test.go
@@ -31,7 +31,7 @@ func TestReplicated(t *testing.T) {
 
 	// Instruct the weavertest deployer to replicate each component. Note that each
 	// component should be replicated weavertest.DefaultReplication times.
-	weavertest.Run(t, weavertest.Multi, weavertest.Options{}, func(w deploy.Widget) {
+	weavertest.Multi.Run(t, func(w deploy.Widget) {
 		dir := t.TempDir()
 		w.Use(ctx, dir)
 		// Verify that deployed processes started.

--- a/weavertest/internal/diverge/diverge_test.go
+++ b/weavertest/internal/diverge/diverge_test.go
@@ -49,8 +49,8 @@ func TestFailer(t *testing.T) {
 		t.Run(runner.Name(), func(t *testing.T) {
 			recorder := &errorRecorder{t, nil}
 			runner.Run(recorder, func(f Failer) {})
-			single := !runner.UsesRPC()
-			if want, got := single, errors.Is(recorder.err, ErrFailed); want != got {
+			localCalls := runner == weavertest.Local
+			if want, got := localCalls, errors.Is(recorder.err, ErrFailed); want != got {
 				t.Fatalf("expecting Is(ErrFailed) = %v, got %v for error %v", want, got, recorder.err)
 			}
 		})
@@ -66,8 +66,8 @@ func TestDealiasing(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				single := !runner.UsesRPC()
-				if want, got := single, (pair.X == pair.Y); want != got {
+				localCalls := runner == weavertest.Local
+				if want, got := localCalls, (pair.X == pair.Y); want != got {
 					t.Fatalf("expecting aliasing = %v, got %v", want, got)
 				}
 			})
@@ -81,8 +81,8 @@ func TestCustomErrors(t *testing.T) {
 		t.Run(runner.Name(), func(t *testing.T) {
 			runner.Run(t, func(e Errer) {
 				err := e.Err(context.Background(), 1)
-				single := !runner.UsesRPC()
-				if want, got := single, errors.Is(err, IntError{2}); want != got {
+				localCalls := runner == weavertest.Local
+				if want, got := localCalls, errors.Is(err, IntError{2}); want != got {
 					t.Fatalf("expecting Is(IntError{2}) = %v, got %v for error %v", want, got, err)
 				}
 			})

--- a/weavertest/internal/diverge/diverge_test.go
+++ b/weavertest/internal/diverge/diverge_test.go
@@ -45,11 +45,11 @@ func (rec *errorRecorder) Fatal(args ...any) {
 // Local mode. In non-local mode, if a constructor returns an error,
 // the entire process crashes. This causes us to get a non-nil network error.
 func TestFailer(t *testing.T) {
-	for _, mode := range weavertest.AllModes() {
-		t.Run(mode.String(), func(t *testing.T) {
+	for _, runner := range weavertest.AllRunners() {
+		t.Run(runner.Name(), func(t *testing.T) {
 			recorder := &errorRecorder{t, nil}
-			weavertest.Run(recorder, mode, weavertest.Options{}, func(f Failer) {})
-			single := (mode == weavertest.Local)
+			runner.Run(recorder, func(f Failer) {})
+			single := !runner.UsesRPC()
 			if want, got := single, errors.Is(recorder.err, ErrFailed); want != got {
 				t.Fatalf("expecting Is(ErrFailed) = %v, got %v for error %v", want, got, recorder.err)
 			}
@@ -59,14 +59,14 @@ func TestFailer(t *testing.T) {
 
 // TestDealiasing demonstrates that pointers are only de-aliased when we use RPCs.
 func TestDealiasing(t *testing.T) {
-	for _, mode := range weavertest.AllModes() {
-		t.Run(mode.String(), func(t *testing.T) {
-			weavertest.Run(t, mode, weavertest.Options{}, func(p Pointer) {
+	for _, runner := range weavertest.AllRunners() {
+		t.Run(runner.Name(), func(t *testing.T) {
+			runner.Run(t, func(p Pointer) {
 				pair, err := p.Get(context.Background())
 				if err != nil {
 					t.Fatal(err)
 				}
-				single := (mode == weavertest.Local)
+				single := !runner.UsesRPC()
 				if want, got := single, (pair.X == pair.Y); want != got {
 					t.Fatalf("expecting aliasing = %v, got %v", want, got)
 				}
@@ -77,11 +77,11 @@ func TestDealiasing(t *testing.T) {
 
 // TestCustomErrors* demonstrates that custom Is methods are ignored when using RPCs.
 func TestCustomErrors(t *testing.T) {
-	for _, mode := range weavertest.AllModes() {
-		t.Run(mode.String(), func(t *testing.T) {
-			weavertest.Run(t, mode, weavertest.Options{}, func(e Errer) {
+	for _, runner := range weavertest.AllRunners() {
+		t.Run(runner.Name(), func(t *testing.T) {
+			runner.Run(t, func(e Errer) {
 				err := e.Err(context.Background(), 1)
-				single := (mode == weavertest.Local)
+				single := !runner.UsesRPC()
 				if want, got := single, errors.Is(err, IntError{2}); want != got {
 					t.Fatalf("expecting Is(IntError{2}) = %v, got %v for error %v", want, got, err)
 				}

--- a/weavertest/internal/generate/app_test.go
+++ b/weavertest/internal/generate/app_test.go
@@ -27,7 +27,7 @@ import (
 // TODO(mwhittaker): Induce an error in the encoding, decoding, and RPC call.
 func TestErrors(t *testing.T) {
 	ctx := context.Background()
-	weavertest.Run(t, weavertest.Multi, weavertest.Options{}, func(client testApp) {
+	weavertest.Multi.Run(t, func(client testApp) {
 		// Trigger an application error. Verify that an application error
 		// is returned.
 		x, err := client.Get(ctx, "foo", appError)
@@ -56,10 +56,10 @@ func TestErrors(t *testing.T) {
 }
 
 func TestPointers(t *testing.T) {
-	for _, mode := range weavertest.AllModes() {
-		t.Run(mode.String(), func(t *testing.T) {
+	for _, runner := range weavertest.AllRunners() {
+		t.Run(runner.Name(), func(t *testing.T) {
 			ctx := context.Background()
-			weavertest.Run(t, mode, weavertest.Options{}, func(client testApp) {
+			runner.Run(t, func(client testApp) {
 				// Check pointer passing for nil pointer.
 				got, err := client.IncPointer(ctx, nil)
 				if err != nil {

--- a/weavertest/internal/protos/ping_test.go
+++ b/weavertest/internal/protos/ping_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestPingPong(t *testing.T) {
 	ctx := context.Background()
-	weavertest.Run(t, weavertest.Multi, weavertest.Options{}, func(pingponger PingPonger) {
+	weavertest.Multi.Run(t, func(pingponger PingPonger) {
 		pong, err := pingponger.Ping(ctx, &Ping{Id: 42})
 		if err != nil {
 			t.Fatal(err)

--- a/weavertest/internal/simple/simple_test.go
+++ b/weavertest/internal/simple/simple_test.go
@@ -40,13 +40,13 @@ func TestOneComponent(t *testing.T) {
 				cPid := os.Getpid()
 				dstPid, _ := dst.Getpid(context.Background())
 				sameProcess := cPid == dstPid
-				if runner.SingleProcess() {
-					if !sameProcess {
-						t.Fatal("the root and the dst components should run in the same process")
-					}
-				} else {
+				if runner == weavertest.Multi {
 					if sameProcess {
 						t.Fatal("the root and the dst components should run in different processes")
+					}
+				} else {
+					if !sameProcess {
+						t.Fatal("the root and the dst components should run in the same process")
 					}
 				}
 			})
@@ -114,7 +114,7 @@ func TestServer(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Could not fetch proxy address: %v", err)
 				}
-				if runner.SingleProcess() && proxy != "" {
+				if runner != weavertest.Multi && proxy != "" {
 					t.Fatalf("Unexpected proxy %q", proxy)
 				}
 

--- a/weavertest/multi.go
+++ b/weavertest/multi.go
@@ -40,7 +40,7 @@ const matchNothingRE = "a^" // Regular expression that never matches
 // component level configs. config is allowed to be empty.
 //
 // Future extension: allow options so the user can control collocation/replication/etc.
-func initMultiProcess(ctx context.Context, name string, isBench bool, mode Mode, config string, logWriter func(*protos.LogEntry)) (context.Context, func() error, error) {
+func initMultiProcess(ctx context.Context, name string, isBench bool, runner Runner, logWriter func(*protos.LogEntry)) (context.Context, func() error, error) {
 	bootstrap, err := runtime.GetBootstrap(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -66,9 +66,9 @@ func initMultiProcess(ctx context.Context, name string, isBench bool, mode Mode,
 
 	// Construct AppConfig and EnvelopeInfo.
 	appConfig := &protos.AppConfig{}
-	if config != "" {
+	if runner.config != "" {
 		var err error
-		appConfig, err = runtime.ParseConfig("[testconfig]", config, codegen.ComponentConfigValidator)
+		appConfig, err = runtime.ParseConfig("[testconfig]", runner.config, codegen.ComponentConfigValidator)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -95,8 +95,8 @@ func initMultiProcess(ctx context.Context, name string, isBench bool, mode Mode,
 	}
 
 	// Launch the deployer.
-	d := newDeployer(ctx, wlet, appConfig, mode, logWriter)
-	if err := d.start(config); err != nil {
+	d := newDeployer(ctx, wlet, appConfig, runner, logWriter)
+	if err := d.start(); err != nil {
 		return nil, nil, err
 	}
 	return d.ctx, d.cleanup, nil

--- a/weavertest/single.go
+++ b/weavertest/single.go
@@ -21,12 +21,12 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime"
 )
 
-// initSingleProcess initializes a brand new single-process execution environment.
+// initSingleProcessLocal initializes a brand new single-process execution environment.
 //
 // config contains configuration identical to what might be found in a file passed
 // when deploying an application. It can contain application level as well as
 // component level configs. config is allowed to be empty.
-func initSingleProcess(ctx context.Context, config string) context.Context {
+func initSingleProcessLocal(ctx context.Context, config string) context.Context {
 	return context.WithValue(ctx, runtime.BootstrapKey{}, runtime.Bootstrap{
 		TestConfig: config,
 		Quiet:      !testing.Verbose(),


### PR DESCRIPTION
Previously, the user would type something like:

```
weavertest.Run(t, weavertest.Local, weavertest.Options{}, func(...) {
  ...
})
```

They can now just get a suitable Runner object and call Run() on it:

```
weavertest.Local.Run(t, func(...) {
  ...
})
```

Options are now set via "With<OptionName>" methods on a Runner. These methods return a new Runner and therefore multiple option setting calls can be chained.