### PR TITLE
Add reflection.Type[T]() helper and use it.

### DIFF
--- a/fillrefs.go
+++ b/fillrefs.go
@@ -17,6 +17,8 @@ package weaver
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/ServiceWeaver/weaver/internal/reflection"
 )
 
 // fillRefs initializes Ref[T] fields in a component implement struct.
@@ -32,7 +34,7 @@ func fillRefs(impl any, get func(reflect.Type) (any, error)) error {
 	if s.Kind() != reflect.Struct {
 		return fmt.Errorf("not a struct pointer")
 	}
-	isRef := reflect.TypeOf((*interface{ isRef() })(nil)).Elem()
+	isRef := reflection.Type[interface{ isRef() }]()
 	for i, n := 0, s.NumField(); i < n; i++ {
 		// Handle field with type weaver.Ref[T].
 		ref := s.Field(i)

--- a/godeps.txt
+++ b/godeps.txt
@@ -13,6 +13,7 @@ github.com/ServiceWeaver/weaver
     github.com/ServiceWeaver/weaver/internal/metrics
     github.com/ServiceWeaver/weaver/internal/net/call
     github.com/ServiceWeaver/weaver/internal/private
+    github.com/ServiceWeaver/weaver/internal/reflection
     github.com/ServiceWeaver/weaver/internal/register
     github.com/ServiceWeaver/weaver/internal/status
     github.com/ServiceWeaver/weaver/internal/tool/single
@@ -466,6 +467,8 @@ github.com/ServiceWeaver/weaver/internal/queue
     context
     github.com/ServiceWeaver/weaver/internal/cond
     sync
+github.com/ServiceWeaver/weaver/internal/reflection
+    reflect
 github.com/ServiceWeaver/weaver/internal/register
     fmt
     sync
@@ -901,6 +904,7 @@ github.com/ServiceWeaver/weaver/weavertest
     github.com/ServiceWeaver/weaver
     github.com/ServiceWeaver/weaver/internal/envelope/conn
     github.com/ServiceWeaver/weaver/internal/private
+    github.com/ServiceWeaver/weaver/internal/reflection
     github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/codegen
     github.com/ServiceWeaver/weaver/runtime/envelope

--- a/internal/envelope/conn/conn_test.go
+++ b/internal/envelope/conn/conn_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ServiceWeaver/weaver"
 	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
+	"github.com/ServiceWeaver/weaver/internal/reflection"
 	"github.com/ServiceWeaver/weaver/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
@@ -195,7 +196,7 @@ func register[Intf, Impl any](name string) {
 	var zero Impl
 	codegen.Register(codegen.Registration{
 		Name:         name,
-		Iface:        reflect.TypeOf((*Intf)(nil)).Elem(),
+		Iface:        reflection.Type[Intf](),
 		Impl:         reflect.TypeOf(zero),
 		LocalStubFn:  func(any, trace.Tracer) any { return nil },
 		ClientStubFn: func(codegen.Stub, string) any { return nil },

--- a/internal/reflection/reflection.go
+++ b/internal/reflection/reflection.go
@@ -1,0 +1,26 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package reflection implements helpers for reflection code.
+package reflection
+
+import "reflect"
+
+// Type returns the reflect.Type for T.
+//
+// This function is particularly useful when T is an interface
+// and it is impossible to get a value with concrete type T.
+func Type[T any]() reflect.Type {
+	return reflect.TypeOf((*T)(nil)).Elem()
+}

--- a/internal/reflection/reflection_test.go
+++ b/internal/reflection/reflection_test.go
@@ -1,0 +1,26 @@
+package reflection_test
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/ServiceWeaver/weaver/internal/reflection"
+)
+
+func TestType(t *testing.T) {
+	for _, test := range []struct {
+		want string
+		t    reflect.Type
+	}{
+		{"int", reflection.Type[int]()},
+		{"io.Reader", reflection.Type[io.Reader]()},
+	} {
+		t.Run(test.want, func(t *testing.T) {
+			if got := fmt.Sprint(test.t); got != test.want {
+				t.Errorf("reflection.Type[io.Reader] = %s, expecting %s", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/reflection/reflection_test.go
+++ b/internal/reflection/reflection_test.go
@@ -33,7 +33,7 @@ func TestType(t *testing.T) {
 	} {
 		t.Run(test.want, func(t *testing.T) {
 			if got := fmt.Sprint(test.t); got != test.want {
-				t.Errorf("reflection.Type[io.Reader] = %s, expecting %s", got, test.want)
+				t.Errorf("reflection.Type() = %s, expecting %s", got, test.want)
 			}
 		})
 	}

--- a/internal/reflection/reflection_test.go
+++ b/internal/reflection/reflection_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package reflection_test
 
 import (

--- a/runtime/codegen/registry_test.go
+++ b/runtime/codegen/registry_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/ServiceWeaver/weaver"
+	"github.com/ServiceWeaver/weaver/internal/reflection"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -120,7 +121,7 @@ func register[Intf, Impl any](name string) {
 	var zero Impl
 	codegen.Register(codegen.Registration{
 		Name:         name,
-		Iface:        reflect.TypeOf((*Intf)(nil)).Elem(),
+		Iface:        reflection.Type[Intf](),
 		Impl:         reflect.TypeOf(zero),
 		LocalStubFn:  func(any, trace.Tracer) any { return nil },
 		ClientStubFn: func(codegen.Stub, string) any { return nil },

--- a/runtime/envelope/envelope_test.go
+++ b/runtime/envelope/envelope_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/ServiceWeaver/weaver"
 	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
+	"github.com/ServiceWeaver/weaver/internal/reflection"
 	"github.com/ServiceWeaver/weaver/internal/traceio"
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
@@ -549,7 +550,7 @@ func register[Intf, Impl any](name string) {
 	var zero Impl
 	codegen.Register(codegen.Registration{
 		Name:         name,
-		Iface:        reflect.TypeOf((*Intf)(nil)).Elem(),
+		Iface:        reflection.Type[Intf](),
 		Impl:         reflect.TypeOf(zero),
 		LocalStubFn:  func(any, trace.Tracer) any { return nil },
 		ClientStubFn: func(codegen.Stub, string) any { return nil },

--- a/weavelet.go
+++ b/weavelet.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
 	"github.com/ServiceWeaver/weaver/internal/net/call"
 	"github.com/ServiceWeaver/weaver/internal/private"
+	"github.com/ServiceWeaver/weaver/internal/reflection"
 	"github.com/ServiceWeaver/weaver/internal/traceio"
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
@@ -250,7 +251,7 @@ func (w *weavelet) start() error {
 func (w *weavelet) getMainIfLocal() (*componentImpl, error) {
 	// Note that a weavertest may have RunMain set to true, but no main
 	// component registered.
-	if m, ok := w.componentsByType[reflect.TypeOf((*Main)(nil)).Elem()]; ok && w.info.RunMain {
+	if m, ok := w.componentsByType[reflection.Type[Main]()]; ok && w.info.RunMain {
 		return w.getImpl(w.ctx, m)
 	}
 	return nil, nil

--- a/weavertest/init.go
+++ b/weavertest/init.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ServiceWeaver/weaver"
 	"github.com/ServiceWeaver/weaver/internal/private"
+	"github.com/ServiceWeaver/weaver/internal/reflection"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 )
 
@@ -83,10 +84,11 @@ type FakeComponent struct {
 // The result is typically placed in Runner.Fakes.
 // REQUIRES: impl must implement T.
 func Fake[T any](impl any) FakeComponent {
+	t := reflection.Type[T]()
 	if _, ok := impl.(T); !ok {
-		panic(fmt.Sprintf("%T does not implement %v", impl, reflect.TypeOf((*T)(nil)).Elem()))
+		panic(fmt.Sprintf("%T does not implement %v", impl, t))
 	}
-	return FakeComponent{intf: reflect.TypeOf((*T)(nil)).Elem(), impl: impl}
+	return FakeComponent{intf: t, impl: impl}
 }
 
 // private.App object per live test or benchmark.


### PR DESCRIPTION
Previously we would have to write complicated code to get the reflect.Type for an interface since an interface cannot have a concrete value and therefore reflect.TypeOf() did not work. Encapsulated this logic into a single generic function.