### PR TITLE
Added `weaver callgraph` command.

### DIFF
--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/ServiceWeaver/weaver/internal/tool/callgraph"
 	"github.com/ServiceWeaver/weaver/internal/tool/generate"
 	"github.com/ServiceWeaver/weaver/internal/tool/multi"
 	"github.com/ServiceWeaver/weaver/internal/tool/single"
@@ -88,6 +89,33 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
+
+	case "callgraph":
+		const usage = `Generate component callgraphs.
+
+Usage:
+  weaver callgraph <binary>
+
+Flags:
+  -h, --help           Print this help message.
+
+Description:
+  "weaver callgraph <file>" outputs a component callgraph in mermaid format
+  [1]. These graphs can be included in GitHub README files [2].
+
+[1]: https://mermaid.js.org/
+[2]: https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/`
+		flags := flag.NewFlagSet("callgraph", flag.ExitOnError)
+		flags.Usage = func() { fmt.Fprintln(os.Stderr, usage) }
+		flags.Parse(flag.Args()[1:]) //nolint:errcheck
+		if flags.NArg() == 0 {
+			fmt.Fprintln(os.Stderr, "ERROR: no binary provided.")
+		}
+		s, err := callgraph.Mermaid(flags.Arg(0))
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		fmt.Println(s)
 		return
 
 	case "single", "multi", "ssh":

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -2,6 +2,21 @@
 
 An example chat application.
 
