### PR TITLE
Small cleanups of "weaver generate" checks.

### DIFF
--- a/examples/chat/weaver_gen.go
+++ b/examples/chat/weaver_gen.go
@@ -14,7 +14,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/chat/weaver_gen.go
+++ b/examples/chat/weaver_gen.go
@@ -78,16 +78,16 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[ImageScaler] = &scaler{}
-var _ weaver.InstanceOf[LocalCache] = &localCache{}
-var _ weaver.InstanceOf[weaver.Main] = &server{}
-var _ weaver.InstanceOf[SQLStore] = &sqlStore{}
+var _ weaver.InstanceOf[ImageScaler] = (*scaler)(nil)
+var _ weaver.InstanceOf[LocalCache] = (*localCache)(nil)
+var _ weaver.InstanceOf[weaver.Main] = (*server)(nil)
+var _ weaver.InstanceOf[SQLStore] = (*sqlStore)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &scaler{}
-var _ weaver.Unrouted = &localCache{}
-var _ weaver.Unrouted = &server{}
-var _ weaver.Unrouted = &sqlStore{}
+var _ weaver.Unrouted = (*scaler)(nil)
+var _ weaver.Unrouted = (*localCache)(nil)
+var _ weaver.Unrouted = (*server)(nil)
+var _ weaver.Unrouted = (*sqlStore)(nil)
 
 // Local stub implementations.
 
@@ -97,7 +97,7 @@ type imageScaler_local_stub struct {
 }
 
 // Check that imageScaler_local_stub implements the ImageScaler interface.
