### PR TITLE
Fixed bug in logic deciding when to run main.

### DIFF
--- a/weavelet.go
+++ b/weavelet.go
@@ -251,7 +251,9 @@ func (w *weavelet) start() error {
 }
 
 func (w *weavelet) Wait(ctx context.Context) error {
-	if m, ok := w.componentsByType[reflect.TypeOf((*Main)(nil)).Elem()]; ok && m.local.Read() {
+	// Note that a weavertest may have RunMain set to true, but no main
+	// component registered.
+	if m, ok := w.componentsByType[reflect.TypeOf((*Main)(nil)).Elem()]; ok && w.info.RunMain {
 		// This process is hosting weaver.Main, so call its Main() method.
 		impl, err := w.getImpl(ctx, m)
 		if err != nil {


### PR DESCRIPTION
Previously, a weavelet decided to run the main component's Main method if it had a registered main component that was marked local. This worked for the single process deployers but broke all other deployers. For weavelets not started in singleprocess mode, the weavelet receives an explicit `RunMain` field in `EnvelopeOptions` that signals it to start running main.

This bug also re-emphasizes the importance of tests that automatically run all the deployers. I'll prioritize this and finish up PR #287.