### PR TITLE
Check for locked database when writing to perfetto db.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ examples/factors/factors
 examples/onlineboutique/onlineboutique
 examples/hello/hello
 website/public/
+
+# Binaries produced by [go test] when passed -c or a profiling option.
+*.test


### PR DESCRIPTION
Previously we would see an infrequent error message saying the database was locked. This was due to a missing isLocked check on the path that attempts to assign a replica number to the current weavelet. Fixed by retrying on a locking error.

Also improved a corresponding error message.

Added a benchmark for calling component methods when tracing is turned on. (This benchmark is what would trigger the preceding issue.)