### PR TITLE
Added test to catch incorrect version updates.

### DIFF
--- a/runtime/version/version.go
+++ b/runtime/version/version.go
@@ -62,8 +62,8 @@ const (
 var version string
 
 func init() {
-	// Make sure that the hardcoded string reflects the values of Major, Minor and
-	// Patch.
+	// Make sure that the hardcoded string reflects the values of Major, Minor
+	// and Patch.
 	version = "⟦wEaVeRvErSiOn:0.13.0⟧"
 }
 

--- a/runtime/version/version.go
+++ b/runtime/version/version.go
@@ -57,14 +57,16 @@ const (
 //
 // NOTE that version should be initialized with a hardcoded string that should
 // reflect the values of Major, Minor and Patch.
-//
-//nolint:unused
 var version string
 
 func init() {
 	// Make sure that the hardcoded string reflects the values of Major, Minor
 	// and Patch.
 	version = "⟦wEaVeRvErSiOn:0.13.0⟧"
+
+	// Disable unused linter errors. A nolint:unused annotation doesn't work
+	// because version is actually used by version_test.go.
+	_ = version
 }
 
 // ReadVersion reads version (major, minor, patch) from the specified binary.

--- a/runtime/version/version_test.go
+++ b/runtime/version/version_test.go
@@ -22,6 +22,23 @@ import (
 	"testing"
 )
 
+// Test that version matches Major, Minor, and Patch.
+func TestStaleVersion(t *testing.T) {
+	major, minor, patch, err := extractVersion([]byte(version))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if major != Major {
+		t.Errorf("major: got %d, want %d", major, Major)
+	}
+	if minor != Minor {
+		t.Errorf("minor: got %d, want %d", minor, Minor)
+	}
+	if patch != Patch {
+		t.Errorf("patch: got %d, want %d", patch, Patch)
+	}
+}
+
 func TestExtractVersion(t *testing.T) {
 	for _, test := range []struct{ major, minor, patch int }{
 		{0, 0, 0},


### PR DESCRIPTION
Recall that we hardcode the deployer API version into every weaver application binary. The hardcoded string is called version. Additionally, we have constants for the Major, Minor, and Patch of the deployer API version. These two need to stay in sync, but because version has to be hardcoded, there is no way to programmatically keep them in sync. This makes it easy to change Major, Minor, and Patch but forget to update version. This PR adds a unit test that fails if you forget to change version.