### PR TITLE
Change component interface name separator character to slash on Windows.

### DIFF
--- a/internal/tool/generate/generator.go
+++ b/internal/tool/generate/generator.go
@@ -26,6 +26,7 @@ import (
 	"go/types"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -548,7 +549,7 @@ type component struct {
 }
 
 func fullName(t *types.Named) string {
-	return filepath.Join(t.Obj().Pkg().Path(), t.Obj().Name())
+	return path.Join(t.Obj().Pkg().Path(), t.Obj().Name())
 }
 
 // intfName returns the component interface name.


### PR DESCRIPTION
`\` character is the path separator on Windows. This is different from the `/` separator on Linux. The component `Name` and `RefData` generated by `weaver generate` on Windows will have `\`, not `/`. Such as `github.com\ServiceWeaver\weaver\Main`. It will cause two problems:
1. differenet from runtime.Main
 ```go
// Main is the name of the main component.
const Main = "github.com/ServiceWeaver/weaver/Main"
 ```
2. `ExtractEdges` cannot match refData containing `\` characters, because the regexp only matches `/`. 

If deploy by weaver multi, it will fali. See issue:https://github.com/ServiceWeaver/weaver/issues/350