### PR TITLE
Fixed buggy `weaver version` output.

### DIFF
--- a/runtime/tool/version.go
+++ b/runtime/tool/version.go
@@ -35,10 +35,8 @@ func VersionCmd(tool string) *Command {
 		Fn: func(context.Context, []string) error {
 			deployerAPI := fmt.Sprintf("%d.%d.%d", version.Major, version.Minor, version.Patch)
 			codegenAPI := fmt.Sprintf("%d.%d.0", codegen.Major, codegen.Minor)
-			release := "?"
 			commit := "?"
 			if info, ok := debug.ReadBuildInfo(); ok {
-				release = info.Main.Version
 				for _, setting := range info.Settings {
 					// vcs.revision stores the commit at which the weaver tool
 					// was built. See [1] for more information.
@@ -50,9 +48,9 @@ func VersionCmd(tool string) *Command {
 					}
 				}
 			}
-			fmt.Printf("%s %s\n", tool, release)
-			fmt.Printf("target: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+			fmt.Printf("tool: %s\n", tool)
 			fmt.Printf("commit: %s\n", commit)
+			fmt.Printf("target: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 			fmt.Printf("deployer API: %s\n", deployerAPI)
 			fmt.Printf("codegen API: %s\n", codegenAPI)
 			return nil


### PR DESCRIPTION
`weaver version` is supposed to print out the weaver module version, something like:

```
$ weaver version
weaver v0.15.0
```

Previously, we used [`runtime.ReadBuildInfo`][ReadBuildInfo] to read the version of the main module. However, I realized that this version was always the string `(devel)`. At first, I thought the version was `(devel)` when on a non-tagged commit, but later realized that it is literally always `(devel)`: https://github.com/golang/go/issues/29228.

I did some Googling to figure out how to print out the current module version, but it seems impossible? This PR gives up and sticks with showing the git commit. It's not as clear, but you can look up the commit in the repo history to find the module version.

@spetrovic77, I think this discovery might mean that https://github.com/ServiceWeaver/weaver-gke/pull/68 is a little buggy?

[ReadBuildInfo]: https://pkg.go.dev/runtime/debug#ReadBuildInfo