### PR TITLE
Add reference/example to the kube deployer

### DIFF
--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -41,6 +41,7 @@ const usage = `USAGE
   weaver ssh       <command> ...  // for multimachine deployments
   weaver gke       <command> ...  // for GKE deployments
   weaver gke-local <command> ...  // for simulated GKE deployments
+  weaver kube      <command> ...  // for vanilla Kubernetes deployments
 
 DESCRIPTION
 

--- a/examples/collatz/weaver.toml
+++ b/examples/collatz/weaver.toml
@@ -13,3 +13,6 @@ regions = ["us-west1"]
 public_listener = [
   {name = "collatz", hostname = "collatz.example.com"},
 ]
+
+[kube]
+public_listeners = [{name = "collatz"}]


### PR DESCRIPTION
Add reference to the `kube` deployer.
Add `[kube]` config in the collatz app, to be able to run it using the `kube` deployer.