### PR TITLE
Added "weaver single deploy <config>" command.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -597,12 +597,19 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     time
 github.com/ServiceWeaver/weaver/internal/tool/single
     context
+    errors
+    flag
     fmt
     github.com/ServiceWeaver/weaver/internal/must
     github.com/ServiceWeaver/weaver/internal/status
     github.com/ServiceWeaver/weaver/runtime
+    github.com/ServiceWeaver/weaver/runtime/codegen
     github.com/ServiceWeaver/weaver/runtime/tool
+    os
+    os/exec
+    os/signal
     path/filepath
+    syscall
 github.com/ServiceWeaver/weaver/internal/tool/ssh
     bufio
     context

--- a/internal/tool/single/deploy.go
+++ b/internal/tool/single/deploy.go
@@ -1,0 +1,86 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package single
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+
+	"github.com/ServiceWeaver/weaver/runtime"
+	"github.com/ServiceWeaver/weaver/runtime/codegen"
+	"github.com/ServiceWeaver/weaver/runtime/tool"
+)
+
+var deployCmd = tool.Command{
+	Name:        "deploy",
+	Description: "Deploy a Service Weaver app",
+	Help:        "Usage:\n  weaver single deploy <configfile>",
+	Flags:       flag.NewFlagSet("deploy", flag.ContinueOnError),
+	Fn:          deploy,
+}
+
+// deploy deploys an application on the local machine using the single process
+// deployer.
+func deploy(ctx context.Context, args []string) error {
+	// Validate command line arguments.
+	if len(args) == 0 {
+		return fmt.Errorf("no config file provided")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments")
+	}
+
+	// Load the config file.
+	configFile := args[0]
+	bytes, err := os.ReadFile(configFile)
+	if err != nil {
+		return fmt.Errorf("load config file %q: %w\n", configFile, err)
+	}
+	config, err := runtime.ParseConfig(configFile, string(bytes), codegen.ComponentConfigValidator)
+	if err != nil {
+		return fmt.Errorf("load config file %q: %w\n", configFile, err)
+	}
+	if _, err := os.Stat(config.Binary); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("binary %q doesn't exist", config.Binary)
+	}
+
+	// Set up the binary.
+	cmd := exec.Command(config.Binary)
+	cmd.Args = config.Args
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Make sure that the subprocess dies when we die. This isn't perfect, as
+	// we can't catch a SIGKILL, but it's good in the common case.
+	killed := make(chan os.Signal, 1)
+	signal.Notify(killed, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-killed
+		if cmd.Process != nil {
+			cmd.Process.Kill() //nolint:errcheck
+		}
+		os.Exit(1)
+	}()
+
+	// Run the binary
+	return cmd.Run()
+}

--- a/internal/tool/single/single.go
+++ b/internal/tool/single/single.go
@@ -49,6 +49,7 @@ var (
 	}
 
 	Commands = map[string]*tool.Command{
+		"deploy":    &deployCmd,
 		"status":    status.StatusCommand("weaver single", defaultRegistry),
 		"dashboard": status.DashboardCommand(dashboardSpec),
 		"metrics":   status.MetricsCommand("weaver single", defaultRegistry),

--- a/website/docs.md
+++ b/website/docs.md
@@ -747,6 +747,12 @@ config file using the `SERVICEWEAVER_CONFIG` environment variable:
 $ SERVICEWEAVER_CONFIG=weaver.toml go run .
 ```
 
+Or, use `weaver single deploy`:
+
+```console
+$ weaver single deploy weaver.toml
+```
+
 # Logging
 
 <div hidden class="todo">
@@ -1363,6 +1369,21 @@ Tutorial](#step-by-step-tutorial) section for a full example.
 
 ```console
 $ go run .
+```
+
+If you run an application using `go run`, you can provide a config file using
+the `SERVICEWEAVER_CONFIG` environment variable:
+
+```console
+$ SERVICEWEAVER_CONFIG=weaver.toml go run .
+```
+
+Or, you can use the `weaver single deploy` command. `weaver single deploy` is
+practically identical to `go run .`, but it makes it easier to provide a config
+file.
+
+```console
+$ weaver single deploy weaver.toml
 ```
 
 You can run `weaver single status` to view the status of all active Service


### PR DESCRIPTION
This PR introduces a `weaver single deploy <config>` command that acts like `go run .` The new command has two benefits. First, it makes the weaver tool's UI more uniform, as there's already a `weaver multi deploy`, `weaver ssh deploy`, etc. Second, it makes it easier to provide config files to single process deployments. Previously, you had to use the `SERVICEWEAVER_CONFIG` environment variable, which was unergonomic and easy to forget.