### PR TITLE
weavertest now supports fake component implementations.

### DIFF
--- a/internal/private/private.go
+++ b/internal/private/private.go
@@ -24,9 +24,17 @@ import (
 	"reflect"
 )
 
+// RunOptions controls a Service  Weaver application execution.
+type RunOptions struct {
+	// Fakes holds a mapping from component interface type to the fake
+	// implementation to use for that component.
+	Fakes map[reflect.Type]any
+}
+
 // Run runs a Service Weaver application rooted at a component with
-// interface type rootType and app as the body of the application.
-var Run func(ctx context.Context, rootType reflect.Type, app func(context.Context, any) error) error
+// interface type rootType, app as the body of the application, and
+// the supplied options.
+var Run func(ctx context.Context, rootType reflect.Type, options RunOptions, app func(context.Context, any) error) error
 
 // Get fetches the component with type t with root recorded as the requester.
 var Get func(root any, t reflect.Type) (any, error)

--- a/weaver.go
+++ b/weaver.go
@@ -133,11 +133,11 @@ func Run[T InstanceOf[Main]](ctx context.Context, app func(context.Context, T) e
 		}
 		return app(ctx, arg)
 	}
-	return internalRun(ctx, rootType, rootBody)
+	return internalRun(ctx, rootType, private.RunOptions{}, rootBody)
 }
 
-func internalRun(ctx context.Context, rootType reflect.Type, rootBody func(context.Context, any) error) error {
-	wlet, err := newWeavelet(ctx, codegen.Registered())
+func internalRun(ctx context.Context, rootType reflect.Type, opts private.RunOptions, rootBody func(context.Context, any) error) error {
+	wlet, err := newWeavelet(ctx, opts, codegen.Registered())
 	if err != nil {
 		return fmt.Errorf("error initializating application: %w", err)
 	}

--- a/weavertest/init.go
+++ b/weavertest/init.go
@@ -77,7 +77,7 @@ type FakeComponent struct {
 	impl any
 }
 
-// Fake arranges to use impl as the implementaion for the component type T.
+// Fake arranges to use impl as the implementation for the component type T.
 // The result is typically placed in Runner.Fakes.
 func Fake[T any](impl T) FakeComponent {
 	return FakeComponent{intf: reflect.TypeOf((*T)(nil)).Elem(), impl: impl}

--- a/weavertest/init.go
+++ b/weavertest/init.go
@@ -79,7 +79,11 @@ type FakeComponent struct {
 
 // Fake arranges to use impl as the implementation for the component type T.
 // The result is typically placed in Runner.Fakes.
-func Fake[T any](impl T) FakeComponent {
+// REQUIRES: impl must implement T.
+func Fake[T any](impl any) FakeComponent {
+	if _, ok := impl.(T); !ok {
+		panic(fmt.Sprintf("%T does not implement %v", impl, reflect.TypeOf((*T)(nil)).Elem()))
+	}
 	return FakeComponent{intf: reflect.TypeOf((*T)(nil)).Elem(), impl: impl}
 }
 

--- a/weavertest/internal/diverge/diverge_test.go
+++ b/weavertest/internal/diverge/diverge_test.go
@@ -32,7 +32,7 @@ func TestDealiasing(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			localCalls := runner == weavertest.Local
+			localCalls := runner.Name == weavertest.Local.Name
 			if want, got := localCalls, (pair.X == pair.Y); want != got {
 				t.Fatalf("expecting aliasing = %v, got %v", want, got)
 			}
@@ -45,7 +45,7 @@ func TestCustomErrors(t *testing.T) {
 	for _, runner := range weavertest.AllRunners() {
 		runner.Test(t, func(t *testing.T, e Errer) {
 			err := e.Err(context.Background(), 1)
-			localCalls := runner == weavertest.Local
+			localCalls := runner.Name == weavertest.Local.Name
 			if want, got := localCalls, errors.Is(err, IntError{2}); want != got {
 				t.Fatalf("expecting Is(IntError{2}) = %v, got %v for error %v", want, got, err)
 			}

--- a/weavertest/multi.go
+++ b/weavertest/multi.go
@@ -55,7 +55,7 @@ func initMultiProcess(ctx context.Context, name string, isBench bool, runner Run
 			}
 			os.Exit(1)
 		}()
-		err := runWeaver(ctx, func(context.Context, any) error {
+		err := runWeaver(ctx, runner, func(context.Context, any) error {
 			return nil
 		})
 		if err != nil {


### PR DESCRIPTION
Some of the components in a Service Weaver application can now be replaced with fake test-specific implementations when using weavertest. The test code registers a set of such fake implementations with weavertest.Runner. When the test runs, the real component implementations are replaced by the supplied fakes.