### PR TITLE
Remove versioning checks in multi/ssh deployers

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -576,7 +576,6 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/retry
     github.com/ServiceWeaver/weaver/runtime/tool
-    github.com/ServiceWeaver/weaver/runtime/version
     github.com/google/uuid
     go.opentelemetry.io/otel/sdk/trace
     golang.org/x/exp/maps
@@ -622,7 +621,6 @@ github.com/ServiceWeaver/weaver/internal/tool/ssh
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/tool
-    github.com/ServiceWeaver/weaver/runtime/version
     github.com/google/uuid
     golang.org/x/exp/maps
     io

--- a/internal/tool/multi/deploy.go
+++ b/internal/tool/multi/deploy.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/retry"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
-	"github.com/ServiceWeaver/weaver/runtime/version"
 	"github.com/google/uuid"
 )
 
@@ -86,17 +85,6 @@ func deploy(ctx context.Context, args []string) error {
 	multiConfig := config{}
 	if err := runtime.ParseConfigSection(configKey, shortConfigKey, appConfig.Sections, &multiConfig); err != nil {
 		return fmt.Errorf("parse multi config: %w", err)
-	}
-	major, minor, patch, err := version.ReadVersion(appConfig.Binary)
-	if err != nil {
-		return fmt.Errorf("read binary version: %w", err)
-	}
-	if major != version.Major || minor != version.Minor || patch != version.Patch {
-		return fmt.Errorf(
-			"version mismatch: deployer version %d.%d.%d is incompatible with app version %d.%d.%d",
-			version.Major, version.Minor, version.Patch,
-			major, minor, patch,
-		)
 	}
 
 	// Create the deployer.

--- a/internal/tool/ssh/deploy.go
+++ b/internal/tool/ssh/deploy.go
@@ -39,7 +39,6 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
-	"github.com/ServiceWeaver/weaver/runtime/version"
 )
 
 var deployCmd = tool.Command{
@@ -75,17 +74,6 @@ func deploy(ctx context.Context, args []string) error {
 	// Sanity check the config.
 	if _, err := os.Stat(app.Binary); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("binary %q doesn't exist", app.Binary)
-	}
-	major, minor, patch, err := version.ReadVersion(app.Binary)
-	if err != nil {
-		return fmt.Errorf("read binary version: %w", err)
-	}
-	if major != version.Major || minor != version.Minor || patch != version.Patch {
-		return fmt.Errorf(
-			"version mismatch: deployer version %d.%d.%d is incompatible with app version %d.%d.%d",
-			version.Major, version.Minor, version.Patch,
-			major, minor, patch,
-		)
 	}
 
 	// Retrieve the list of locations to deploy.


### PR DESCRIPTION
Note that we do these checks when we create an envelope, hence these checks are stale.