### PR TITLE
Fixed onlineboutique bug.

### DIFF
--- a/examples/onlineboutique/main.go
+++ b/examples/onlineboutique/main.go
@@ -30,6 +30,7 @@ import (
 	"os"
 
 	"github.com/ServiceWeaver/weaver"
+	_ "github.com/ServiceWeaver/weaver/examples/onlineboutique/frontend"
 )
 
 //go:generate ../../cmd/weaver/weaver generate ./...

--- a/godeps.txt
+++ b/godeps.txt
@@ -164,6 +164,7 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique
     flag
     fmt
     github.com/ServiceWeaver/weaver
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/frontend
     os
 github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice
     context


### PR DESCRIPTION
Because the main component was a in a non-main package but not referenced from the main package, it was not linked. We're working on a better fix for this problem, but this PR fixes online boutique in the short term.