### PR TITLE
Add a test for the examples

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,6 +49,10 @@ jobs:
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
         if: ${{ matrix.command == 'lint' }}
 
+      - name: Build the weaver binary
+        run: cd cmd/weaver; go build .
+        if: ${{ matrix.command == 'test' || matrix.command == 'testrace' }}
+
       - name: ${{ matrix.command }}
         run: ./dev/build_and_test ${{ matrix.command }}
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -1,0 +1,181 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/ServiceWeaver/weaver/runtime/retry"
+)
+
+type test struct {
+	url  string // url to GET
+	want string // expected response
+}
+
+func TestExamples(t *testing.T) {
+	testCases := map[string]test{
+		"hello": {
+			url:  "http://localhost:12345/hello?name=something",
+			want: "Hello, gnihtemos!\n",
+		},
+		"collatz": {
+			url:  "http://127.0.0.1:9000?x=8",
+			want: "8\n4\n2\n1\n",
+		},
+		"reverser": {
+			url:  "http://127.0.0.1:9000/reverse?s=abcdef",
+			want: "fedcba\n",
+		},
+	}
+
+	examples, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, example := range examples {
+		if !example.IsDir() {
+			continue
+		}
+
+		name := example.Name()
+		t.Run(name, func(t *testing.T) {
+			test, ok := testCases[name]
+			if !ok {
+				// TODO: make this t.Fatal once existing examples have tests
+				t.Skip("no test case defined")
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			t.Cleanup(cancel)
+
+			// Build the example binary.
+			chdir(t, name)
+			cmd := startCmd(ctx, t, "go", "build", ".")
+			if err := cmd.Wait(); err != nil {
+				t.Fatalf("failed to build binary: %v", err)
+			}
+
+			// Run the application directly.
+			t.Run("single", func(t *testing.T) {
+				cmd := startCmd(ctx, t, "./"+name)
+				t.Cleanup(terminateCmdAndWait(t, cmd))
+				run(t, test)
+			})
+
+			// "weaver single deploy" the application.
+			t.Run("weaver-single", func(t *testing.T) {
+				cmd := startCmd(ctx, t, "../../cmd/weaver/weaver", "single", "deploy", "weaver.toml")
+				t.Cleanup(terminateCmdAndWait(t, cmd))
+				run(t, test)
+			})
+
+			// "weaver multi deploy" the application.
+			t.Run("weaver-multi", func(t *testing.T) {
+				cmd := startCmd(ctx, t, "../../cmd/weaver/weaver", "multi", "deploy", "weaver.toml")
+				t.Cleanup(terminateCmdAndWait(t, cmd))
+				run(t, test)
+			})
+
+			// TODO: other deployers?
+		})
+	}
+}
+
+func run(t *testing.T, test test) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	t.Cleanup(cancel)
+
+	// Send a GET request to the endpoint, retrying on error.
+	client := http.DefaultClient
+	var resp *http.Response
+	var err error
+	for r := retry.Begin(); r.Continue(ctx); {
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, test.url, nil)
+		if reqErr != nil {
+			t.Fatal(reqErr)
+		}
+
+		resp, err = client.Do(req)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		t.Fatalf("timeout waiting on listener, last error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check that the GET response is as expected.
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected response code OK 200, got %v", resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual := string(body); actual != test.want {
+		t.Fatalf("response body is %v, expected %v", actual, test.want)
+	}
+}
+
+// chdir cd's to the provided path, cd'ing back to the current working
+// directory when the test finishes.
+func chdir(t *testing.T, path string) {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(path); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func startCmd(ctx context.Context, t *testing.T, name string, args ...string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.WaitDelay = 2 * time.Second
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	return cmd
+}
+
+func terminateCmdAndWait(t *testing.T, cmd *exec.Cmd) func() {
+	return func() {
+		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+			t.Fatalf("failed to terminate process: %v", err)
+		}
+		if err := cmd.Wait(); err != nil {
+			t.Logf("exit error: %v", err)
+		}
+	}
+}

--- a/godeps.txt
+++ b/godeps.txt
@@ -83,6 +83,7 @@ github.com/ServiceWeaver/weaver/dev/docgen
     path/filepath
     regexp
     strings
+github.com/ServiceWeaver/weaver/examples
 github.com/ServiceWeaver/weaver/examples/chat
     bytes
     context

--- a/runtime/logging/logger_test.go
+++ b/runtime/logging/logger_test.go
@@ -36,13 +36,14 @@ func TestTestLogger(t *testing.T) {
 		go func() {
 			for {
 				logger.Debug("Ping")
+				time.Sleep(200 * time.Microsecond)
 			}
 		}()
 		// Give the logger a chance to log something.
 		time.Sleep(1 * time.Millisecond)
 	})
 	// Allow the goroutine to keep running, even though the test has finished.
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 }
 
 func TestWithAttribute(t *testing.T) {


### PR DESCRIPTION
This PR was originally written by @dnephin in https://github.com/ServiceWeaver/weaver/pull/287. The tests were
working locally but not on GitHub Actions. After some debugging, I found
that running subcommands using "sh -c" was causing things to hang. I
still have no idea why that is, but things are working now :)

I also tweaked logger_test.go because it was printing a lot (and I mean
a LOT) of stuff. When debugging on GitHub Actions, these logs were very
annoying.

Original commit messages from @dnephin:

> This commit adds a test case for running each of the examples as both a
> single deploy and multi-deploy. This test should ensure that the
> examples are always in a working state, and provide some end-to-end
> coverage of the single and multi deployers.
>
> It also provides some test coverage of the integration of codegen with a
> real application.
>
> Register signal handler before listening
>
> TestExamples only waits for a listener to be listening and handling HTTP
> requests.
>
> The signal handler must be registered before the listener is started,
> otherwise a test waiting on the listener could send a SIGTERM before
> the signal handler is registered.