### PR TITLE
Move prometheus files to runtime

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -406,17 +406,10 @@ github.com/ServiceWeaver/weaver/internal/files
 github.com/ServiceWeaver/weaver/internal/heap
     container/heap
 github.com/ServiceWeaver/weaver/internal/metrics
-    bytes
     context
-    fmt
     github.com/ServiceWeaver/weaver/runtime/codegen
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/metrics
-    github.com/ServiceWeaver/weaver/runtime/protos
-    golang.org/x/exp/maps
-    math
-    sort
-    strconv
     strings
     sync
     time
@@ -489,12 +482,12 @@ github.com/ServiceWeaver/weaver/internal/status
     flag
     fmt
     github.com/ServiceWeaver/weaver/internal/files
-    github.com/ServiceWeaver/weaver/internal/metrics
     github.com/ServiceWeaver/weaver/runtime/codegen
     github.com/ServiceWeaver/weaver/runtime/colors
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/metrics
     github.com/ServiceWeaver/weaver/runtime/perfetto
+    github.com/ServiceWeaver/weaver/runtime/prometheus
     github.com/ServiceWeaver/weaver/runtime/protomsg
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/tool
@@ -839,6 +832,17 @@ github.com/ServiceWeaver/weaver/runtime/profiling
     fmt
     github.com/google/pprof/profile
     sync
+github.com/ServiceWeaver/weaver/runtime/prometheus
+    bytes
+    fmt
+    github.com/ServiceWeaver/weaver/runtime/logging
+    github.com/ServiceWeaver/weaver/runtime/metrics
+    github.com/ServiceWeaver/weaver/runtime/protos
+    golang.org/x/exp/maps
+    math
+    sort
+    strconv
+    strings
 github.com/ServiceWeaver/weaver/runtime/protomsg
     bytes
     context

--- a/internal/status/dashboard.go
+++ b/internal/status/dashboard.go
@@ -29,11 +29,11 @@ import (
 	"strings"
 	"time"
 
-	imetrics "github.com/ServiceWeaver/weaver/internal/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/perfetto"
+	imetrics "github.com/ServiceWeaver/weaver/runtime/prometheus"
 	protos "github.com/ServiceWeaver/weaver/runtime/protos"
 	dtool "github.com/ServiceWeaver/weaver/runtime/tool"
 	"github.com/pkg/browser"

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -19,8 +19,8 @@ import (
 	"context"
 	"net/http"
 
-	imetrics "github.com/ServiceWeaver/weaver/internal/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
+	imetrics "github.com/ServiceWeaver/weaver/runtime/prometheus"
 	"github.com/ServiceWeaver/weaver/runtime/protomsg"
 	protos "github.com/ServiceWeaver/weaver/runtime/protos"
 	"golang.org/x/exp/slog"

--- a/runtime/prometheus/prometheus.go
+++ b/runtime/prometheus/prometheus.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metrics
+package prometheus
 
 import (
 	"bytes"

--- a/runtime/prometheus/prometheus_test.go
+++ b/runtime/prometheus/prometheus_test.go
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metrics_test
+package prometheus_test
 
 import (
 	"bytes"
 	"regexp"
 	"testing"
 
-	imetrics "github.com/ServiceWeaver/weaver/internal/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
+	imetrics "github.com/ServiceWeaver/weaver/runtime/prometheus"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 )
 


### PR DESCRIPTION
In the current implementation, we are using prometheus to export metrics from the single/multi/ssh deployer, which are part of the weaver repo.

However, in the upcoming kubernetes deployer (that's in a different repo), we will rely on prometheus to export the metrics as well. However, we can't (shouldn't) depend on internal files from /weaver.

Given that the prometheus metric translator will be used in other repos, we should move it to runtime/prometheus (we already have runtime/perfetto).