### PR TITLE
Fixed args + env bug in "weaver single deploy".

### DIFF
--- a/internal/tool/single/deploy.go
+++ b/internal/tool/single/deploy.go
@@ -63,11 +63,11 @@ func deploy(ctx context.Context, args []string) error {
 	}
 
 	// Set up the binary.
-	cmd := exec.Command(config.Binary)
-	cmd.Args = config.Args
+	cmd := exec.Command(config.Binary, config.Args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Env = append(cmd.Environ(), "SERVICEWEAVER_CONFIG="+configFile)
 
 	// Make sure that the subprocess dies when we die. This isn't perfect, as
 	// we can't catch a SIGKILL, but it's good in the common case.


### PR DESCRIPTION
This PR fixes two bugs. First, `weaver single deploy <config>` was not actually passing the config file to the underlying Service Weaver app, completely defeating the purpose of the command (d'oh). Second, I was incorrectly passing arguments using `Cmd.Args` instead of `exec.Command`.