### PR TITLE
Fix invalid permissions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -67,6 +67,14 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
 
+      # Set the right file permissions, based on https://github.com/actions/upload-pages-artifact#file-permissions. 
+      - shell: sh
+        run: |
+          chmod -c -R +rX "website/public" |
+          while read line; do
+              echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
The website deployment action has been failing lately. Looking at the issue, it seems to be related to https://github.com/actions/deploy-pages/issues/188 that is due to https://github.com/actions/upload-pages-artifact#file-permissions.