+```mermaid
+%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
+graph TD
+    %% Nodes.
+    github.com/ServiceWeaver/weaver/Main(weaver.Main)
+    github.com/ServiceWeaver/weaver/examples/chat/ImageScaler(chat.ImageScaler)
+    github.com/ServiceWeaver/weaver/examples/chat/LocalCache(chat.LocalCache)
+    github.com/ServiceWeaver/weaver/examples/chat/SQLStore(chat.SQLStore)
+
+    %% Edges.
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/chat/ImageScaler
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/chat/LocalCache
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/chat/SQLStore
+```
+
 ## How to Run Locally
 
 ```sh

--- a/examples/collatz/README.md
+++ b/examples/collatz/README.md
@@ -24,6 +24,19 @@ This Service Weaver application has three components: `main`, `Odd` and `Even`. 
 positive number `x`, main repeatedly calls `Odd` (if `x` is odd) or `Even` (if
 `x` is even) to receive the next number in the hailstone sequence.
 
+```mermaid
+%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
+graph TD
+    %% Nodes.
+    github.com/ServiceWeaver/weaver/Main(weaver.Main)
+    github.com/ServiceWeaver/weaver/examples/collatz/Even(collatz.Even)
+    github.com/ServiceWeaver/weaver/examples/collatz/Odd(collatz.Odd)
+
+    %% Edges.
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/collatz/Even
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/collatz/Odd
+```
+
 This application highlights the benefits of colocation. The performance of the
 application improves significantly when `main`, `Odd`, and `Even` are colocated
 in the same OS process.

--- a/examples/factors/README.md
+++ b/examples/factors/README.md
@@ -10,6 +10,17 @@ provided integer. Repeated calls to the `Factor` method with the same integer
 will tend to route to the same component replica. This improves the cache hit
 rate of the `Factorer` component.
 
+```mermaid
+%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
+graph TD
+    %% Nodes.
+    github.com/ServiceWeaver/weaver/Main(weaver.Main)
+    github.com/ServiceWeaver/weaver/examples/factors/Factorer(factors.Factorer)
+
+    %% Edges.
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/factors/Factorer
+```
+
 ## Running Locally
 
 To run this app locally, run `go run .`:

--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -5,5 +5,16 @@ Tutorial"][tutorial] section of the [Service Weaver documentation][docs]. To run
 the application, run `go run .`.  Then, curl the `/hello` endpoint (e.g., `curl
 localhost:12345/hello?name=Alice`).
 
+```mermaid
+%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
+graph TD
+    %% Nodes.
+    github.com/ServiceWeaver/weaver/Main(weaver.Main)
+    github.com/ServiceWeaver/weaver/examples/hello/Reverser(hello.Reverser)
+
+    %% Edges.
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/hello/Reverser
+```
+
 [docs]: https://serviceweaver.dev/docs.html
 [tutorial]: https://serviceweaver.dev/docs.html#step-by-step-tutorial

--- a/examples/onlineboutique/README.md
+++ b/examples/onlineboutique/README.md
@@ -1,7 +1,41 @@
 # Online Boutique
 
-This directory contains the port of the Google Cloud's
-[`Online Boutique`][boutique] demo application.
+This directory contains the port of the Google Cloud's [`Online
+Boutique`][boutique] demo application.
+
+```mermaid
+%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
+graph TD
+    %% Nodes.
+    github.com/ServiceWeaver/weaver/Main(weaver.Main)
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice/T(adservice.T)
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T(cartservice.T)
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/cartCache(cartservice.cartCache)
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice/T(checkoutservice.T)
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T(currencyservice.T)
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/emailservice/T(emailservice.T)
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/paymentservice/T(paymentservice.T)
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T(productcatalogservice.T)
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/recommendationservice/T(recommendationservice.T)
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T(shippingservice.T)
+
+    %% Edges.
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice/T
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice/T
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/onlineboutique/recommendationservice/T
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T --> github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/cartCache
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice/T --> github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice/T --> github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice/T --> github.com/ServiceWeaver/weaver/examples/onlineboutique/emailservice/T
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice/T --> github.com/ServiceWeaver/weaver/examples/onlineboutique/paymentservice/T
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice/T --> github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice/T --> github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T
+    github.com/ServiceWeaver/weaver/examples/onlineboutique/recommendationservice/T --> github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T
+```
 
 Here are the changes made to the original application:
 

--- a/examples/reverser/README.md
+++ b/examples/reverser/README.md
@@ -3,6 +3,17 @@
 This directory contains a Service Weaver web application that reverses text.
 The application has a main component and a `Reverser` component.
 
+```mermaid
+%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
+graph TD
+    %% Nodes.
+    github.com/ServiceWeaver/weaver/Main(weaver.Main)
+    github.com/ServiceWeaver/weaver/examples/reverser/Reverser(reverser.Reverser)
+
+    %% Edges.
+    github.com/ServiceWeaver/weaver/Main --> github.com/ServiceWeaver/weaver/examples/reverser/Reverser
+```
+
 ## How to run?
 
 To run this application locally in a single process, run `go run .` To run the

--- a/godeps.txt
+++ b/godeps.txt
@@ -60,6 +60,7 @@ github.com/ServiceWeaver/weaver/cmd/weaver
     errors
     flag
     fmt
+    github.com/ServiceWeaver/weaver/internal/tool/callgraph
     github.com/ServiceWeaver/weaver/internal/tool/generate
     github.com/ServiceWeaver/weaver/internal/tool/multi
     github.com/ServiceWeaver/weaver/internal/tool/single
@@ -517,6 +518,13 @@ github.com/ServiceWeaver/weaver/internal/status
     syscall
     text/template
     time
+github.com/ServiceWeaver/weaver/internal/tool/callgraph
+    fmt
+    github.com/ServiceWeaver/weaver/runtime/bin
+    github.com/ServiceWeaver/weaver/runtime/logging
+    golang.org/x/exp/maps
+    sort
+    strings
 github.com/ServiceWeaver/weaver/internal/tool/certs
     bytes
     crypto

--- a/internal/tool/callgraph/callgraph.go
+++ b/internal/tool/callgraph/callgraph.go
@@ -1,0 +1,97 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package callgraph contains code to create visualizations of component
+// call graphs stored inside a Service Weaver binary.
+package callgraph
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ServiceWeaver/weaver/runtime/bin"
+	"github.com/ServiceWeaver/weaver/runtime/logging"
+	"golang.org/x/exp/maps"
+)
+
+// Mermaid returns a Mermaid diagram, https://mermaid.js.org/, of the component
+// call graph embedded in the provided Service Weaver binary.
+func Mermaid(binary string) (string, error) {
+	g, err := readGraph(binary)
+	if err != nil {
+		return "", err
+	}
+	return g.mermaid(), nil
+}
+
+// graph is a (potentially cyclic) call graph.
+type graph struct {
+	edges []edge
+}
+
+// An edge from src to dst exists when component src has a weaver.Ref on dst.
+type edge struct {
+	src, dst string
+}
+
+// readGraph reads a graph from the provided Service Weaver binary.
+func readGraph(binary string) (*graph, error) {
+	edges, err := bin.ReadComponentGraph(binary)
+	if err != nil {
+		return nil, fmt.Errorf("read graph %q: %w", binary, err)
+	}
+
+	g := graph{}
+	for _, e := range edges {
+		g.edges = append(g.edges, edge{e[0], e[1]})
+	}
+	return &g, nil
+}
+
+// nodes returns the nodes (aka components) in a graph.
+func (g *graph) nodes() []string {
+	components := map[string]struct{}{}
+	for _, edge := range g.edges {
+		components[edge.src] = struct{}{}
+		components[edge.dst] = struct{}{}
+	}
+	keys := maps.Keys(components)
+	sort.Strings(keys)
+	return keys
+}
+
+// mermaid returns a Mermaid diagram of the graph.
+func (g *graph) mermaid() string {
+	// See https://mermaid.js.org/syntax/flowchart.html for details.
+	var b strings.Builder
+	fmt.Fprintln(&b, `%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%`)
+	fmt.Fprintln(&b, "graph TD")
+
+	// Nodes.
+	fmt.Fprintln(&b, `    %% Nodes.`)
+	for _, node := range g.nodes() {
+		fmt.Fprintf(&b, "    %s(%s)\n", node, logging.ShortenComponent(node))
+	}
+	fmt.Fprintln(&b, "")
+
+	// Edges.
+	fmt.Fprintln(&b, `    %% Edges.`)
+	for _, edge := range g.edges {
+		fmt.Fprintf(&b, "    %s --> %s\n", edge.src, edge.dst)
+	}
+	return b.String()
+}
+
+// TODO(mwhittaker): Support graphviz?


### PR DESCRIPTION
This PR introduces a `weaver callgraph` command that outputs a [Mermaid][] diagram of the component call graph. I also updated every example's README with its callgraph diagram. See https://github.com/ServiceWeaver/weaver/blob/callgraph/examples/onlineboutique/README.md for an example.

[Mermaid]: https://mermaid.js.org/syntax/flowchart.html