### PR TITLE
Revamped 'weaver version' commands.

### DIFF
--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -34,6 +35,7 @@ import (
 const usage = `USAGE
 
   weaver generate                 // weaver code generator
+  weaver version                  // show weaver version
   weaver single    <command> ...  // for single process deployments
   weaver multi     <command> ...  // for multiprocess deployments
   weaver ssh       <command> ...  // for multimachine deployments
@@ -44,8 +46,8 @@ DESCRIPTION
 
   Use the "weaver" command to deploy and manage Weaver applications.
 
-  The "weaver generate", "weaver single", "weaver multi", and "weaver ssh"
-  subcommands are baked in, but all other subcommands of the form
+  The "weaver generate", "weaver version", "weaver single", "weaver multi", and
+  "weaver ssh" subcommands are baked in, but all other subcommands of the form
   "weaver <deployer>" dispatch to a binary called "weaver-<deployer>".
   "weaver gke status", for example, dispatches to "weaver-gke status".
 `
@@ -74,6 +76,14 @@ func main() {
 		}
 		generateFlags.Parse(flag.Args()[1:]) //nolint:errcheck // does os.Exit on error
 		if err := generate.Generate(".", flag.Args()[1:], generate.Options{}); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+
+	case "version":
+		cmd := tool.VersionCmd("weaver")
+		if err := cmd.Fn(context.Background(), flag.Args()[1:]); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}

--- a/godeps.txt
+++ b/godeps.txt
@@ -54,6 +54,7 @@ github.com/ServiceWeaver/weaver
     syscall
     time
 github.com/ServiceWeaver/weaver/cmd/weaver
+    context
     errors
     flag
     fmt
@@ -871,6 +872,7 @@ github.com/ServiceWeaver/weaver/runtime/tool
     errors
     flag
     fmt
+    github.com/ServiceWeaver/weaver/runtime/codegen
     github.com/ServiceWeaver/weaver/runtime/colors
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/version

--- a/runtime/tool/version.go
+++ b/runtime/tool/version.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"runtime/debug"
 
+	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"github.com/ServiceWeaver/weaver/runtime/version"
 )
 
@@ -32,9 +33,12 @@ func VersionCmd(tool string) *Command {
 		Description: fmt.Sprintf("Show %q version", tool),
 		Help:        fmt.Sprintf("Usage:\n  %s version", tool),
 		Fn: func(context.Context, []string) error {
-			semver := fmt.Sprintf("%d.%d.%d", version.Major, version.Minor, version.Patch)
+			deployerAPI := fmt.Sprintf("%d.%d.%d", version.Major, version.Minor, version.Patch)
+			codegenAPI := fmt.Sprintf("%d.%d.0", codegen.Major, codegen.Minor)
+			release := "?"
 			commit := "?"
 			if info, ok := debug.ReadBuildInfo(); ok {
+				release = info.Main.Version
 				for _, setting := range info.Settings {
 					// vcs.revision stores the commit at which the weaver tool
 					// was built. See [1] for more information.
@@ -46,7 +50,11 @@ func VersionCmd(tool string) *Command {
 					}
 				}
 			}
-			fmt.Printf("%s: commit=%s deployer=v%s target=%s/%s\n", tool, commit, semver, runtime.GOOS, runtime.GOARCH)
+			fmt.Printf("%s %s\n", tool, release)
+			fmt.Printf("target: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+			fmt.Printf("commit: %s\n", commit)
+			fmt.Printf("deployer API: %s\n", deployerAPI)
+			fmt.Printf("codegen API: %s\n", codegenAPI)
 			return nil
 		},
 	}

--- a/website/docs.md
+++ b/website/docs.md
@@ -59,6 +59,7 @@ $ weaver --help
 USAGE
 
   weaver generate                 // weaver code generator
+  weaver version                  // show weaver version
   weaver single    <command> ...  // for single process deployments
   weaver multi     <command> ...  // for multiprocess deployments
   ...


### PR DESCRIPTION
```console
$ weaver version
weaver 0.13.0
target: linux/amd64
commit: ea2a43e272d709a8e6d866d3dbc456885a5f55af
deployer API: 0.13.0
codegen API: 0.11.0
```

This PR does three things:

1. It adds the module version and codegen API version to the output of the weaver version commands.
2. It reformats the output of the weaver version commands to be multiple lines instead of one.
3. It adds a 'weaver version' command (fixes #360).