### PR TITLE
Small example fixes.

### DIFF
--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"flag"
+	"log"
 
 	"github.com/ServiceWeaver/weaver"
 )
@@ -25,5 +26,7 @@ import (
 
 func main() {
 	flag.Parse()
-	weaver.Run(context.Background())
+	if err := weaver.Run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -36,15 +37,23 @@ func TestExamples(t *testing.T) {
 	testCases := map[string]test{
 		"hello": {
 			url:  "http://localhost:12345/hello?name=something",
-			want: "Hello, gnihtemos!\n",
+			want: "Hello, gnihtemos!",
 		},
 		"collatz": {
 			url:  "http://127.0.0.1:9000?x=8",
-			want: "8\n4\n2\n1\n",
+			want: "8\n4\n2\n1",
 		},
 		"reverser": {
 			url:  "http://127.0.0.1:9000/reverse?s=abcdef",
-			want: "fedcba\n",
+			want: "fedcba",
+		},
+		"factors": {
+			url:  "http://127.0.0.1:9000?x=10",
+			want: "[1 2 5 10]",
+		},
+		"onlineboutique": {
+			url:  "http://127.0.0.1:12345",
+			want: "Online Boutique",
 		},
 	}
 
@@ -135,7 +144,7 @@ func run(t *testing.T, test test) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if actual := string(body); actual != test.want {
+	if actual := string(body); !strings.Contains(actual, test.want) {
 		t.Fatalf("response body is %v, expected %v", actual, test.want)
 	}
 }
@@ -161,8 +170,10 @@ func chdir(t *testing.T, path string) {
 func startCmd(ctx context.Context, t *testing.T, env []string, name string, args ...string) *exec.Cmd {
 	t.Helper()
 	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	if testing.Verbose() {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
 	cmd.WaitDelay = 2 * time.Second
 	cmd.Env = append(os.Environ(), env...)
 	if err := cmd.Start(); err != nil {

--- a/examples/factors/main.go
+++ b/examples/factors/main.go
@@ -18,8 +18,7 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
-	"os"
+	"log"
 
 	"github.com/ServiceWeaver/weaver"
 )
@@ -30,7 +29,6 @@ func main() {
 	flag.Parse()
 	ctx := context.Background()
 	if err := weaver.Run(ctx); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }

--- a/examples/onlineboutique/main.go
+++ b/examples/onlineboutique/main.go
@@ -26,8 +26,7 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
-	"os"
+	"log"
 
 	"github.com/ServiceWeaver/weaver"
 	_ "github.com/ServiceWeaver/weaver/examples/onlineboutique/frontend"
@@ -38,7 +37,6 @@ import (
 func main() {
 	flag.Parse()
 	if err := weaver.Run(context.Background()); err != nil {
-		fmt.Fprintln(os.Stderr, "Error creating frontend: ", err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }

--- a/godeps.txt
+++ b/godeps.txt
@@ -106,6 +106,7 @@ github.com/ServiceWeaver/weaver/examples/chat
     image/jpeg
     image/png
     io
+    log
     math
     modernc.org/sqlite
     net/http
@@ -142,6 +143,7 @@ github.com/ServiceWeaver/weaver/examples/factors
     github.com/hashicorp/golang-lru/v2
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
+    log
     net/http
     os
     reflect
@@ -162,10 +164,9 @@ github.com/ServiceWeaver/weaver/examples/hello
 github.com/ServiceWeaver/weaver/examples/onlineboutique
     context
     flag
-    fmt
     github.com/ServiceWeaver/weaver
     github.com/ServiceWeaver/weaver/examples/onlineboutique/frontend
-    os
+    log
 github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice
     context
     errors


### PR DESCRIPTION
1. I added factors and onlineboutique to `examples_test.go`. Adding chat is hard because it requires a mysql database.
2. I made all examples `log.Fatal` the error returned by `weaver.Run`. Before, there was a mix of doing nothing, using `log.Fatal`, and writing to `os.Stderr`.
3. Quiet `examples_test.go` when -v isn't provided.