### PR TITLE
Added `weaver completion` bash completion command.

### DIFF
--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"flag"
 	"fmt"
@@ -51,6 +52,9 @@ DESCRIPTION
   "weaver <deployer>" dispatch to a binary called "weaver-<deployer>".
   "weaver gke status", for example, dispatches to "weaver-gke status".
 `
+
+//go:embed weaver_completion.bash
+var completion string
 
 func main() {
 	// Parse flags.
@@ -87,6 +91,10 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
+		return
+
+	case "completion":
+		fmt.Print(completion)
 		return
 
 	case "single", "multi", "ssh":

--- a/cmd/weaver/weaver_completion.bash
+++ b/cmd/weaver/weaver_completion.bash
@@ -1,0 +1,63 @@
+#/usr/bin/env bash
+
+# This file is a bash completion script that enables tab completion for the
+# weaver command. For example:
+#
+#     $ weaver <tab><tab>
+#     generate   gke        gke-local  multi      single     ssh        version
+#     $ weaver single <tab><tab>
+#     dashboard  deploy     help       metrics    profile    purge      status     version
+#     $ weaver single p<tab><tab>
+#     profile  purge
+#
+# To enable the tab completion, you must source this file, typically by running
+# `source <(weaver completion)`. This mirrors `kubectl completion bash` [3].
+# Source the file in your ~/.bashrc if you always want it to be enabled.
+#
+# See [1] for a tutorial on how to write bash completion scripts. See [2] for an
+# explanation of our usage of `-o default`.
+#
+# [1]: https://opensource.com/article/18/3/creating-bash-completion-script
+# [2]: https://stackoverflow.com/a/19062943
+# [3]: https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-autocomplete
+
+_weaver_complete() {
+  compopt +o default
+
+  # weaver
+  if [[ $COMP_CWORD == 1 ]]; then
+    COMPREPLY=($(compgen -W "generate version single multi ssh gke gke-local" "${COMP_WORDS[1]}"))
+    return
+  fi
+
+  # weaver generate
+  if [[ "${COMP_WORDS[1]}" == "generate" ]]; then
+    compopt -o default
+    return
+  fi
+
+  # weaver version
+  if [[ "${COMP_WORDS[1]}" == "version" ]]; then
+    return
+  fi
+
+  # weaver {single,multi,ssh,gke,gke-local}
+  declare -A subcommands
+  subcommands["single"]="dashboard deploy help metrics profile purge status version"
+  subcommands["multi"]="dashboard deploy help logs metrics profile purge status version"
+  subcommands["ssh"]="dashboard deploy help logs version"
+  subcommands["gke"]="dashboard deploy help kill logs profile status version"
+  subcommands["gke-local"]="dashboard deploy help kill logs profile purge status version"
+  local -r deployer="${COMP_WORDS[1]}"
+  if [[ "${subcommands[$deployer]}" != "" ]]; then
+    return
+  elif [[ $COMP_CWORD == 2 ]]; then
+    COMPREPLY=($(compgen -W "${subcommands[$deployer]}" "${COMP_WORDS[2]}"))
+  elif [[ ${COMP_WORDS[2]} == "deploy" && $COMP_CWORD == 3 ]]; then
+    compopt -o default
+  elif [[ ${COMP_WORDS[2]} == "help" && $COMP_CWORD == 3 ]]; then
+    COMPREPLY=($(compgen -W "${subcommands[$deployer]}" "${COMP_WORDS[3]}"))
+  fi
+}
+
+complete -o default -F _weaver_complete weaver

--- a/godeps.txt
+++ b/godeps.txt
@@ -55,6 +55,7 @@ github.com/ServiceWeaver/weaver
     time
 github.com/ServiceWeaver/weaver/cmd/weaver
     context
+    embed
     errors
     flag
     fmt


### PR DESCRIPTION
This PR introduces a `weaver completion` command that spits out a bash completion script that enables tab completion for the weaver command. For example:

```bash
$ weaver <tab><tab>
generate   gke        gke-local  multi      single     ssh        version
$ weaver single <tab><tab>
dashboard  deploy     help       metrics    profile    purge      status     version
$ weaver single p<tab><tab>
profile  purge
```

To enable the tab completion, you run `source <(weaver completion)`. This mirrors [`kubectl completion bash`][3]. Source the file in your `~/.bashrc` if you always want it to be enabled.

I added `weaver completion` selfishly, as I thought it was useful. If others find it useful, we can advertise it to users. There is a bit of overhead in updating it whenever commands change, and the gke commands could be stale, so it would require work to be more robust. Also happy to leave this out of the repo and have it privately for myself.

[3]: https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-autocomplete