-var _ ImageScaler = &imageScaler_local_stub{}
+var _ ImageScaler = (*imageScaler_local_stub)(nil)
 
 func (s imageScaler_local_stub) Scale(ctx context.Context, a0 []byte, a1 int, a2 int) (r0 []byte, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -122,7 +122,7 @@ type localCache_local_stub struct {
 }
 
 // Check that localCache_local_stub implements the LocalCache interface.
-var _ LocalCache = &localCache_local_stub{}
+var _ LocalCache = (*localCache_local_stub)(nil)
 
 func (s localCache_local_stub) Get(ctx context.Context, a0 string) (r0 string, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -164,7 +164,7 @@ type main_local_stub struct {
 }
 
 // Check that main_local_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_local_stub{}
+var _ weaver.Main = (*main_local_stub)(nil)
 
 type sQLStore_local_stub struct {
 	impl   SQLStore
@@ -172,7 +172,7 @@ type sQLStore_local_stub struct {
 }
 
 // Check that sQLStore_local_stub implements the SQLStore interface.
-var _ SQLStore = &sQLStore_local_stub{}
+var _ SQLStore = (*sQLStore_local_stub)(nil)
 
 func (s sQLStore_local_stub) CreatePost(ctx context.Context, a0 string, a1 time.Time, a2 ThreadID, a3 string) (err error) {
 	span := trace.SpanFromContext(ctx)
@@ -250,7 +250,7 @@ type imageScaler_client_stub struct {
 }
 
 // Check that imageScaler_client_stub implements the ImageScaler interface.
-var _ ImageScaler = &imageScaler_client_stub{}
+var _ ImageScaler = (*imageScaler_client_stub)(nil)
 
 func (s imageScaler_client_stub) Scale(ctx context.Context, a0 []byte, a1 int, a2 int) (r0 []byte, err error) {
 	// Update metrics.
@@ -320,7 +320,7 @@ type localCache_client_stub struct {
 }
 
 // Check that localCache_client_stub implements the LocalCache interface.
-var _ LocalCache = &localCache_client_stub{}
+var _ LocalCache = (*localCache_client_stub)(nil)
 
 func (s localCache_client_stub) Get(ctx context.Context, a0 string) (r0 string, err error) {
 	// Update metrics.
@@ -442,7 +442,7 @@ type main_client_stub struct {
 }
 
 // Check that main_client_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_client_stub{}
+var _ weaver.Main = (*main_client_stub)(nil)
 
 type sQLStore_client_stub struct {
 	stub                codegen.Stub
@@ -453,7 +453,7 @@ type sQLStore_client_stub struct {
 }
 
 // Check that sQLStore_client_stub implements the SQLStore interface.
-var _ SQLStore = &sQLStore_client_stub{}
+var _ SQLStore = (*sQLStore_client_stub)(nil)
 
 func (s sQLStore_client_stub) CreatePost(ctx context.Context, a0 string, a1 time.Time, a2 ThreadID, a3 string) (err error) {
 	// Update metrics.
@@ -689,7 +689,7 @@ type imageScaler_server_stub struct {
 }
 
 // Check that imageScaler_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &imageScaler_server_stub{}
+var _ codegen.Server = (*imageScaler_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s imageScaler_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -736,7 +736,7 @@ type localCache_server_stub struct {
 }
 
 // Check that localCache_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &localCache_server_stub{}
+var _ codegen.Server = (*localCache_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s localCache_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -807,7 +807,7 @@ type main_server_stub struct {
 }
 
 // Check that main_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &main_server_stub{}
+var _ codegen.Server = (*main_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s main_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -823,7 +823,7 @@ type sQLStore_server_stub struct {
 }
 
 // Check that sQLStore_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &sQLStore_server_stub{}
+var _ codegen.Server = (*sQLStore_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s sQLStore_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -958,7 +958,7 @@ func (s sQLStore_server_stub) getImage(ctx context.Context, args []byte) (res []
 
 // AutoMarshal implementations.
 
-var _ codegen.AutoMarshal = &Post{}
+var _ codegen.AutoMarshal = (*Post)(nil)
 
 type __is_Post[T ~struct {
 	weaver.AutoMarshal
@@ -993,7 +993,7 @@ func (x *Post) WeaverUnmarshal(dec *codegen.Decoder) {
 	*(*int64)(&x.ImageID) = dec.Int64()
 }
 
-var _ codegen.AutoMarshal = &Thread{}
+var _ codegen.AutoMarshal = (*Thread)(nil)
 
 type __is_Thread[T ~struct {
 	weaver.AutoMarshal

--- a/examples/collatz/weaver_gen.go
+++ b/examples/collatz/weaver_gen.go
@@ -58,14 +58,14 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[Even] = &even{}
-var _ weaver.InstanceOf[weaver.Main] = &server{}
-var _ weaver.InstanceOf[Odd] = &odd{}
+var _ weaver.InstanceOf[Even] = (*even)(nil)
+var _ weaver.InstanceOf[weaver.Main] = (*server)(nil)
+var _ weaver.InstanceOf[Odd] = (*odd)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &even{}
-var _ weaver.Unrouted = &server{}
-var _ weaver.Unrouted = &odd{}
+var _ weaver.Unrouted = (*even)(nil)
+var _ weaver.Unrouted = (*server)(nil)
+var _ weaver.Unrouted = (*odd)(nil)
 
 // Local stub implementations.
 
@@ -75,7 +75,7 @@ type even_local_stub struct {
 }
 
 // Check that even_local_stub implements the Even interface.
-var _ Even = &even_local_stub{}
+var _ Even = (*even_local_stub)(nil)
 
 func (s even_local_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -100,7 +100,7 @@ type main_local_stub struct {
 }
 
 // Check that main_local_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_local_stub{}
+var _ weaver.Main = (*main_local_stub)(nil)
 
 type odd_local_stub struct {
 	impl   Odd
@@ -108,7 +108,7 @@ type odd_local_stub struct {
 }
 
 // Check that odd_local_stub implements the Odd interface.
-var _ Odd = &odd_local_stub{}
+var _ Odd = (*odd_local_stub)(nil)
 
 func (s odd_local_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -135,7 +135,7 @@ type even_client_stub struct {
 }
 
 // Check that even_client_stub implements the Even interface.
-var _ Even = &even_client_stub{}
+var _ Even = (*even_client_stub)(nil)
 
 func (s even_client_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
 	// Update metrics.
@@ -199,7 +199,7 @@ type main_client_stub struct {
 }
 
 // Check that main_client_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_client_stub{}
+var _ weaver.Main = (*main_client_stub)(nil)
 
 type odd_client_stub struct {
 	stub      codegen.Stub
@@ -207,7 +207,7 @@ type odd_client_stub struct {
 }
 
 // Check that odd_client_stub implements the Odd interface.
-var _ Odd = &odd_client_stub{}
+var _ Odd = (*odd_client_stub)(nil)
 
 func (s odd_client_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
 	// Update metrics.
@@ -274,7 +274,7 @@ type even_server_stub struct {
 }
 
 // Check that even_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &even_server_stub{}
+var _ codegen.Server = (*even_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s even_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -317,7 +317,7 @@ type main_server_stub struct {
 }
 
 // Check that main_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &main_server_stub{}
+var _ codegen.Server = (*main_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s main_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -333,7 +333,7 @@ type odd_server_stub struct {
 }
 
 // Check that odd_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &odd_server_stub{}
+var _ codegen.Server = (*odd_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s odd_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/examples/collatz/weaver_gen.go
+++ b/examples/collatz/weaver_gen.go
@@ -13,7 +13,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/factors/weaver_gen.go
+++ b/examples/factors/weaver_gen.go
@@ -13,7 +13,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/factors/weaver_gen.go
+++ b/examples/factors/weaver_gen.go
@@ -48,12 +48,12 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[Factorer] = &factorer{}
-var _ weaver.InstanceOf[weaver.Main] = &server{}
+var _ weaver.InstanceOf[Factorer] = (*factorer)(nil)
+var _ weaver.InstanceOf[weaver.Main] = (*server)(nil)
 
 // weaver.Router checks.
-var _ weaver.RoutedBy[router] = &factorer{}
-var _ weaver.Unrouted = &server{}
+var _ weaver.RoutedBy[router] = (*factorer)(nil)
+var _ weaver.Unrouted = (*server)(nil)
 
 // Component "factorer", router "router" checks.
 var _ func(_ context.Context, x int) int = (&router{}).Factors // routed
@@ -66,7 +66,7 @@ type factorer_local_stub struct {
 }
 
 // Check that factorer_local_stub implements the Factorer interface.
-var _ Factorer = &factorer_local_stub{}
+var _ Factorer = (*factorer_local_stub)(nil)
 
 func (s factorer_local_stub) Factors(ctx context.Context, a0 int) (r0 []int, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -91,7 +91,7 @@ type main_local_stub struct {
 }
 
 // Check that main_local_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_local_stub{}
+var _ weaver.Main = (*main_local_stub)(nil)
 
 // Client stub implementations.
 
@@ -101,7 +101,7 @@ type factorer_client_stub struct {
 }
 
 // Check that factorer_client_stub implements the Factorer interface.
-var _ Factorer = &factorer_client_stub{}
+var _ Factorer = (*factorer_client_stub)(nil)
 
 func (s factorer_client_stub) Factors(ctx context.Context, a0 int) (r0 []int, err error) {
 	// Update metrics.
@@ -168,7 +168,7 @@ type main_client_stub struct {
 }
 
 // Check that main_client_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_client_stub{}
+var _ weaver.Main = (*main_client_stub)(nil)
 
 // Server stub implementations.
 
@@ -178,7 +178,7 @@ type factorer_server_stub struct {
 }
 
 // Check that factorer_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &factorer_server_stub{}
+var _ codegen.Server = (*factorer_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s factorer_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -223,7 +223,7 @@ type main_server_stub struct {
 }
 
 // Check that main_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &main_server_stub{}
+var _ codegen.Server = (*main_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s main_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/examples/hello/weaver_gen.go
+++ b/examples/hello/weaver_gen.go
@@ -47,12 +47,12 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[weaver.Main] = &app{}
-var _ weaver.InstanceOf[Reverser] = &reverser{}
+var _ weaver.InstanceOf[weaver.Main] = (*app)(nil)
+var _ weaver.InstanceOf[Reverser] = (*reverser)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &app{}
-var _ weaver.Unrouted = &reverser{}
+var _ weaver.Unrouted = (*app)(nil)
+var _ weaver.Unrouted = (*reverser)(nil)
 
 // Local stub implementations.
 
@@ -62,7 +62,7 @@ type main_local_stub struct {
 }
 
 // Check that main_local_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_local_stub{}
+var _ weaver.Main = (*main_local_stub)(nil)
 
 type reverser_local_stub struct {
 	impl   Reverser
@@ -70,7 +70,7 @@ type reverser_local_stub struct {
 }
 
 // Check that reverser_local_stub implements the Reverser interface.
-var _ Reverser = &reverser_local_stub{}
+var _ Reverser = (*reverser_local_stub)(nil)
 
 func (s reverser_local_stub) Reverse(ctx context.Context, a0 string) (r0 string, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -96,7 +96,7 @@ type main_client_stub struct {
 }
 
 // Check that main_client_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_client_stub{}
+var _ weaver.Main = (*main_client_stub)(nil)
 
 type reverser_client_stub struct {
 	stub           codegen.Stub
@@ -104,7 +104,7 @@ type reverser_client_stub struct {
 }
 
 // Check that reverser_client_stub implements the Reverser interface.
-var _ Reverser = &reverser_client_stub{}
+var _ Reverser = (*reverser_client_stub)(nil)
 
 func (s reverser_client_stub) Reverse(ctx context.Context, a0 string) (r0 string, err error) {
 	// Update metrics.
@@ -171,7 +171,7 @@ type main_server_stub struct {
 }
 
 // Check that main_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &main_server_stub{}
+var _ codegen.Server = (*main_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s main_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -187,7 +187,7 @@ type reverser_server_stub struct {
 }
 
 // Check that reverser_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &reverser_server_stub{}
+var _ codegen.Server = (*reverser_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s reverser_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/examples/hello/weaver_gen.go
+++ b/examples/hello/weaver_gen.go
@@ -13,7 +13,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/adservice/weaver_gen.go
+++ b/examples/onlineboutique/adservice/weaver_gen.go
@@ -14,7 +14,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/adservice/weaver_gen.go
+++ b/examples/onlineboutique/adservice/weaver_gen.go
@@ -33,10 +33,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[T] = &impl{}
+var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &impl{}
+var _ weaver.Unrouted = (*impl)(nil)
 
 // Local stub implementations.
 
@@ -46,7 +46,7 @@ type t_local_stub struct {
 }
 
 // Check that t_local_stub implements the T interface.
-var _ T = &t_local_stub{}
+var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) GetAds(ctx context.Context, a0 []string) (r0 []Ad, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -73,7 +73,7 @@ type t_client_stub struct {
 }
 
 // Check that t_client_stub implements the T interface.
-var _ T = &t_client_stub{}
+var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) GetAds(ctx context.Context, a0 []string) (r0 []Ad, err error) {
 	// Update metrics.
@@ -135,7 +135,7 @@ type t_server_stub struct {
 }
 
 // Check that t_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &t_server_stub{}
+var _ codegen.Server = (*t_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s t_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -174,7 +174,7 @@ func (s t_server_stub) getAds(ctx context.Context, args []byte) (res []byte, err
 
 // AutoMarshal implementations.
 
-var _ codegen.AutoMarshal = &Ad{}
+var _ codegen.AutoMarshal = (*Ad)(nil)
 
 type __is_Ad[T ~struct {
 	weaver.AutoMarshal

--- a/examples/onlineboutique/cartservice/weaver_gen.go
+++ b/examples/onlineboutique/cartservice/weaver_gen.go
@@ -49,12 +49,12 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[T] = &impl{}
-var _ weaver.InstanceOf[cartCache] = &cartCacheImpl{}
+var _ weaver.InstanceOf[T] = (*impl)(nil)
+var _ weaver.InstanceOf[cartCache] = (*cartCacheImpl)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &impl{}
-var _ weaver.RoutedBy[cartCacheRouter] = &cartCacheImpl{}
+var _ weaver.Unrouted = (*impl)(nil)
+var _ weaver.RoutedBy[cartCacheRouter] = (*cartCacheImpl)(nil)
 
 // Component "cartCacheImpl", router "cartCacheRouter" checks.
 var _ func(_ context.Context, key string, value []CartItem) string = (&cartCacheRouter{}).Add // routed
@@ -69,7 +69,7 @@ type t_local_stub struct {
 }
 
 // Check that t_local_stub implements the T interface.
-var _ T = &t_local_stub{}
+var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) AddItem(ctx context.Context, a0 string, a1 CartItem) (err error) {
 	span := trace.SpanFromContext(ctx)
@@ -128,7 +128,7 @@ type cartCache_local_stub struct {
 }
 
 // Check that cartCache_local_stub implements the cartCache interface.
-var _ cartCache = &cartCache_local_stub{}
+var _ cartCache = (*cartCache_local_stub)(nil)
 
 func (s cartCache_local_stub) Add(ctx context.Context, a0 string, a1 []CartItem) (err error) {
 	span := trace.SpanFromContext(ctx)
@@ -191,7 +191,7 @@ type t_client_stub struct {
 }
 
 // Check that t_client_stub implements the T interface.
-var _ T = &t_client_stub{}
+var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) AddItem(ctx context.Context, a0 string, a1 CartItem) (err error) {
 	// Update metrics.
@@ -372,7 +372,7 @@ type cartCache_client_stub struct {
 }
 
 // Check that cartCache_client_stub implements the cartCache interface.
-var _ cartCache = &cartCache_client_stub{}
+var _ cartCache = (*cartCache_client_stub)(nil)
 
 func (s cartCache_client_stub) Add(ctx context.Context, a0 string, a1 []CartItem) (err error) {
 	// Update metrics.
@@ -557,7 +557,7 @@ type t_server_stub struct {
 }
 
 // Check that t_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &t_server_stub{}
+var _ codegen.Server = (*t_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s t_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -654,7 +654,7 @@ type cartCache_server_stub struct {
 }
 
 // Check that cartCache_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &cartCache_server_stub{}
+var _ codegen.Server = (*cartCache_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s cartCache_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -754,7 +754,7 @@ func (s cartCache_server_stub) remove(ctx context.Context, args []byte) (res []b
 
 // AutoMarshal implementations.
 
-var _ codegen.AutoMarshal = &CartItem{}
+var _ codegen.AutoMarshal = (*CartItem)(nil)
 
 type __is_CartItem[T ~struct {
 	weaver.AutoMarshal

--- a/examples/onlineboutique/cartservice/weaver_gen.go
+++ b/examples/onlineboutique/cartservice/weaver_gen.go
@@ -14,7 +14,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/checkoutservice/weaver_gen.go
+++ b/examples/onlineboutique/checkoutservice/weaver_gen.go
@@ -17,7 +17,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/checkoutservice/weaver_gen.go
+++ b/examples/onlineboutique/checkoutservice/weaver_gen.go
@@ -36,10 +36,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[T] = &impl{}
+var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &impl{}
+var _ weaver.Unrouted = (*impl)(nil)
 
 // Local stub implementations.
 
@@ -49,7 +49,7 @@ type t_local_stub struct {
 }
 
 // Check that t_local_stub implements the T interface.
-var _ T = &t_local_stub{}
+var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) PlaceOrder(ctx context.Context, a0 PlaceOrderRequest) (r0 types.Order, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -76,7 +76,7 @@ type t_client_stub struct {
 }
 
 // Check that t_client_stub implements the T interface.
-var _ T = &t_client_stub{}
+var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) PlaceOrder(ctx context.Context, a0 PlaceOrderRequest) (r0 types.Order, err error) {
 	// Update metrics.
@@ -138,7 +138,7 @@ type t_server_stub struct {
 }
 
 // Check that t_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &t_server_stub{}
+var _ codegen.Server = (*t_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s t_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -177,7 +177,7 @@ func (s t_server_stub) placeOrder(ctx context.Context, args []byte) (res []byte,
 
 // AutoMarshal implementations.
 
-var _ codegen.AutoMarshal = &PlaceOrderRequest{}
+var _ codegen.AutoMarshal = (*PlaceOrderRequest)(nil)
 
 type __is_PlaceOrderRequest[T ~struct {
 	weaver.AutoMarshal

--- a/examples/onlineboutique/currencyservice/weaver_gen.go
+++ b/examples/onlineboutique/currencyservice/weaver_gen.go
@@ -14,7 +14,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/currencyservice/weaver_gen.go
+++ b/examples/onlineboutique/currencyservice/weaver_gen.go
@@ -33,10 +33,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[T] = &impl{}
+var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &impl{}
+var _ weaver.Unrouted = (*impl)(nil)
 
 // Local stub implementations.
 
@@ -46,7 +46,7 @@ type t_local_stub struct {
 }
 
 // Check that t_local_stub implements the T interface.
-var _ T = &t_local_stub{}
+var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) Convert(ctx context.Context, a0 money.T, a1 string) (r0 money.T, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -91,7 +91,7 @@ type t_client_stub struct {
 }
 
 // Check that t_client_stub implements the T interface.
-var _ T = &t_client_stub{}
+var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) Convert(ctx context.Context, a0 money.T, a1 string) (r0 money.T, err error) {
 	// Update metrics.
@@ -203,7 +203,7 @@ type t_server_stub struct {
 }
 
 // Check that t_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &t_server_stub{}
+var _ codegen.Server = (*t_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s t_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/examples/onlineboutique/emailservice/weaver_gen.go
+++ b/examples/onlineboutique/emailservice/weaver_gen.go
@@ -14,7 +14,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/emailservice/weaver_gen.go
+++ b/examples/onlineboutique/emailservice/weaver_gen.go
@@ -33,10 +33,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[T] = &impl{}
+var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &impl{}
+var _ weaver.Unrouted = (*impl)(nil)
 
 // Local stub implementations.
 
@@ -46,7 +46,7 @@ type t_local_stub struct {
 }
 
 // Check that t_local_stub implements the T interface.
-var _ T = &t_local_stub{}
+var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) SendOrderConfirmation(ctx context.Context, a0 string, a1 types.Order) (err error) {
 	span := trace.SpanFromContext(ctx)
@@ -73,7 +73,7 @@ type t_client_stub struct {
 }
 
 // Check that t_client_stub implements the T interface.
-var _ T = &t_client_stub{}
+var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) SendOrderConfirmation(ctx context.Context, a0 string, a1 types.Order) (err error) {
 	// Update metrics.
@@ -135,7 +135,7 @@ type t_server_stub struct {
 }
 
 // Check that t_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &t_server_stub{}
+var _ codegen.Server = (*t_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s t_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/examples/onlineboutique/frontend/weaver_gen.go
+++ b/examples/onlineboutique/frontend/weaver_gen.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/frontend/weaver_gen.go
+++ b/examples/onlineboutique/frontend/weaver_gen.go
@@ -29,10 +29,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[weaver.Main] = &Server{}
+var _ weaver.InstanceOf[weaver.Main] = (*Server)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &Server{}
+var _ weaver.Unrouted = (*Server)(nil)
 
 // Local stub implementations.
 
@@ -42,7 +42,7 @@ type main_local_stub struct {
 }
 
 // Check that main_local_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_local_stub{}
+var _ weaver.Main = (*main_local_stub)(nil)
 
 // Client stub implementations.
 
@@ -51,7 +51,7 @@ type main_client_stub struct {
 }
 
 // Check that main_client_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_client_stub{}
+var _ weaver.Main = (*main_client_stub)(nil)
 
 // Server stub implementations.
 
@@ -61,7 +61,7 @@ type main_server_stub struct {
 }
 
 // Check that main_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &main_server_stub{}
+var _ codegen.Server = (*main_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s main_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/examples/onlineboutique/paymentservice/weaver_gen.go
+++ b/examples/onlineboutique/paymentservice/weaver_gen.go
@@ -15,7 +15,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/paymentservice/weaver_gen.go
+++ b/examples/onlineboutique/paymentservice/weaver_gen.go
@@ -34,10 +34,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[T] = &impl{}
+var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &impl{}
+var _ weaver.Unrouted = (*impl)(nil)
 
 // Local stub implementations.
 
@@ -47,7 +47,7 @@ type t_local_stub struct {
 }
 
 // Check that t_local_stub implements the T interface.
-var _ T = &t_local_stub{}
+var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) Charge(ctx context.Context, a0 money.T, a1 CreditCardInfo) (r0 string, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -74,7 +74,7 @@ type t_client_stub struct {
 }
 
 // Check that t_client_stub implements the T interface.
-var _ T = &t_client_stub{}
+var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) Charge(ctx context.Context, a0 money.T, a1 CreditCardInfo) (r0 string, err error) {
 	// Update metrics.
@@ -137,7 +137,7 @@ type t_server_stub struct {
 }
 
 // Check that t_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &t_server_stub{}
+var _ codegen.Server = (*t_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s t_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -178,7 +178,7 @@ func (s t_server_stub) charge(ctx context.Context, args []byte) (res []byte, err
 
 // AutoMarshal implementations.
 
-var _ codegen.AutoMarshal = &CreditCardInfo{}
+var _ codegen.AutoMarshal = (*CreditCardInfo)(nil)
 
 type __is_CreditCardInfo[T ~struct {
 	weaver.AutoMarshal

--- a/examples/onlineboutique/productcatalogservice/weaver_gen.go
+++ b/examples/onlineboutique/productcatalogservice/weaver_gen.go
@@ -15,7 +15,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/productcatalogservice/weaver_gen.go
+++ b/examples/onlineboutique/productcatalogservice/weaver_gen.go
@@ -34,10 +34,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[T] = &impl{}
+var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &impl{}
+var _ weaver.Unrouted = (*impl)(nil)
 
 // Local stub implementations.
 
@@ -47,7 +47,7 @@ type t_local_stub struct {
 }
 
 // Check that t_local_stub implements the T interface.
-var _ T = &t_local_stub{}
+var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) GetProduct(ctx context.Context, a0 string) (r0 Product, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -110,7 +110,7 @@ type t_client_stub struct {
 }
 
 // Check that t_client_stub implements the T interface.
-var _ T = &t_client_stub{}
+var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) GetProduct(ctx context.Context, a0 string) (r0 Product, err error) {
 	// Update metrics.
@@ -283,7 +283,7 @@ type t_server_stub struct {
 }
 
 // Check that t_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &t_server_stub{}
+var _ codegen.Server = (*t_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s t_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -371,7 +371,7 @@ func (s t_server_stub) searchProducts(ctx context.Context, args []byte) (res []b
 
 // AutoMarshal implementations.
 
-var _ codegen.AutoMarshal = &Product{}
+var _ codegen.AutoMarshal = (*Product)(nil)
 
 type __is_Product[T ~struct {
 	weaver.AutoMarshal

--- a/examples/onlineboutique/recommendationservice/weaver_gen.go
+++ b/examples/onlineboutique/recommendationservice/weaver_gen.go
@@ -32,10 +32,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[T] = &impl{}
+var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &impl{}
+var _ weaver.Unrouted = (*impl)(nil)
 
 // Local stub implementations.
 
@@ -45,7 +45,7 @@ type t_local_stub struct {
 }
 
 // Check that t_local_stub implements the T interface.
-var _ T = &t_local_stub{}
+var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) ListRecommendations(ctx context.Context, a0 string, a1 []string) (r0 []string, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -72,7 +72,7 @@ type t_client_stub struct {
 }
 
 // Check that t_client_stub implements the T interface.
-var _ T = &t_client_stub{}
+var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) ListRecommendations(ctx context.Context, a0 string, a1 []string) (r0 []string, err error) {
 	// Update metrics.
@@ -135,7 +135,7 @@ type t_server_stub struct {
 }
 
 // Check that t_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &t_server_stub{}
+var _ codegen.Server = (*t_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s t_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/examples/onlineboutique/recommendationservice/weaver_gen.go
+++ b/examples/onlineboutique/recommendationservice/weaver_gen.go
@@ -13,7 +13,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/shippingservice/weaver_gen.go
+++ b/examples/onlineboutique/shippingservice/weaver_gen.go
@@ -16,7 +16,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/shippingservice/weaver_gen.go
+++ b/examples/onlineboutique/shippingservice/weaver_gen.go
@@ -35,10 +35,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[T] = &impl{}
+var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &impl{}
+var _ weaver.Unrouted = (*impl)(nil)
 
 // Local stub implementations.
 
@@ -48,7 +48,7 @@ type t_local_stub struct {
 }
 
 // Check that t_local_stub implements the T interface.
-var _ T = &t_local_stub{}
+var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) GetQuote(ctx context.Context, a0 Address, a1 []cartservice.CartItem) (r0 money.T, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -93,7 +93,7 @@ type t_client_stub struct {
 }
 
 // Check that t_client_stub implements the T interface.
-var _ T = &t_client_stub{}
+var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) GetQuote(ctx context.Context, a0 Address, a1 []cartservice.CartItem) (r0 money.T, err error) {
 	// Update metrics.
@@ -209,7 +209,7 @@ type t_server_stub struct {
 }
 
 // Check that t_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &t_server_stub{}
+var _ codegen.Server = (*t_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s t_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -279,7 +279,7 @@ func (s t_server_stub) shipOrder(ctx context.Context, args []byte) (res []byte, 
 
 // AutoMarshal implementations.
 
-var _ codegen.AutoMarshal = &Address{}
+var _ codegen.AutoMarshal = (*Address)(nil)
 
 type __is_Address[T ~struct {
 	weaver.AutoMarshal

--- a/examples/onlineboutique/types/money/weaver_gen.go
+++ b/examples/onlineboutique/types/money/weaver_gen.go
@@ -22,7 +22,7 @@ var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver
 
 // AutoMarshal implementations.
 
-var _ codegen.AutoMarshal = &T{}
+var _ codegen.AutoMarshal = (*T)(nil)
 
 type __is_T[T ~struct {
 	weaver.AutoMarshal

--- a/examples/onlineboutique/types/money/weaver_gen.go
+++ b/examples/onlineboutique/types/money/weaver_gen.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ServiceWeaver/weaver"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 // weaver.Instance checks.
 

--- a/examples/onlineboutique/types/weaver_gen.go
+++ b/examples/onlineboutique/types/weaver_gen.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ServiceWeaver/weaver/examples/onlineboutique/types/money"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 // weaver.Instance checks.
 

--- a/examples/onlineboutique/types/weaver_gen.go
+++ b/examples/onlineboutique/types/weaver_gen.go
@@ -25,7 +25,7 @@ var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver
 
 // AutoMarshal implementations.
 
-var _ codegen.AutoMarshal = &Order{}
+var _ codegen.AutoMarshal = (*Order)(nil)
 
 type __is_Order[T ~struct {
 	weaver.AutoMarshal
@@ -83,7 +83,7 @@ func serviceweaver_dec_slice_OrderItem_2b9377cb(dec *codegen.Decoder) []OrderIte
 	return res
 }
 
-var _ codegen.AutoMarshal = &OrderItem{}
+var _ codegen.AutoMarshal = (*OrderItem)(nil)
 
 type __is_OrderItem[T ~struct {
 	weaver.AutoMarshal

--- a/examples/reverser/weaver_gen.go
+++ b/examples/reverser/weaver_gen.go
@@ -13,7 +13,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/reverser/weaver_gen.go
+++ b/examples/reverser/weaver_gen.go
@@ -47,12 +47,12 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[weaver.Main] = &server{}
-var _ weaver.InstanceOf[Reverser] = &reverser{}
+var _ weaver.InstanceOf[weaver.Main] = (*server)(nil)
+var _ weaver.InstanceOf[Reverser] = (*reverser)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &server{}
-var _ weaver.Unrouted = &reverser{}
+var _ weaver.Unrouted = (*server)(nil)
+var _ weaver.Unrouted = (*reverser)(nil)
 
 // Local stub implementations.
 
@@ -62,7 +62,7 @@ type main_local_stub struct {
 }
 
 // Check that main_local_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_local_stub{}
+var _ weaver.Main = (*main_local_stub)(nil)
 
 type reverser_local_stub struct {
 	impl   Reverser
@@ -70,7 +70,7 @@ type reverser_local_stub struct {
 }
 
 // Check that reverser_local_stub implements the Reverser interface.
-var _ Reverser = &reverser_local_stub{}
+var _ Reverser = (*reverser_local_stub)(nil)
 
 func (s reverser_local_stub) Reverse(ctx context.Context, a0 string) (r0 string, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -96,7 +96,7 @@ type main_client_stub struct {
 }
 
 // Check that main_client_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_client_stub{}
+var _ weaver.Main = (*main_client_stub)(nil)
 
 type reverser_client_stub struct {
 	stub           codegen.Stub
@@ -104,7 +104,7 @@ type reverser_client_stub struct {
 }
 
 // Check that reverser_client_stub implements the Reverser interface.
-var _ Reverser = &reverser_client_stub{}
+var _ Reverser = (*reverser_client_stub)(nil)
 
 func (s reverser_client_stub) Reverse(ctx context.Context, a0 string) (r0 string, err error) {
 	// Update metrics.
@@ -171,7 +171,7 @@ type main_server_stub struct {
 }
 
 // Check that main_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &main_server_stub{}
+var _ codegen.Server = (*main_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s main_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -187,7 +187,7 @@ type reverser_server_stub struct {
 }
 
 // Check that reverser_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &reverser_server_stub{}
+var _ codegen.Server = (*reverser_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s reverser_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/internal/benchmarks/weaver_gen.go
+++ b/internal/benchmarks/weaver_gen.go
@@ -14,7 +14,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/internal/benchmarks/weaver_gen.go
+++ b/internal/benchmarks/weaver_gen.go
@@ -150,28 +150,28 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[Ping1] = &ping1{}
-var _ weaver.InstanceOf[Ping10] = &ping10{}
-var _ weaver.InstanceOf[Ping2] = &ping2{}
-var _ weaver.InstanceOf[Ping3] = &ping3{}
-var _ weaver.InstanceOf[Ping4] = &ping4{}
-var _ weaver.InstanceOf[Ping5] = &ping5{}
-var _ weaver.InstanceOf[Ping6] = &ping6{}
-var _ weaver.InstanceOf[Ping7] = &ping7{}
-var _ weaver.InstanceOf[Ping8] = &ping8{}
-var _ weaver.InstanceOf[Ping9] = &ping9{}
+var _ weaver.InstanceOf[Ping1] = (*ping1)(nil)
+var _ weaver.InstanceOf[Ping10] = (*ping10)(nil)
+var _ weaver.InstanceOf[Ping2] = (*ping2)(nil)
+var _ weaver.InstanceOf[Ping3] = (*ping3)(nil)
+var _ weaver.InstanceOf[Ping4] = (*ping4)(nil)
+var _ weaver.InstanceOf[Ping5] = (*ping5)(nil)
+var _ weaver.InstanceOf[Ping6] = (*ping6)(nil)
+var _ weaver.InstanceOf[Ping7] = (*ping7)(nil)
+var _ weaver.InstanceOf[Ping8] = (*ping8)(nil)
+var _ weaver.InstanceOf[Ping9] = (*ping9)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &ping1{}
-var _ weaver.Unrouted = &ping10{}
-var _ weaver.Unrouted = &ping2{}
-var _ weaver.Unrouted = &ping3{}
-var _ weaver.Unrouted = &ping4{}
-var _ weaver.Unrouted = &ping5{}
-var _ weaver.Unrouted = &ping6{}
-var _ weaver.Unrouted = &ping7{}
-var _ weaver.Unrouted = &ping8{}
-var _ weaver.Unrouted = &ping9{}
+var _ weaver.Unrouted = (*ping1)(nil)
+var _ weaver.Unrouted = (*ping10)(nil)
+var _ weaver.Unrouted = (*ping2)(nil)
+var _ weaver.Unrouted = (*ping3)(nil)
+var _ weaver.Unrouted = (*ping4)(nil)
+var _ weaver.Unrouted = (*ping5)(nil)
+var _ weaver.Unrouted = (*ping6)(nil)
+var _ weaver.Unrouted = (*ping7)(nil)
+var _ weaver.Unrouted = (*ping8)(nil)
+var _ weaver.Unrouted = (*ping9)(nil)
 
 // Local stub implementations.
 
@@ -181,7 +181,7 @@ type ping1_local_stub struct {
 }
 
 // Check that ping1_local_stub implements the Ping1 interface.
-var _ Ping1 = &ping1_local_stub{}
+var _ Ping1 = (*ping1_local_stub)(nil)
 
 func (s ping1_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -223,7 +223,7 @@ type ping10_local_stub struct {
 }
 
 // Check that ping10_local_stub implements the Ping10 interface.
-var _ Ping10 = &ping10_local_stub{}
+var _ Ping10 = (*ping10_local_stub)(nil)
 
 func (s ping10_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -265,7 +265,7 @@ type ping2_local_stub struct {
 }
 
 // Check that ping2_local_stub implements the Ping2 interface.
-var _ Ping2 = &ping2_local_stub{}
+var _ Ping2 = (*ping2_local_stub)(nil)
 
 func (s ping2_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -307,7 +307,7 @@ type ping3_local_stub struct {
 }
 
 // Check that ping3_local_stub implements the Ping3 interface.
-var _ Ping3 = &ping3_local_stub{}
+var _ Ping3 = (*ping3_local_stub)(nil)
 
 func (s ping3_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -349,7 +349,7 @@ type ping4_local_stub struct {
 }
 
 // Check that ping4_local_stub implements the Ping4 interface.
-var _ Ping4 = &ping4_local_stub{}
+var _ Ping4 = (*ping4_local_stub)(nil)
 
 func (s ping4_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -391,7 +391,7 @@ type ping5_local_stub struct {
 }
 
 // Check that ping5_local_stub implements the Ping5 interface.
-var _ Ping5 = &ping5_local_stub{}
+var _ Ping5 = (*ping5_local_stub)(nil)
 
 func (s ping5_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -433,7 +433,7 @@ type ping6_local_stub struct {
 }
 
 // Check that ping6_local_stub implements the Ping6 interface.
-var _ Ping6 = &ping6_local_stub{}
+var _ Ping6 = (*ping6_local_stub)(nil)
 
 func (s ping6_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -475,7 +475,7 @@ type ping7_local_stub struct {
 }
 
 // Check that ping7_local_stub implements the Ping7 interface.
-var _ Ping7 = &ping7_local_stub{}
+var _ Ping7 = (*ping7_local_stub)(nil)
 
 func (s ping7_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -517,7 +517,7 @@ type ping8_local_stub struct {
 }
 
 // Check that ping8_local_stub implements the Ping8 interface.
-var _ Ping8 = &ping8_local_stub{}
+var _ Ping8 = (*ping8_local_stub)(nil)
 
 func (s ping8_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -559,7 +559,7 @@ type ping9_local_stub struct {
 }
 
 // Check that ping9_local_stub implements the Ping9 interface.
-var _ Ping9 = &ping9_local_stub{}
+var _ Ping9 = (*ping9_local_stub)(nil)
 
 func (s ping9_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -604,7 +604,7 @@ type ping1_client_stub struct {
 }
 
 // Check that ping1_client_stub implements the Ping1 interface.
-var _ Ping1 = &ping1_client_stub{}
+var _ Ping1 = (*ping1_client_stub)(nil)
 
 func (s ping1_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
@@ -725,7 +725,7 @@ type ping10_client_stub struct {
 }
 
 // Check that ping10_client_stub implements the Ping10 interface.
-var _ Ping10 = &ping10_client_stub{}
+var _ Ping10 = (*ping10_client_stub)(nil)
 
 func (s ping10_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
@@ -846,7 +846,7 @@ type ping2_client_stub struct {
 }
 
 // Check that ping2_client_stub implements the Ping2 interface.
-var _ Ping2 = &ping2_client_stub{}
+var _ Ping2 = (*ping2_client_stub)(nil)
 
 func (s ping2_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
@@ -967,7 +967,7 @@ type ping3_client_stub struct {
 }
 
 // Check that ping3_client_stub implements the Ping3 interface.
-var _ Ping3 = &ping3_client_stub{}
+var _ Ping3 = (*ping3_client_stub)(nil)
 
 func (s ping3_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
@@ -1088,7 +1088,7 @@ type ping4_client_stub struct {
 }
 
 // Check that ping4_client_stub implements the Ping4 interface.
-var _ Ping4 = &ping4_client_stub{}
+var _ Ping4 = (*ping4_client_stub)(nil)
 
 func (s ping4_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
@@ -1209,7 +1209,7 @@ type ping5_client_stub struct {
 }
 
 // Check that ping5_client_stub implements the Ping5 interface.
-var _ Ping5 = &ping5_client_stub{}
+var _ Ping5 = (*ping5_client_stub)(nil)
 
 func (s ping5_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
@@ -1330,7 +1330,7 @@ type ping6_client_stub struct {
 }
 
 // Check that ping6_client_stub implements the Ping6 interface.
-var _ Ping6 = &ping6_client_stub{}
+var _ Ping6 = (*ping6_client_stub)(nil)
 
 func (s ping6_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
@@ -1451,7 +1451,7 @@ type ping7_client_stub struct {
 }
 
 // Check that ping7_client_stub implements the Ping7 interface.
-var _ Ping7 = &ping7_client_stub{}
+var _ Ping7 = (*ping7_client_stub)(nil)
 
 func (s ping7_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
@@ -1572,7 +1572,7 @@ type ping8_client_stub struct {
 }
 
 // Check that ping8_client_stub implements the Ping8 interface.
-var _ Ping8 = &ping8_client_stub{}
+var _ Ping8 = (*ping8_client_stub)(nil)
 
 func (s ping8_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
@@ -1693,7 +1693,7 @@ type ping9_client_stub struct {
 }
 
 // Check that ping9_client_stub implements the Ping9 interface.
-var _ Ping9 = &ping9_client_stub{}
+var _ Ping9 = (*ping9_client_stub)(nil)
 
 func (s ping9_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
@@ -1815,7 +1815,7 @@ type ping1_server_stub struct {
 }
 
 // Check that ping1_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &ping1_server_stub{}
+var _ codegen.Server = (*ping1_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s ping1_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -1889,7 +1889,7 @@ type ping10_server_stub struct {
 }
 
 // Check that ping10_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &ping10_server_stub{}
+var _ codegen.Server = (*ping10_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s ping10_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -1963,7 +1963,7 @@ type ping2_server_stub struct {
 }
 
 // Check that ping2_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &ping2_server_stub{}
+var _ codegen.Server = (*ping2_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s ping2_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -2037,7 +2037,7 @@ type ping3_server_stub struct {
 }
 
 // Check that ping3_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &ping3_server_stub{}
+var _ codegen.Server = (*ping3_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s ping3_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -2111,7 +2111,7 @@ type ping4_server_stub struct {
 }
 
 // Check that ping4_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &ping4_server_stub{}
+var _ codegen.Server = (*ping4_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s ping4_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -2185,7 +2185,7 @@ type ping5_server_stub struct {
 }
 
 // Check that ping5_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &ping5_server_stub{}
+var _ codegen.Server = (*ping5_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s ping5_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -2259,7 +2259,7 @@ type ping6_server_stub struct {
 }
 
 // Check that ping6_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &ping6_server_stub{}
+var _ codegen.Server = (*ping6_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s ping6_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -2333,7 +2333,7 @@ type ping7_server_stub struct {
 }
 
 // Check that ping7_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &ping7_server_stub{}
+var _ codegen.Server = (*ping7_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s ping7_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -2407,7 +2407,7 @@ type ping8_server_stub struct {
 }
 
 // Check that ping8_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &ping8_server_stub{}
+var _ codegen.Server = (*ping8_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s ping8_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -2481,7 +2481,7 @@ type ping9_server_stub struct {
 }
 
 // Check that ping9_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &ping9_server_stub{}
+var _ codegen.Server = (*ping9_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s ping9_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -2551,7 +2551,7 @@ func (s ping9_server_stub) pingS(ctx context.Context, args []byte) (res []byte, 
 
 // AutoMarshal implementations.
 
-var _ codegen.AutoMarshal = &X1{}
+var _ codegen.AutoMarshal = (*X1)(nil)
 
 type __is_X1[T ~struct {
 	weaver.AutoMarshal
@@ -2600,7 +2600,7 @@ func serviceweaver_dec_slice_int64_a8f7f092(dec *codegen.Decoder) []int64 {
 	return res
 }
 
-var _ codegen.AutoMarshal = &X2{}
+var _ codegen.AutoMarshal = (*X2)(nil)
 
 type __is_X2[T ~struct {
 	weaver.AutoMarshal
@@ -2623,7 +2623,7 @@ func (x *X2) WeaverUnmarshal(dec *codegen.Decoder) {
 	(&x.A).WeaverUnmarshal(dec)
 }
 
-var _ codegen.AutoMarshal = &X3{}
+var _ codegen.AutoMarshal = (*X3)(nil)
 
 type __is_X3[T ~struct {
 	weaver.AutoMarshal
@@ -2652,7 +2652,7 @@ func (x *X3) WeaverUnmarshal(dec *codegen.Decoder) {
 	x.C = dec.Int64()
 }
 
-var _ codegen.AutoMarshal = &X4{}
+var _ codegen.AutoMarshal = (*X4)(nil)
 
 type __is_X4[T ~struct {
 	weaver.AutoMarshal
@@ -2681,7 +2681,7 @@ func (x *X4) WeaverUnmarshal(dec *codegen.Decoder) {
 	x.C = dec.Int64()
 }
 
-var _ codegen.AutoMarshal = &X5{}
+var _ codegen.AutoMarshal = (*X5)(nil)
 
 type __is_X5[T ~struct {
 	weaver.AutoMarshal
@@ -2707,7 +2707,7 @@ func (x *X5) WeaverUnmarshal(dec *codegen.Decoder) {
 	x.B = dec.Int64()
 }
 
-var _ codegen.AutoMarshal = &X6{}
+var _ codegen.AutoMarshal = (*X6)(nil)
 
 type __is_X6[T ~struct {
 	weaver.AutoMarshal
@@ -2753,7 +2753,7 @@ func serviceweaver_dec_slice_bool_c791c3b0(dec *codegen.Decoder) []bool {
 	return res
 }
 
-var _ codegen.AutoMarshal = &payloadC{}
+var _ codegen.AutoMarshal = (*payloadC)(nil)
 
 type __is_payloadC[T ~struct {
 	weaver.AutoMarshal
@@ -2806,7 +2806,7 @@ func (x *payloadC) WeaverUnmarshal(dec *codegen.Decoder) {
 	x.K = dec.String()
 }
 
-var _ codegen.AutoMarshal = &payloadS{}
+var _ codegen.AutoMarshal = (*payloadS)(nil)
 
 type __is_payloadS[T ~struct {
 	weaver.AutoMarshal

--- a/internal/tool/generate/generator.go
+++ b/internal/tool/generate/generator.go
@@ -897,7 +897,7 @@ func (g *generator) generateInstanceChecks(p printFn) {
 	p(`// weaver.Instance checks.`)
 	for _, c := range g.components {
 		// e.g., var _ weaver.InstanceOf[Odd] = &odd{}
-		p(`var _ %s[%s] = &%s{}`, g.weaver().qualify("InstanceOf"), g.tset.genTypeString(c.intf), g.tset.genTypeString(c.impl))
+		p(`var _ %s[%s] = (*%s)(nil)`, g.weaver().qualify("InstanceOf"), g.tset.genTypeString(c.intf), g.tset.genTypeString(c.impl))
 	}
 }
 
@@ -912,11 +912,11 @@ func (g *generator) generateRouterChecks(p printFn) {
 	for _, c := range g.components {
 		if c.router == nil {
 			// e.g., var _ weaver.Unrouted = &odd{}
-			p(`var _ %s = &%s{}`, g.weaver().qualify("Unrouted"), g.tset.genTypeString(c.impl))
+			p(`var _ %s = (*%s)(nil)`, g.weaver().qualify("Unrouted"), g.tset.genTypeString(c.impl))
 
 		} else {
 			// e.g., var _ weaver.RoutedBy[router] = &odd{}
-			p(`var _ %s[%s] = &%s{}`, g.weaver().qualify("RoutedBy"), g.tset.genTypeString(c.router), g.tset.genTypeString(c.impl))
+			p(`var _ %s[%s] = (*%s)(nil)`, g.weaver().qualify("RoutedBy"), g.tset.genTypeString(c.router), g.tset.genTypeString(c.impl))
 		}
 	}
 
@@ -1069,7 +1069,7 @@ func (g *generator) generateLocalStubs(p printFn) {
 
 		p(``)
 		p(`// Check that %s implements the %s interface.`, stub, g.tset.genTypeString(comp.intf))
-		p(`var _ %s = &%s{}`, g.tset.genTypeString(comp.intf), stub)
+		p(`var _ %s = (*%s)(nil)`, g.tset.genTypeString(comp.intf), stub)
 		p(``)
 
 		for _, m := range comp.methods() {
@@ -1128,7 +1128,7 @@ func (g *generator) generateClientStubs(p printFn) {
 
 		p(``)
 		p(`// Check that %s implements the %s interface.`, stub, g.tset.genTypeString(comp.intf))
-		p(`var _ %s = &%s{}`, g.tset.genTypeString(comp.intf), stub)
+		p(`var _ %s = (*%s)(nil)`, g.tset.genTypeString(comp.intf), stub)
 		p(``)
 
 		// Assign method indices in sorted order.
@@ -1608,7 +1608,7 @@ func (g *generator) generateServerStubs(p printFn) {
 		p(``)
 
 		p(`// Check that %s implements the %s interface.`, stub, g.codegen().qualify("Server"))
-		p(`var _ %s = &%s{}`, g.codegen().qualify("Server"), stub)
+		p(`var _ %s = (*%s)(nil)`, g.codegen().qualify("Server"), stub)
 		p(``)
 
 		p(`// GetStubFn implements the codegen.Server interface.`)
@@ -1762,7 +1762,7 @@ func (g *generator) generateAutoMarshalMethods(p printFn) {
 		// These checks ensure that if a user changes the Pair struct and
 		// forgets to re-run "weaver generate", the app will not build.
 		p(``)
-		p(`var _ %s = &%s{}`, g.codegen().qualify("AutoMarshal"), ts(t))
+		p(`var _ %s = (*%s)(nil)`, g.codegen().qualify("AutoMarshal"), ts(t))
 		p(`type __is_%s[T ~%s] struct{}`, t.(*types.Named).Obj().Name(), ts(s))
 		p(`var _ __is_%s[%s]`, t.(*types.Named).Obj().Name(), ts(t))
 

--- a/internal/tool/generate/testdata/automarshal_checks.go
+++ b/internal/tool/generate/testdata/automarshal_checks.go
@@ -1,0 +1,31 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// EXPECTED
+// var _ codegen.AutoMarshal = (*Pair)(nil)
+// weaver.AutoMarshal
+// X int
+// Y int
+// }] struct{}
+// var _ __is_Pair[Pair]
+
+package foo
+
+import "github.com/ServiceWeaver/weaver"
+
+type Pair struct {
+	weaver.AutoMarshal
+	X int
+	Y int
+}

--- a/internal/tool/generate/testdata/component_checks.go
+++ b/internal/tool/generate/testdata/component_checks.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// EXPECTED
+// var _ weaver.InstanceOf[foo] = (*impl)(nil)
+// var _ foo = (*foo_local_stub)(nil)
+// var _ foo = (*foo_client_stub)(nil)
+// var _ codegen.Server = (*foo_server_stub)(nil)
+
+package foo
+
+import "github.com/ServiceWeaver/weaver"
+
+type foo interface{}
+
+type impl struct {
+	weaver.Implements[foo]
+}

--- a/internal/tool/generate/testdata/router_checks.go
+++ b/internal/tool/generate/testdata/router_checks.go
@@ -1,0 +1,49 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// EXPECTED
+// var _ weaver.Unrouted = (*unrouted)(nil)
+// var _ weaver.RoutedBy[router] = (*routed)(nil)
+// var _ func(context.Context) int = (&router{}).A
+// var _ = (&__routed_router_if_youre_seeing_this_you_probably_forgot_to_run_weaver_generate{}).B
+package foo
+
+import (
+	"context"
+
+	"github.com/ServiceWeaver/weaver"
+)
+
+type Unrouted interface{}
+
+type unrouted struct {
+	weaver.Implements[Unrouted]
+}
+
+type Routed interface {
+	A(context.Context) error
+	B(context.Context) error
+}
+
+type routed struct {
+	weaver.Implements[Routed]
+	weaver.WithRouter[router]
+}
+
+func (routed) A(context.Context) error { return nil }
+func (routed) B(context.Context) error { return nil }
+
+type router struct{}
+
+func (router) A(context.Context) int { return 42 }

--- a/runtime/bin/testprogram/weaver_gen.go
+++ b/runtime/bin/testprogram/weaver_gen.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/runtime/bin/testprogram/weaver_gen.go
+++ b/runtime/bin/testprogram/weaver_gen.go
@@ -62,16 +62,16 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[A] = &a{}
-var _ weaver.InstanceOf[B] = &b{}
-var _ weaver.InstanceOf[C] = &c{}
-var _ weaver.InstanceOf[weaver.Main] = &app{}
+var _ weaver.InstanceOf[A] = (*a)(nil)
+var _ weaver.InstanceOf[B] = (*b)(nil)
+var _ weaver.InstanceOf[C] = (*c)(nil)
+var _ weaver.InstanceOf[weaver.Main] = (*app)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &a{}
-var _ weaver.Unrouted = &b{}
-var _ weaver.Unrouted = &c{}
-var _ weaver.Unrouted = &app{}
+var _ weaver.Unrouted = (*a)(nil)
+var _ weaver.Unrouted = (*b)(nil)
+var _ weaver.Unrouted = (*c)(nil)
+var _ weaver.Unrouted = (*app)(nil)
 
 // Local stub implementations.
 
@@ -81,7 +81,7 @@ type a_local_stub struct {
 }
 
 // Check that a_local_stub implements the A interface.
-var _ A = &a_local_stub{}
+var _ A = (*a_local_stub)(nil)
 
 type b_local_stub struct {
 	impl   B
@@ -89,7 +89,7 @@ type b_local_stub struct {
 }
 
 // Check that b_local_stub implements the B interface.
-var _ B = &b_local_stub{}
+var _ B = (*b_local_stub)(nil)
 
 type c_local_stub struct {
 	impl   C
@@ -97,7 +97,7 @@ type c_local_stub struct {
 }
 
 // Check that c_local_stub implements the C interface.
-var _ C = &c_local_stub{}
+var _ C = (*c_local_stub)(nil)
 
 type main_local_stub struct {
 	impl   weaver.Main
@@ -105,7 +105,7 @@ type main_local_stub struct {
 }
 
 // Check that main_local_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_local_stub{}
+var _ weaver.Main = (*main_local_stub)(nil)
 
 // Client stub implementations.
 
@@ -114,28 +114,28 @@ type a_client_stub struct {
 }
 
 // Check that a_client_stub implements the A interface.
-var _ A = &a_client_stub{}
+var _ A = (*a_client_stub)(nil)
 
 type b_client_stub struct {
 	stub codegen.Stub
 }
 
 // Check that b_client_stub implements the B interface.
-var _ B = &b_client_stub{}
+var _ B = (*b_client_stub)(nil)
 
 type c_client_stub struct {
 	stub codegen.Stub
 }
 
 // Check that c_client_stub implements the C interface.
-var _ C = &c_client_stub{}
+var _ C = (*c_client_stub)(nil)
 
 type main_client_stub struct {
 	stub codegen.Stub
 }
 
 // Check that main_client_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_client_stub{}
+var _ weaver.Main = (*main_client_stub)(nil)
 
 // Server stub implementations.
 
@@ -145,7 +145,7 @@ type a_server_stub struct {
 }
 
 // Check that a_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &a_server_stub{}
+var _ codegen.Server = (*a_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s a_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -161,7 +161,7 @@ type b_server_stub struct {
 }
 
 // Check that b_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &b_server_stub{}
+var _ codegen.Server = (*b_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s b_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -177,7 +177,7 @@ type c_server_stub struct {
 }
 
 // Check that c_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &c_server_stub{}
+var _ codegen.Server = (*c_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s c_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -193,7 +193,7 @@ type main_server_stub struct {
 }
 
 // Check that main_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &main_server_stub{}
+var _ codegen.Server = (*main_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s main_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/runtime/codegen/version.go
+++ b/runtime/codegen/version.go
@@ -53,7 +53,7 @@ const (
 	// TODO(mwhittaker): Write a doc explaining this version as well as the
 	// module version and deployer API version.
 	Major = 0
-	Minor = 10
+	Minor = 11
 	// NOTE: Patch is omitted because all API changes should bump the major or
 	// minor version. Patch is assumed to be 0.
 )

--- a/runtime/version/testprogram/weaver_gen.go
+++ b/runtime/version/testprogram/weaver_gen.go
@@ -29,10 +29,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[weaver.Main] = &app{}
+var _ weaver.InstanceOf[weaver.Main] = (*app)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &app{}
+var _ weaver.Unrouted = (*app)(nil)
 
 // Local stub implementations.
 
@@ -42,7 +42,7 @@ type main_local_stub struct {
 }
 
 // Check that main_local_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_local_stub{}
+var _ weaver.Main = (*main_local_stub)(nil)
 
 // Client stub implementations.
 
@@ -51,7 +51,7 @@ type main_client_stub struct {
 }
 
 // Check that main_client_stub implements the weaver.Main interface.
-var _ weaver.Main = &main_client_stub{}
+var _ weaver.Main = (*main_client_stub)(nil)
 
 // Server stub implementations.
 
@@ -61,7 +61,7 @@ type main_server_stub struct {
 }
 
 // Check that main_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &main_server_stub{}
+var _ codegen.Server = (*main_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s main_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/runtime/version/testprogram/weaver_gen.go
+++ b/runtime/version/testprogram/weaver_gen.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/internal/deploy/weaver_gen.go
+++ b/weavertest/internal/deploy/weaver_gen.go
@@ -13,7 +13,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/internal/deploy/weaver_gen.go
+++ b/weavertest/internal/deploy/weaver_gen.go
@@ -47,12 +47,12 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[Started] = &started{}
-var _ weaver.InstanceOf[Widget] = &widget{}
+var _ weaver.InstanceOf[Started] = (*started)(nil)
+var _ weaver.InstanceOf[Widget] = (*widget)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &started{}
-var _ weaver.Unrouted = &widget{}
+var _ weaver.Unrouted = (*started)(nil)
+var _ weaver.Unrouted = (*widget)(nil)
 
 // Local stub implementations.
 
@@ -62,7 +62,7 @@ type started_local_stub struct {
 }
 
 // Check that started_local_stub implements the Started interface.
-var _ Started = &started_local_stub{}
+var _ Started = (*started_local_stub)(nil)
 
 func (s started_local_stub) MarkStarted(ctx context.Context, a0 string) (err error) {
 	span := trace.SpanFromContext(ctx)
@@ -87,7 +87,7 @@ type widget_local_stub struct {
 }
 
 // Check that widget_local_stub implements the Widget interface.
-var _ Widget = &widget_local_stub{}
+var _ Widget = (*widget_local_stub)(nil)
 
 func (s widget_local_stub) Use(ctx context.Context, a0 string) (err error) {
 	span := trace.SpanFromContext(ctx)
@@ -114,7 +114,7 @@ type started_client_stub struct {
 }
 
 // Check that started_client_stub implements the Started interface.
-var _ Started = &started_client_stub{}
+var _ Started = (*started_client_stub)(nil)
 
 func (s started_client_stub) MarkStarted(ctx context.Context, a0 string) (err error) {
 	// Update metrics.
@@ -178,7 +178,7 @@ type widget_client_stub struct {
 }
 
 // Check that widget_client_stub implements the Widget interface.
-var _ Widget = &widget_client_stub{}
+var _ Widget = (*widget_client_stub)(nil)
 
 func (s widget_client_stub) Use(ctx context.Context, a0 string) (err error) {
 	// Update metrics.
@@ -244,7 +244,7 @@ type started_server_stub struct {
 }
 
 // Check that started_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &started_server_stub{}
+var _ codegen.Server = (*started_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s started_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -286,7 +286,7 @@ type widget_server_stub struct {
 }
 
 // Check that widget_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &widget_server_stub{}
+var _ codegen.Server = (*widget_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s widget_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/weavertest/internal/diverge/weaver_gen.go
+++ b/weavertest/internal/diverge/weaver_gen.go
@@ -14,7 +14,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/internal/diverge/weaver_gen.go
+++ b/weavertest/internal/diverge/weaver_gen.go
@@ -61,14 +61,14 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[Errer] = &errer{}
-var _ weaver.InstanceOf[Failer] = &failer{}
-var _ weaver.InstanceOf[Pointer] = &pointer{}
+var _ weaver.InstanceOf[Errer] = (*errer)(nil)
+var _ weaver.InstanceOf[Failer] = (*failer)(nil)
+var _ weaver.InstanceOf[Pointer] = (*pointer)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &errer{}
-var _ weaver.Unrouted = &failer{}
-var _ weaver.Unrouted = &pointer{}
+var _ weaver.Unrouted = (*errer)(nil)
+var _ weaver.Unrouted = (*failer)(nil)
+var _ weaver.Unrouted = (*pointer)(nil)
 
 // Local stub implementations.
 
@@ -78,7 +78,7 @@ type errer_local_stub struct {
 }
 
 // Check that errer_local_stub implements the Errer interface.
-var _ Errer = &errer_local_stub{}
+var _ Errer = (*errer_local_stub)(nil)
 
 func (s errer_local_stub) Err(ctx context.Context, a0 int) (err error) {
 	span := trace.SpanFromContext(ctx)
@@ -103,7 +103,7 @@ type failer_local_stub struct {
 }
 
 // Check that failer_local_stub implements the Failer interface.
-var _ Failer = &failer_local_stub{}
+var _ Failer = (*failer_local_stub)(nil)
 
 func (s failer_local_stub) ImJustHereSoWeaverGenerateDoesntComplain(ctx context.Context) (err error) {
 	span := trace.SpanFromContext(ctx)
@@ -128,7 +128,7 @@ type pointer_local_stub struct {
 }
 
 // Check that pointer_local_stub implements the Pointer interface.
-var _ Pointer = &pointer_local_stub{}
+var _ Pointer = (*pointer_local_stub)(nil)
 
 func (s pointer_local_stub) Get(ctx context.Context) (r0 Pair, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -155,7 +155,7 @@ type errer_client_stub struct {
 }
 
 // Check that errer_client_stub implements the Errer interface.
-var _ Errer = &errer_client_stub{}
+var _ Errer = (*errer_client_stub)(nil)
 
 func (s errer_client_stub) Err(ctx context.Context, a0 int) (err error) {
 	// Update metrics.
@@ -219,7 +219,7 @@ type failer_client_stub struct {
 }
 
 // Check that failer_client_stub implements the Failer interface.
-var _ Failer = &failer_client_stub{}
+var _ Failer = (*failer_client_stub)(nil)
 
 func (s failer_client_stub) ImJustHereSoWeaverGenerateDoesntComplain(ctx context.Context) (err error) {
 	// Update metrics.
@@ -275,7 +275,7 @@ type pointer_client_stub struct {
 }
 
 // Check that pointer_client_stub implements the Pointer interface.
-var _ Pointer = &pointer_client_stub{}
+var _ Pointer = (*pointer_client_stub)(nil)
 
 func (s pointer_client_stub) Get(ctx context.Context) (r0 Pair, err error) {
 	// Update metrics.
@@ -334,7 +334,7 @@ type errer_server_stub struct {
 }
 
 // Check that errer_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &errer_server_stub{}
+var _ codegen.Server = (*errer_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s errer_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -376,7 +376,7 @@ type failer_server_stub struct {
 }
 
 // Check that failer_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &failer_server_stub{}
+var _ codegen.Server = (*failer_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s failer_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -413,7 +413,7 @@ type pointer_server_stub struct {
 }
 
 // Check that pointer_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &pointer_server_stub{}
+var _ codegen.Server = (*pointer_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s pointer_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -447,7 +447,7 @@ func (s pointer_server_stub) get(ctx context.Context, args []byte) (res []byte, 
 
 // AutoMarshal implementations.
 
-var _ codegen.AutoMarshal = &Pair{}
+var _ codegen.AutoMarshal = (*Pair)(nil)
 
 type __is_Pair[T ~struct {
 	weaver.AutoMarshal

--- a/weavertest/internal/generate/weaver_gen.go
+++ b/weavertest/internal/generate/weaver_gen.go
@@ -13,7 +13,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/internal/generate/weaver_gen.go
+++ b/weavertest/internal/generate/weaver_gen.go
@@ -34,10 +34,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[testApp] = &impl{}
+var _ weaver.InstanceOf[testApp] = (*impl)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &impl{}
+var _ weaver.Unrouted = (*impl)(nil)
 
 // Local stub implementations.
 
@@ -47,7 +47,7 @@ type testApp_local_stub struct {
 }
 
 // Check that testApp_local_stub implements the testApp interface.
-var _ testApp = &testApp_local_stub{}
+var _ testApp = (*testApp_local_stub)(nil)
 
 func (s testApp_local_stub) Get(ctx context.Context, a0 string, a1 behaviorType) (r0 int, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -92,7 +92,7 @@ type testApp_client_stub struct {
 }
 
 // Check that testApp_client_stub implements the testApp interface.
-var _ testApp = &testApp_client_stub{}
+var _ testApp = (*testApp_client_stub)(nil)
 
 func (s testApp_client_stub) Get(ctx context.Context, a0 string, a1 behaviorType) (r0 int, err error) {
 	// Update metrics.
@@ -218,7 +218,7 @@ type testApp_server_stub struct {
 }
 
 // Check that testApp_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &testApp_server_stub{}
+var _ codegen.Server = (*testApp_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s testApp_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/weavertest/internal/protos/weaver_gen.go
+++ b/weavertest/internal/protos/weaver_gen.go
@@ -13,7 +13,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/internal/protos/weaver_gen.go
+++ b/weavertest/internal/protos/weaver_gen.go
@@ -34,10 +34,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[PingPonger] = &impl{}
+var _ weaver.InstanceOf[PingPonger] = (*impl)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &impl{}
+var _ weaver.Unrouted = (*impl)(nil)
 
 // Local stub implementations.
 
@@ -47,7 +47,7 @@ type pingPonger_local_stub struct {
 }
 
 // Check that pingPonger_local_stub implements the PingPonger interface.
-var _ PingPonger = &pingPonger_local_stub{}
+var _ PingPonger = (*pingPonger_local_stub)(nil)
 
 func (s pingPonger_local_stub) Ping(ctx context.Context, a0 *Ping) (r0 *Pong, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -74,7 +74,7 @@ type pingPonger_client_stub struct {
 }
 
 // Check that pingPonger_client_stub implements the PingPonger interface.
-var _ PingPonger = &pingPonger_client_stub{}
+var _ PingPonger = (*pingPonger_client_stub)(nil)
 
 func (s pingPonger_client_stub) Ping(ctx context.Context, a0 *Ping) (r0 *Pong, err error) {
 	// Update metrics.
@@ -136,7 +136,7 @@ type pingPonger_server_stub struct {
 }
 
 // Check that pingPonger_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &pingPonger_server_stub{}
+var _ codegen.Server = (*pingPonger_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s pingPonger_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/weavertest/internal/simple/weaver_gen.go
+++ b/weavertest/internal/simple/weaver_gen.go
@@ -61,14 +61,14 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[Destination] = &destination{}
-var _ weaver.InstanceOf[Server] = &server{}
-var _ weaver.InstanceOf[Source] = &source{}
+var _ weaver.InstanceOf[Destination] = (*destination)(nil)
+var _ weaver.InstanceOf[Server] = (*server)(nil)
+var _ weaver.InstanceOf[Source] = (*source)(nil)
 
 // weaver.Router checks.
-var _ weaver.RoutedBy[destRouter] = &destination{}
-var _ weaver.Unrouted = &server{}
-var _ weaver.Unrouted = &source{}
+var _ weaver.RoutedBy[destRouter] = (*destination)(nil)
+var _ weaver.Unrouted = (*server)(nil)
+var _ weaver.Unrouted = (*source)(nil)
 
 // Component "destination", router "destRouter" checks.
 type __destination_destRouter_if_youre_seeing_this_you_probably_forgot_to_run_weaver_generate struct {
@@ -95,7 +95,7 @@ type destination_local_stub struct {
 }
 
 // Check that destination_local_stub implements the Destination interface.
-var _ Destination = &destination_local_stub{}
+var _ Destination = (*destination_local_stub)(nil)
 
 func (s destination_local_stub) GetAll(ctx context.Context, a0 string) (r0 []string, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -171,7 +171,7 @@ type server_local_stub struct {
 }
 
 // Check that server_local_stub implements the Server interface.
-var _ Server = &server_local_stub{}
+var _ Server = (*server_local_stub)(nil)
 
 func (s server_local_stub) Address(ctx context.Context) (r0 string, err error) {
 	span := trace.SpanFromContext(ctx)
@@ -230,7 +230,7 @@ type source_local_stub struct {
 }
 
 // Check that source_local_stub implements the Source interface.
-var _ Source = &source_local_stub{}
+var _ Source = (*source_local_stub)(nil)
 
 func (s source_local_stub) Emit(ctx context.Context, a0 string, a1 string) (err error) {
 	span := trace.SpanFromContext(ctx)
@@ -260,7 +260,7 @@ type destination_client_stub struct {
 }
 
 // Check that destination_client_stub implements the Destination interface.
-var _ Destination = &destination_client_stub{}
+var _ Destination = (*destination_client_stub)(nil)
 
 func (s destination_client_stub) GetAll(ctx context.Context, a0 string) (r0 []string, err error) {
 	// Update metrics.
@@ -495,7 +495,7 @@ type server_client_stub struct {
 }
 
 // Check that server_client_stub implements the Server interface.
-var _ Server = &server_client_stub{}
+var _ Server = (*server_client_stub)(nil)
 
 func (s server_client_stub) Address(ctx context.Context) (r0 string, err error) {
 	// Update metrics.
@@ -649,7 +649,7 @@ type source_client_stub struct {
 }
 
 // Check that source_client_stub implements the Source interface.
-var _ Source = &source_client_stub{}
+var _ Source = (*source_client_stub)(nil)
 
 func (s source_client_stub) Emit(ctx context.Context, a0 string, a1 string) (err error) {
 	// Update metrics.
@@ -717,7 +717,7 @@ type destination_server_stub struct {
 }
 
 // Check that destination_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &destination_server_stub{}
+var _ codegen.Server = (*destination_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s destination_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -840,7 +840,7 @@ type server_server_stub struct {
 }
 
 // Check that server_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &server_server_stub{}
+var _ codegen.Server = (*server_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s server_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
@@ -921,7 +921,7 @@ type source_server_stub struct {
 }
 
 // Check that source_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &source_server_stub{}
+var _ codegen.Server = (*source_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s source_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {

--- a/weavertest/internal/simple/weaver_gen.go
+++ b/weavertest/internal/simple/weaver_gen.go
@@ -13,7 +13,7 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/weaver_gen.go
+++ b/weavertest/weaver_gen.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][10]struct{}]("You used 'weaver generate' codegen version 0.10.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+var _ codegen.LatestVersion = codegen.Version[[0][11]struct{}]("You used 'weaver generate' codegen version 0.11.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/weaver_gen.go
+++ b/weavertest/weaver_gen.go
@@ -29,10 +29,10 @@ func init() {
 }
 
 // weaver.Instance checks.
-var _ weaver.InstanceOf[testMainInterface] = &testMain{}
+var _ weaver.InstanceOf[testMainInterface] = (*testMain)(nil)
 
 // weaver.Router checks.
-var _ weaver.Unrouted = &testMain{}
+var _ weaver.Unrouted = (*testMain)(nil)
 
 // Local stub implementations.
 
@@ -42,7 +42,7 @@ type testMainInterface_local_stub struct {
 }
 
 // Check that testMainInterface_local_stub implements the testMainInterface interface.
-var _ testMainInterface = &testMainInterface_local_stub{}
+var _ testMainInterface = (*testMainInterface_local_stub)(nil)
 
 // Client stub implementations.
 
@@ -51,7 +51,7 @@ type testMainInterface_client_stub struct {
 }
 
 // Check that testMainInterface_client_stub implements the testMainInterface interface.
-var _ testMainInterface = &testMainInterface_client_stub{}
+var _ testMainInterface = (*testMainInterface_client_stub)(nil)
 
 // Server stub implementations.
 
@@ -61,7 +61,7 @@ type testMainInterface_server_stub struct {
 }
 
 // Check that testMainInterface_server_stub implements the codegen.Server interface.
-var _ codegen.Server = &testMainInterface_server_stub{}
+var _ codegen.Server = (*testMainInterface_server_stub)(nil)
 
 // GetStubFn implements the codegen.Server interface.
 func (s testMainInterface_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {


### PR DESCRIPTION
This PR changes the interface checks generated by `weaver generate` from

```go
var _ Fooer = &foo{}
```

to

```go
var _ Fooer = (*foo)(nil)
```

Practically, I don't think it makes a big difference, but in theory if `foo` is something like the following, instantiating a `foo` could be expensive.

```go
type foo struct { big [1000000000]byte }
```

I also added unit tests for the various `weaver generate` staleness checks generated by `weaver generate`.