### PR TITLE
Restore metric collection for local calls.

### DIFF
--- a/examples/chat/weaver_gen.go
+++ b/examples/chat/weaver_gen.go
@@ -21,11 +21,11 @@ func init() {
 		Name:  "github.com/ServiceWeaver/weaver/examples/chat/ImageScaler",
 		Iface: reflect.TypeOf((*ImageScaler)(nil)).Elem(),
 		Impl:  reflect.TypeOf(scaler{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any {
-			return imageScaler_local_stub{impl: impl.(ImageScaler), tracer: tracer}
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return imageScaler_local_stub{impl: impl.(ImageScaler), tracer: tracer, scaleMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/ImageScaler", Method: "Scale", Remote: false})}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return imageScaler_client_stub{stub: stub, scaleMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/ImageScaler", Method: "Scale"})}
+			return imageScaler_client_stub{stub: stub, scaleMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/ImageScaler", Method: "Scale", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return imageScaler_server_stub{impl: impl.(ImageScaler), addLoad: addLoad}
@@ -36,11 +36,11 @@ func init() {
 		Name:  "github.com/ServiceWeaver/weaver/examples/chat/LocalCache",
 		Iface: reflect.TypeOf((*LocalCache)(nil)).Elem(),
 		Impl:  reflect.TypeOf(localCache{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any {
-			return localCache_local_stub{impl: impl.(LocalCache), tracer: tracer}
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return localCache_local_stub{impl: impl.(LocalCache), tracer: tracer, getMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/LocalCache", Method: "Get", Remote: false}), putMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/LocalCache", Method: "Put", Remote: false})}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return localCache_client_stub{stub: stub, getMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/LocalCache", Method: "Get"}), putMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/LocalCache", Method: "Put"})}
+			return localCache_client_stub{stub: stub, getMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/LocalCache", Method: "Get", Remote: true}), putMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/LocalCache", Method: "Put", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return localCache_server_stub{impl: impl.(LocalCache), addLoad: addLoad}
@@ -52,7 +52,7 @@ func init() {
 		Iface:     reflect.TypeOf((*weaver.Main)(nil)).Elem(),
 		Impl:      reflect.TypeOf(server{}),
 		Listeners: []string{"chat"},
-		LocalStubFn: func(impl any, tracer trace.Tracer) any {
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
 			return main_local_stub{impl: impl.(weaver.Main), tracer: tracer}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any { return main_client_stub{stub: stub} },
@@ -65,11 +65,11 @@ func init() {
 		Name:  "github.com/ServiceWeaver/weaver/examples/chat/SQLStore",
 		Iface: reflect.TypeOf((*SQLStore)(nil)).Elem(),
 		Impl:  reflect.TypeOf(sqlStore{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any {
-			return sQLStore_local_stub{impl: impl.(SQLStore), tracer: tracer}
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return sQLStore_local_stub{impl: impl.(SQLStore), tracer: tracer, createPostMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "CreatePost", Remote: false}), createThreadMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "CreateThread", Remote: false}), getFeedMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "GetFeed", Remote: false}), getImageMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "GetImage", Remote: false})}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return sQLStore_client_stub{stub: stub, createPostMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "CreatePost"}), createThreadMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "CreateThread"}), getFeedMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "GetFeed"}), getImageMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "GetImage"})}
+			return sQLStore_client_stub{stub: stub, createPostMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "CreatePost", Remote: true}), createThreadMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "CreateThread", Remote: true}), getFeedMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "GetFeed", Remote: true}), getImageMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "GetImage", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return sQLStore_server_stub{impl: impl.(SQLStore), addLoad: addLoad}
@@ -93,14 +93,18 @@ var _ weaver.Unrouted = (*sqlStore)(nil)
 // Local stub implementations.
 
 type imageScaler_local_stub struct {
-	impl   ImageScaler
-	tracer trace.Tracer
+	impl         ImageScaler
+	tracer       trace.Tracer
+	scaleMetrics *codegen.MethodMetrics
 }
 
 // Check that imageScaler_local_stub implements the ImageScaler interface.
 var _ ImageScaler = (*imageScaler_local_stub)(nil)
 
 func (s imageScaler_local_stub) Scale(ctx context.Context, a0 []byte, a1 int, a2 int) (r0 []byte, err error) {
+	// Update metrics.
+	begin := s.scaleMetrics.Begin()
+	defer func() { s.scaleMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -118,14 +122,19 @@ func (s imageScaler_local_stub) Scale(ctx context.Context, a0 []byte, a1 int, a2
 }
 
 type localCache_local_stub struct {
-	impl   LocalCache
-	tracer trace.Tracer
+	impl       LocalCache
+	tracer     trace.Tracer
+	getMetrics *codegen.MethodMetrics
+	putMetrics *codegen.MethodMetrics
 }
 
 // Check that localCache_local_stub implements the LocalCache interface.
 var _ LocalCache = (*localCache_local_stub)(nil)
 
 func (s localCache_local_stub) Get(ctx context.Context, a0 string) (r0 string, err error) {
+	// Update metrics.
+	begin := s.getMetrics.Begin()
+	defer func() { s.getMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -143,6 +152,9 @@ func (s localCache_local_stub) Get(ctx context.Context, a0 string) (r0 string, e
 }
 
 func (s localCache_local_stub) Put(ctx context.Context, a0 string, a1 string) (err error) {
+	// Update metrics.
+	begin := s.putMetrics.Begin()
+	defer func() { s.putMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -168,14 +180,21 @@ type main_local_stub struct {
 var _ weaver.Main = (*main_local_stub)(nil)
 
 type sQLStore_local_stub struct {
-	impl   SQLStore
-	tracer trace.Tracer
+	impl                SQLStore
+	tracer              trace.Tracer
+	createPostMetrics   *codegen.MethodMetrics
+	createThreadMetrics *codegen.MethodMetrics
+	getFeedMetrics      *codegen.MethodMetrics
+	getImageMetrics     *codegen.MethodMetrics
 }
 
 // Check that sQLStore_local_stub implements the SQLStore interface.
 var _ SQLStore = (*sQLStore_local_stub)(nil)
 
 func (s sQLStore_local_stub) CreatePost(ctx context.Context, a0 string, a1 time.Time, a2 ThreadID, a3 string) (err error) {
+	// Update metrics.
+	begin := s.createPostMetrics.Begin()
+	defer func() { s.createPostMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -193,6 +212,9 @@ func (s sQLStore_local_stub) CreatePost(ctx context.Context, a0 string, a1 time.
 }
 
 func (s sQLStore_local_stub) CreateThread(ctx context.Context, a0 string, a1 time.Time, a2 []string, a3 string, a4 []byte) (r0 ThreadID, err error) {
+	// Update metrics.
+	begin := s.createThreadMetrics.Begin()
+	defer func() { s.createThreadMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -210,6 +232,9 @@ func (s sQLStore_local_stub) CreateThread(ctx context.Context, a0 string, a1 tim
 }
 
 func (s sQLStore_local_stub) GetFeed(ctx context.Context, a0 string) (r0 []Thread, err error) {
+	// Update metrics.
+	begin := s.getFeedMetrics.Begin()
+	defer func() { s.getFeedMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -227,6 +252,9 @@ func (s sQLStore_local_stub) GetFeed(ctx context.Context, a0 string) (r0 []Threa
 }
 
 func (s sQLStore_local_stub) GetImage(ctx context.Context, a0 string, a1 ImageID) (r0 []byte, err error) {
+	// Update metrics.
+	begin := s.getImageMetrics.Begin()
+	defer func() { s.getImageMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -255,8 +283,9 @@ var _ ImageScaler = (*imageScaler_client_stub)(nil)
 
 func (s imageScaler_client_stub) Scale(ctx context.Context, a0 []byte, a1 int, a2 int) (r0 []byte, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.scaleMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.scaleMetrics.Begin()
+	defer func() { s.scaleMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -276,11 +305,9 @@ func (s imageScaler_client_stub) Scale(ctx context.Context, a0 []byte, a1 int, a
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.scaleMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.scaleMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -298,14 +325,14 @@ func (s imageScaler_client_stub) Scale(ctx context.Context, a0 []byte, a1 int, a
 	var shardKey uint64
 
 	// Call the remote method.
-	s.scaleMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.scaleMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -325,8 +352,9 @@ var _ LocalCache = (*localCache_client_stub)(nil)
 
 func (s localCache_client_stub) Get(ctx context.Context, a0 string) (r0 string, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.getMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.getMetrics.Begin()
+	defer func() { s.getMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -346,11 +374,9 @@ func (s localCache_client_stub) Get(ctx context.Context, a0 string) (r0 string, 
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.getMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.getMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -364,14 +390,14 @@ func (s localCache_client_stub) Get(ctx context.Context, a0 string) (r0 string, 
 	var shardKey uint64
 
 	// Call the remote method.
-	s.getMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.getMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -382,8 +408,9 @@ func (s localCache_client_stub) Get(ctx context.Context, a0 string) (r0 string, 
 
 func (s localCache_client_stub) Put(ctx context.Context, a0 string, a1 string) (err error) {
 	// Update metrics.
-	start := time.Now()
-	s.putMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.putMetrics.Begin()
+	defer func() { s.putMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -403,11 +430,9 @@ func (s localCache_client_stub) Put(ctx context.Context, a0 string, a1 string) (
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.putMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.putMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -423,14 +448,14 @@ func (s localCache_client_stub) Put(ctx context.Context, a0 string, a1 string) (
 	var shardKey uint64
 
 	// Call the remote method.
-	s.putMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.putMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -458,8 +483,9 @@ var _ SQLStore = (*sQLStore_client_stub)(nil)
 
 func (s sQLStore_client_stub) CreatePost(ctx context.Context, a0 string, a1 time.Time, a2 ThreadID, a3 string) (err error) {
 	// Update metrics.
-	start := time.Now()
-	s.createPostMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.createPostMetrics.Begin()
+	defer func() { s.createPostMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -479,11 +505,9 @@ func (s sQLStore_client_stub) CreatePost(ctx context.Context, a0 string, a1 time
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.createPostMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.createPostMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -495,14 +519,14 @@ func (s sQLStore_client_stub) CreatePost(ctx context.Context, a0 string, a1 time
 	var shardKey uint64
 
 	// Call the remote method.
-	s.createPostMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.createPostMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -512,8 +536,9 @@ func (s sQLStore_client_stub) CreatePost(ctx context.Context, a0 string, a1 time
 
 func (s sQLStore_client_stub) CreateThread(ctx context.Context, a0 string, a1 time.Time, a2 []string, a3 string, a4 []byte) (r0 ThreadID, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.createThreadMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.createThreadMetrics.Begin()
+	defer func() { s.createThreadMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -533,11 +558,9 @@ func (s sQLStore_client_stub) CreateThread(ctx context.Context, a0 string, a1 ti
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.createThreadMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.createThreadMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -550,14 +573,14 @@ func (s sQLStore_client_stub) CreateThread(ctx context.Context, a0 string, a1 ti
 	var shardKey uint64
 
 	// Call the remote method.
-	s.createThreadMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.createThreadMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -568,8 +591,9 @@ func (s sQLStore_client_stub) CreateThread(ctx context.Context, a0 string, a1 ti
 
 func (s sQLStore_client_stub) GetFeed(ctx context.Context, a0 string) (r0 []Thread, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.getFeedMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.getFeedMetrics.Begin()
+	defer func() { s.getFeedMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -589,11 +613,9 @@ func (s sQLStore_client_stub) GetFeed(ctx context.Context, a0 string) (r0 []Thre
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.getFeedMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.getFeedMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -607,14 +629,14 @@ func (s sQLStore_client_stub) GetFeed(ctx context.Context, a0 string) (r0 []Thre
 	var shardKey uint64
 
 	// Call the remote method.
-	s.getFeedMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 2, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.getFeedMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -625,8 +647,9 @@ func (s sQLStore_client_stub) GetFeed(ctx context.Context, a0 string) (r0 []Thre
 
 func (s sQLStore_client_stub) GetImage(ctx context.Context, a0 string, a1 ImageID) (r0 []byte, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.getImageMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.getImageMetrics.Begin()
+	defer func() { s.getImageMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -646,11 +669,9 @@ func (s sQLStore_client_stub) GetImage(ctx context.Context, a0 string, a1 ImageI
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.getImageMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.getImageMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -666,14 +687,14 @@ func (s sQLStore_client_stub) GetImage(ctx context.Context, a0 string, a1 ImageI
 	var shardKey uint64
 
 	// Call the remote method.
-	s.getImageMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 3, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.getImageMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/examples/collatz/weaver_gen.go
+++ b/examples/collatz/weaver_gen.go
@@ -11,18 +11,19 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
-	"time"
 )
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/examples/collatz/Even",
-		Iface:       reflect.TypeOf((*Even)(nil)).Elem(),
-		Impl:        reflect.TypeOf(even{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return even_local_stub{impl: impl.(Even), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/examples/collatz/Even",
+		Iface: reflect.TypeOf((*Even)(nil)).Elem(),
+		Impl:  reflect.TypeOf(even{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return even_local_stub{impl: impl.(Even), tracer: tracer, doMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/collatz/Even", Method: "Do", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return even_client_stub{stub: stub, doMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/collatz/Even", Method: "Do"})}
+			return even_client_stub{stub: stub, doMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/collatz/Even", Method: "Do", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return even_server_stub{impl: impl.(Even), addLoad: addLoad}
@@ -34,7 +35,7 @@ func init() {
 		Iface:     reflect.TypeOf((*weaver.Main)(nil)).Elem(),
 		Impl:      reflect.TypeOf(server{}),
 		Listeners: []string{"collatz"},
-		LocalStubFn: func(impl any, tracer trace.Tracer) any {
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
 			return main_local_stub{impl: impl.(weaver.Main), tracer: tracer}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any { return main_client_stub{stub: stub} },
@@ -44,12 +45,14 @@ func init() {
 		RefData: "⟦f95ad2dd:wEaVeReDgE:github.com/ServiceWeaver/weaver/Main→github.com/ServiceWeaver/weaver/examples/collatz/Odd⟧\n⟦987c175b:wEaVeReDgE:github.com/ServiceWeaver/weaver/Main→github.com/ServiceWeaver/weaver/examples/collatz/Even⟧\n⟦f3b62957:wEaVeRlIsTeNeRs:github.com/ServiceWeaver/weaver/Main→collatz⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/examples/collatz/Odd",
-		Iface:       reflect.TypeOf((*Odd)(nil)).Elem(),
-		Impl:        reflect.TypeOf(odd{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return odd_local_stub{impl: impl.(Odd), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/examples/collatz/Odd",
+		Iface: reflect.TypeOf((*Odd)(nil)).Elem(),
+		Impl:  reflect.TypeOf(odd{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return odd_local_stub{impl: impl.(Odd), tracer: tracer, doMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/collatz/Odd", Method: "Do", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return odd_client_stub{stub: stub, doMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/collatz/Odd", Method: "Do"})}
+			return odd_client_stub{stub: stub, doMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/collatz/Odd", Method: "Do", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return odd_server_stub{impl: impl.(Odd), addLoad: addLoad}
@@ -71,14 +74,18 @@ var _ weaver.Unrouted = (*odd)(nil)
 // Local stub implementations.
 
 type even_local_stub struct {
-	impl   Even
-	tracer trace.Tracer
+	impl      Even
+	tracer    trace.Tracer
+	doMetrics *codegen.MethodMetrics
 }
 
 // Check that even_local_stub implements the Even interface.
 var _ Even = (*even_local_stub)(nil)
 
 func (s even_local_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
+	// Update metrics.
+	begin := s.doMetrics.Begin()
+	defer func() { s.doMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -104,14 +111,18 @@ type main_local_stub struct {
 var _ weaver.Main = (*main_local_stub)(nil)
 
 type odd_local_stub struct {
-	impl   Odd
-	tracer trace.Tracer
+	impl      Odd
+	tracer    trace.Tracer
+	doMetrics *codegen.MethodMetrics
 }
 
 // Check that odd_local_stub implements the Odd interface.
 var _ Odd = (*odd_local_stub)(nil)
 
 func (s odd_local_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
+	// Update metrics.
+	begin := s.doMetrics.Begin()
+	defer func() { s.doMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -140,8 +151,9 @@ var _ Even = (*even_client_stub)(nil)
 
 func (s even_client_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.doMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.doMetrics.Begin()
+	defer func() { s.doMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -161,11 +173,9 @@ func (s even_client_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.doMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.doMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -179,14 +189,14 @@ func (s even_client_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
 	var shardKey uint64
 
 	// Call the remote method.
-	s.doMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.doMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -212,8 +222,9 @@ var _ Odd = (*odd_client_stub)(nil)
 
 func (s odd_client_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.doMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.doMetrics.Begin()
+	defer func() { s.doMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -233,11 +244,9 @@ func (s odd_client_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.doMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.doMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -251,14 +260,14 @@ func (s odd_client_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
 	var shardKey uint64
 
 	// Call the remote method.
-	s.doMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.doMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/examples/helloworld/weaver_gen.go
+++ b/examples/helloworld/weaver_gen.go
@@ -17,7 +17,7 @@ func init() {
 		Name:  "github.com/ServiceWeaver/weaver/Main",
 		Iface: reflect.TypeOf((*weaver.Main)(nil)).Elem(),
 		Impl:  reflect.TypeOf(app{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any {
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
 			return main_local_stub{impl: impl.(weaver.Main), tracer: tracer}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any { return main_client_stub{stub: stub} },

--- a/examples/onlineboutique/adservice/weaver_gen.go
+++ b/examples/onlineboutique/adservice/weaver_gen.go
@@ -12,18 +12,19 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
-	"time"
 )
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice/T",
-		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		Impl:        reflect.TypeOf(impl{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice/T",
+		Iface: reflect.TypeOf((*T)(nil)).Elem(),
+		Impl:  reflect.TypeOf(impl{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return t_local_stub{impl: impl.(T), tracer: tracer, getAdsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice/T", Method: "GetAds", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return t_client_stub{stub: stub, getAdsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice/T", Method: "GetAds"})}
+			return t_client_stub{stub: stub, getAdsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice/T", Method: "GetAds", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return t_server_stub{impl: impl.(T), addLoad: addLoad}
@@ -41,14 +42,18 @@ var _ weaver.Unrouted = (*impl)(nil)
 // Local stub implementations.
 
 type t_local_stub struct {
-	impl   T
-	tracer trace.Tracer
+	impl          T
+	tracer        trace.Tracer
+	getAdsMetrics *codegen.MethodMetrics
 }
 
 // Check that t_local_stub implements the T interface.
 var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) GetAds(ctx context.Context, a0 []string) (r0 []Ad, err error) {
+	// Update metrics.
+	begin := s.getAdsMetrics.Begin()
+	defer func() { s.getAdsMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -77,8 +82,9 @@ var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) GetAds(ctx context.Context, a0 []string) (r0 []Ad, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.getAdsMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.getAdsMetrics.Begin()
+	defer func() { s.getAdsMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -98,11 +104,9 @@ func (s t_client_stub) GetAds(ctx context.Context, a0 []string) (r0 []Ad, err er
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.getAdsMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.getAdsMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -111,14 +115,14 @@ func (s t_client_stub) GetAds(ctx context.Context, a0 []string) (r0 []Ad, err er
 	var shardKey uint64
 
 	// Call the remote method.
-	s.getAdsMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.getAdsMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/examples/onlineboutique/cartservice/weaver_gen.go
+++ b/examples/onlineboutique/cartservice/weaver_gen.go
@@ -12,18 +12,19 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
-	"time"
 )
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T",
-		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		Impl:        reflect.TypeOf(impl{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T",
+		Iface: reflect.TypeOf((*T)(nil)).Elem(),
+		Impl:  reflect.TypeOf(impl{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return t_local_stub{impl: impl.(T), tracer: tracer, addItemMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "AddItem", Remote: false}), emptyCartMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "EmptyCart", Remote: false}), getCartMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "GetCart", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return t_client_stub{stub: stub, addItemMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "AddItem"}), emptyCartMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "EmptyCart"}), getCartMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "GetCart"})}
+			return t_client_stub{stub: stub, addItemMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "AddItem", Remote: true}), emptyCartMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "EmptyCart", Remote: true}), getCartMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/T", Method: "GetCart", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return t_server_stub{impl: impl.(T), addLoad: addLoad}
@@ -35,11 +36,11 @@ func init() {
 		Iface:  reflect.TypeOf((*cartCache)(nil)).Elem(),
 		Impl:   reflect.TypeOf(cartCacheImpl{}),
 		Routed: true,
-		LocalStubFn: func(impl any, tracer trace.Tracer) any {
-			return cartCache_local_stub{impl: impl.(cartCache), tracer: tracer}
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return cartCache_local_stub{impl: impl.(cartCache), tracer: tracer, addMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/cartCache", Method: "Add", Remote: false}), getMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/cartCache", Method: "Get", Remote: false}), removeMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/cartCache", Method: "Remove", Remote: false})}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return cartCache_client_stub{stub: stub, addMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/cartCache", Method: "Add"}), getMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/cartCache", Method: "Get"}), removeMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/cartCache", Method: "Remove"})}
+			return cartCache_client_stub{stub: stub, addMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/cartCache", Method: "Add", Remote: true}), getMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/cartCache", Method: "Get", Remote: true}), removeMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice/cartCache", Method: "Remove", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return cartCache_server_stub{impl: impl.(cartCache), addLoad: addLoad}
@@ -64,14 +65,20 @@ var _ func(_ context.Context, key string) string = (&cartCacheRouter{}).Remove  
 // Local stub implementations.
 
 type t_local_stub struct {
-	impl   T
-	tracer trace.Tracer
+	impl             T
+	tracer           trace.Tracer
+	addItemMetrics   *codegen.MethodMetrics
+	emptyCartMetrics *codegen.MethodMetrics
+	getCartMetrics   *codegen.MethodMetrics
 }
 
 // Check that t_local_stub implements the T interface.
 var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) AddItem(ctx context.Context, a0 string, a1 CartItem) (err error) {
+	// Update metrics.
+	begin := s.addItemMetrics.Begin()
+	defer func() { s.addItemMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -89,6 +96,9 @@ func (s t_local_stub) AddItem(ctx context.Context, a0 string, a1 CartItem) (err 
 }
 
 func (s t_local_stub) EmptyCart(ctx context.Context, a0 string) (err error) {
+	// Update metrics.
+	begin := s.emptyCartMetrics.Begin()
+	defer func() { s.emptyCartMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -106,6 +116,9 @@ func (s t_local_stub) EmptyCart(ctx context.Context, a0 string) (err error) {
 }
 
 func (s t_local_stub) GetCart(ctx context.Context, a0 string) (r0 []CartItem, err error) {
+	// Update metrics.
+	begin := s.getCartMetrics.Begin()
+	defer func() { s.getCartMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -123,14 +136,20 @@ func (s t_local_stub) GetCart(ctx context.Context, a0 string) (r0 []CartItem, er
 }
 
 type cartCache_local_stub struct {
-	impl   cartCache
-	tracer trace.Tracer
+	impl          cartCache
+	tracer        trace.Tracer
+	addMetrics    *codegen.MethodMetrics
+	getMetrics    *codegen.MethodMetrics
+	removeMetrics *codegen.MethodMetrics
 }
 
 // Check that cartCache_local_stub implements the cartCache interface.
 var _ cartCache = (*cartCache_local_stub)(nil)
 
 func (s cartCache_local_stub) Add(ctx context.Context, a0 string, a1 []CartItem) (err error) {
+	// Update metrics.
+	begin := s.addMetrics.Begin()
+	defer func() { s.addMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -148,6 +167,9 @@ func (s cartCache_local_stub) Add(ctx context.Context, a0 string, a1 []CartItem)
 }
 
 func (s cartCache_local_stub) Get(ctx context.Context, a0 string) (r0 []CartItem, err error) {
+	// Update metrics.
+	begin := s.getMetrics.Begin()
+	defer func() { s.getMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -165,6 +187,9 @@ func (s cartCache_local_stub) Get(ctx context.Context, a0 string) (r0 []CartItem
 }
 
 func (s cartCache_local_stub) Remove(ctx context.Context, a0 string) (r0 bool, err error) {
+	// Update metrics.
+	begin := s.removeMetrics.Begin()
+	defer func() { s.removeMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -195,8 +220,9 @@ var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) AddItem(ctx context.Context, a0 string, a1 CartItem) (err error) {
 	// Update metrics.
-	start := time.Now()
-	s.addItemMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.addItemMetrics.Begin()
+	defer func() { s.addItemMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -216,11 +242,9 @@ func (s t_client_stub) AddItem(ctx context.Context, a0 string, a1 CartItem) (err
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.addItemMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.addItemMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -236,14 +260,14 @@ func (s t_client_stub) AddItem(ctx context.Context, a0 string, a1 CartItem) (err
 	var shardKey uint64
 
 	// Call the remote method.
-	s.addItemMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.addItemMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -253,8 +277,9 @@ func (s t_client_stub) AddItem(ctx context.Context, a0 string, a1 CartItem) (err
 
 func (s t_client_stub) EmptyCart(ctx context.Context, a0 string) (err error) {
 	// Update metrics.
-	start := time.Now()
-	s.emptyCartMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.emptyCartMetrics.Begin()
+	defer func() { s.emptyCartMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -274,11 +299,9 @@ func (s t_client_stub) EmptyCart(ctx context.Context, a0 string) (err error) {
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.emptyCartMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.emptyCartMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -292,14 +315,14 @@ func (s t_client_stub) EmptyCart(ctx context.Context, a0 string) (err error) {
 	var shardKey uint64
 
 	// Call the remote method.
-	s.emptyCartMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.emptyCartMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -309,8 +332,9 @@ func (s t_client_stub) EmptyCart(ctx context.Context, a0 string) (err error) {
 
 func (s t_client_stub) GetCart(ctx context.Context, a0 string) (r0 []CartItem, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.getCartMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.getCartMetrics.Begin()
+	defer func() { s.getCartMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -330,11 +354,9 @@ func (s t_client_stub) GetCart(ctx context.Context, a0 string) (r0 []CartItem, e
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.getCartMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.getCartMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -348,14 +370,14 @@ func (s t_client_stub) GetCart(ctx context.Context, a0 string) (r0 []CartItem, e
 	var shardKey uint64
 
 	// Call the remote method.
-	s.getCartMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 2, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.getCartMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -376,8 +398,9 @@ var _ cartCache = (*cartCache_client_stub)(nil)
 
 func (s cartCache_client_stub) Add(ctx context.Context, a0 string, a1 []CartItem) (err error) {
 	// Update metrics.
-	start := time.Now()
-	s.addMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.addMetrics.Begin()
+	defer func() { s.addMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -397,11 +420,9 @@ func (s cartCache_client_stub) Add(ctx context.Context, a0 string, a1 []CartItem
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.addMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.addMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -414,14 +435,14 @@ func (s cartCache_client_stub) Add(ctx context.Context, a0 string, a1 []CartItem
 	shardKey := _hashCartCache(r.Add(ctx, a0, a1))
 
 	// Call the remote method.
-	s.addMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.addMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -431,8 +452,9 @@ func (s cartCache_client_stub) Add(ctx context.Context, a0 string, a1 []CartItem
 
 func (s cartCache_client_stub) Get(ctx context.Context, a0 string) (r0 []CartItem, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.getMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.getMetrics.Begin()
+	defer func() { s.getMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -452,11 +474,9 @@ func (s cartCache_client_stub) Get(ctx context.Context, a0 string) (r0 []CartIte
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.getMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.getMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -473,14 +493,14 @@ func (s cartCache_client_stub) Get(ctx context.Context, a0 string) (r0 []CartIte
 	shardKey := _hashCartCache(r.Get(ctx, a0))
 
 	// Call the remote method.
-	s.getMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.getMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -491,8 +511,9 @@ func (s cartCache_client_stub) Get(ctx context.Context, a0 string) (r0 []CartIte
 
 func (s cartCache_client_stub) Remove(ctx context.Context, a0 string) (r0 bool, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.removeMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.removeMetrics.Begin()
+	defer func() { s.removeMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -512,11 +533,9 @@ func (s cartCache_client_stub) Remove(ctx context.Context, a0 string) (r0 bool, 
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.removeMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.removeMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -533,14 +552,14 @@ func (s cartCache_client_stub) Remove(ctx context.Context, a0 string) (r0 bool, 
 	shardKey := _hashCartCache(r.Remove(ctx, a0))
 
 	// Call the remote method.
-	s.removeMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 2, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.removeMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/examples/onlineboutique/currencyservice/weaver_gen.go
+++ b/examples/onlineboutique/currencyservice/weaver_gen.go
@@ -12,18 +12,19 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
-	"time"
 )
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T",
-		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		Impl:        reflect.TypeOf(impl{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T",
+		Iface: reflect.TypeOf((*T)(nil)).Elem(),
+		Impl:  reflect.TypeOf(impl{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return t_local_stub{impl: impl.(T), tracer: tracer, convertMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T", Method: "Convert", Remote: false}), getSupportedCurrenciesMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T", Method: "GetSupportedCurrencies", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return t_client_stub{stub: stub, convertMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T", Method: "Convert"}), getSupportedCurrenciesMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T", Method: "GetSupportedCurrencies"})}
+			return t_client_stub{stub: stub, convertMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T", Method: "Convert", Remote: true}), getSupportedCurrenciesMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice/T", Method: "GetSupportedCurrencies", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return t_server_stub{impl: impl.(T), addLoad: addLoad}
@@ -41,14 +42,19 @@ var _ weaver.Unrouted = (*impl)(nil)
 // Local stub implementations.
 
 type t_local_stub struct {
-	impl   T
-	tracer trace.Tracer
+	impl                          T
+	tracer                        trace.Tracer
+	convertMetrics                *codegen.MethodMetrics
+	getSupportedCurrenciesMetrics *codegen.MethodMetrics
 }
 
 // Check that t_local_stub implements the T interface.
 var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) Convert(ctx context.Context, a0 money.T, a1 string) (r0 money.T, err error) {
+	// Update metrics.
+	begin := s.convertMetrics.Begin()
+	defer func() { s.convertMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -66,6 +72,9 @@ func (s t_local_stub) Convert(ctx context.Context, a0 money.T, a1 string) (r0 mo
 }
 
 func (s t_local_stub) GetSupportedCurrencies(ctx context.Context) (r0 []string, err error) {
+	// Update metrics.
+	begin := s.getSupportedCurrenciesMetrics.Begin()
+	defer func() { s.getSupportedCurrenciesMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -95,8 +104,9 @@ var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) Convert(ctx context.Context, a0 money.T, a1 string) (r0 money.T, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.convertMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.convertMetrics.Begin()
+	defer func() { s.convertMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -116,11 +126,9 @@ func (s t_client_stub) Convert(ctx context.Context, a0 money.T, a1 string) (r0 m
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.convertMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.convertMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -130,14 +138,14 @@ func (s t_client_stub) Convert(ctx context.Context, a0 money.T, a1 string) (r0 m
 	var shardKey uint64
 
 	// Call the remote method.
-	s.convertMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.convertMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -148,8 +156,9 @@ func (s t_client_stub) Convert(ctx context.Context, a0 money.T, a1 string) (r0 m
 
 func (s t_client_stub) GetSupportedCurrencies(ctx context.Context) (r0 []string, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.getSupportedCurrenciesMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.getSupportedCurrenciesMetrics.Begin()
+	defer func() { s.getSupportedCurrenciesMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -169,24 +178,21 @@ func (s t_client_stub) GetSupportedCurrencies(ctx context.Context) (r0 []string,
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.getSupportedCurrenciesMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.getSupportedCurrenciesMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	var shardKey uint64
 
 	// Call the remote method.
-	s.getSupportedCurrenciesMetrics.BytesRequest.Put(0)
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, nil, shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.getSupportedCurrenciesMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/examples/onlineboutique/frontend/weaver_gen.go
+++ b/examples/onlineboutique/frontend/weaver_gen.go
@@ -18,7 +18,7 @@ func init() {
 		Iface:     reflect.TypeOf((*weaver.Main)(nil)).Elem(),
 		Impl:      reflect.TypeOf(Server{}),
 		Listeners: []string{"boutique"},
-		LocalStubFn: func(impl any, tracer trace.Tracer) any {
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
 			return main_local_stub{impl: impl.(weaver.Main), tracer: tracer}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any { return main_client_stub{stub: stub} },

--- a/examples/onlineboutique/paymentservice/weaver_gen.go
+++ b/examples/onlineboutique/paymentservice/weaver_gen.go
@@ -19,12 +19,14 @@ var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/paymentservice/T",
-		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		Impl:        reflect.TypeOf(impl{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/examples/onlineboutique/paymentservice/T",
+		Iface: reflect.TypeOf((*T)(nil)).Elem(),
+		Impl:  reflect.TypeOf(impl{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return t_local_stub{impl: impl.(T), tracer: tracer, chargeMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/paymentservice/T", Method: "Charge", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return t_client_stub{stub: stub, chargeMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/paymentservice/T", Method: "Charge"})}
+			return t_client_stub{stub: stub, chargeMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/paymentservice/T", Method: "Charge", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return t_server_stub{impl: impl.(T), addLoad: addLoad}
@@ -42,14 +44,18 @@ var _ weaver.Unrouted = (*impl)(nil)
 // Local stub implementations.
 
 type t_local_stub struct {
-	impl   T
-	tracer trace.Tracer
+	impl          T
+	tracer        trace.Tracer
+	chargeMetrics *codegen.MethodMetrics
 }
 
 // Check that t_local_stub implements the T interface.
 var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) Charge(ctx context.Context, a0 money.T, a1 CreditCardInfo) (r0 string, err error) {
+	// Update metrics.
+	begin := s.chargeMetrics.Begin()
+	defer func() { s.chargeMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -78,8 +84,9 @@ var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) Charge(ctx context.Context, a0 money.T, a1 CreditCardInfo) (r0 string, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.chargeMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.chargeMetrics.Begin()
+	defer func() { s.chargeMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -99,11 +106,9 @@ func (s t_client_stub) Charge(ctx context.Context, a0 money.T, a1 CreditCardInfo
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.chargeMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.chargeMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -113,14 +118,14 @@ func (s t_client_stub) Charge(ctx context.Context, a0 money.T, a1 CreditCardInfo
 	var shardKey uint64
 
 	// Call the remote method.
-	s.chargeMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.chargeMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/examples/onlineboutique/productcatalogservice/weaver_gen.go
+++ b/examples/onlineboutique/productcatalogservice/weaver_gen.go
@@ -13,18 +13,19 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
-	"time"
 )
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T",
-		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		Impl:        reflect.TypeOf(impl{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T",
+		Iface: reflect.TypeOf((*T)(nil)).Elem(),
+		Impl:  reflect.TypeOf(impl{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return t_local_stub{impl: impl.(T), tracer: tracer, getProductMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "GetProduct", Remote: false}), listProductsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "ListProducts", Remote: false}), searchProductsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "SearchProducts", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return t_client_stub{stub: stub, getProductMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "GetProduct"}), listProductsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "ListProducts"}), searchProductsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "SearchProducts"})}
+			return t_client_stub{stub: stub, getProductMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "GetProduct", Remote: true}), listProductsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "ListProducts", Remote: true}), searchProductsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice/T", Method: "SearchProducts", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return t_server_stub{impl: impl.(T), addLoad: addLoad}
@@ -42,14 +43,20 @@ var _ weaver.Unrouted = (*impl)(nil)
 // Local stub implementations.
 
 type t_local_stub struct {
-	impl   T
-	tracer trace.Tracer
+	impl                  T
+	tracer                trace.Tracer
+	getProductMetrics     *codegen.MethodMetrics
+	listProductsMetrics   *codegen.MethodMetrics
+	searchProductsMetrics *codegen.MethodMetrics
 }
 
 // Check that t_local_stub implements the T interface.
 var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) GetProduct(ctx context.Context, a0 string) (r0 Product, err error) {
+	// Update metrics.
+	begin := s.getProductMetrics.Begin()
+	defer func() { s.getProductMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -67,6 +74,9 @@ func (s t_local_stub) GetProduct(ctx context.Context, a0 string) (r0 Product, er
 }
 
 func (s t_local_stub) ListProducts(ctx context.Context) (r0 []Product, err error) {
+	// Update metrics.
+	begin := s.listProductsMetrics.Begin()
+	defer func() { s.listProductsMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -84,6 +94,9 @@ func (s t_local_stub) ListProducts(ctx context.Context) (r0 []Product, err error
 }
 
 func (s t_local_stub) SearchProducts(ctx context.Context, a0 string) (r0 []Product, err error) {
+	// Update metrics.
+	begin := s.searchProductsMetrics.Begin()
+	defer func() { s.searchProductsMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -114,8 +127,9 @@ var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) GetProduct(ctx context.Context, a0 string) (r0 Product, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.getProductMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.getProductMetrics.Begin()
+	defer func() { s.getProductMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -135,11 +149,9 @@ func (s t_client_stub) GetProduct(ctx context.Context, a0 string) (r0 Product, e
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.getProductMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.getProductMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -153,14 +165,14 @@ func (s t_client_stub) GetProduct(ctx context.Context, a0 string) (r0 Product, e
 	var shardKey uint64
 
 	// Call the remote method.
-	s.getProductMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.getProductMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -171,8 +183,9 @@ func (s t_client_stub) GetProduct(ctx context.Context, a0 string) (r0 Product, e
 
 func (s t_client_stub) ListProducts(ctx context.Context) (r0 []Product, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.listProductsMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.listProductsMetrics.Begin()
+	defer func() { s.listProductsMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -192,24 +205,21 @@ func (s t_client_stub) ListProducts(ctx context.Context) (r0 []Product, err erro
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.listProductsMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.listProductsMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	var shardKey uint64
 
 	// Call the remote method.
-	s.listProductsMetrics.BytesRequest.Put(0)
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, nil, shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.listProductsMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -220,8 +230,9 @@ func (s t_client_stub) ListProducts(ctx context.Context) (r0 []Product, err erro
 
 func (s t_client_stub) SearchProducts(ctx context.Context, a0 string) (r0 []Product, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.searchProductsMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.searchProductsMetrics.Begin()
+	defer func() { s.searchProductsMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -241,11 +252,9 @@ func (s t_client_stub) SearchProducts(ctx context.Context, a0 string) (r0 []Prod
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.searchProductsMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.searchProductsMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -259,14 +268,14 @@ func (s t_client_stub) SearchProducts(ctx context.Context, a0 string) (r0 []Prod
 	var shardKey uint64
 
 	// Call the remote method.
-	s.searchProductsMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 2, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.searchProductsMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/examples/onlineboutique/recommendationservice/weaver_gen.go
+++ b/examples/onlineboutique/recommendationservice/weaver_gen.go
@@ -11,18 +11,19 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
-	"time"
 )
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/recommendationservice/T",
-		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		Impl:        reflect.TypeOf(impl{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/examples/onlineboutique/recommendationservice/T",
+		Iface: reflect.TypeOf((*T)(nil)).Elem(),
+		Impl:  reflect.TypeOf(impl{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return t_local_stub{impl: impl.(T), tracer: tracer, listRecommendationsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/recommendationservice/T", Method: "ListRecommendations", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return t_client_stub{stub: stub, listRecommendationsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/recommendationservice/T", Method: "ListRecommendations"})}
+			return t_client_stub{stub: stub, listRecommendationsMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/recommendationservice/T", Method: "ListRecommendations", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return t_server_stub{impl: impl.(T), addLoad: addLoad}
@@ -40,14 +41,18 @@ var _ weaver.Unrouted = (*impl)(nil)
 // Local stub implementations.
 
 type t_local_stub struct {
-	impl   T
-	tracer trace.Tracer
+	impl                       T
+	tracer                     trace.Tracer
+	listRecommendationsMetrics *codegen.MethodMetrics
 }
 
 // Check that t_local_stub implements the T interface.
 var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) ListRecommendations(ctx context.Context, a0 string, a1 []string) (r0 []string, err error) {
+	// Update metrics.
+	begin := s.listRecommendationsMetrics.Begin()
+	defer func() { s.listRecommendationsMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -76,8 +81,9 @@ var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) ListRecommendations(ctx context.Context, a0 string, a1 []string) (r0 []string, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.listRecommendationsMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.listRecommendationsMetrics.Begin()
+	defer func() { s.listRecommendationsMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -97,11 +103,9 @@ func (s t_client_stub) ListRecommendations(ctx context.Context, a0 string, a1 []
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.listRecommendationsMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.listRecommendationsMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -111,14 +115,14 @@ func (s t_client_stub) ListRecommendations(ctx context.Context, a0 string, a1 []
 	var shardKey uint64
 
 	// Call the remote method.
-	s.listRecommendationsMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.listRecommendationsMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/examples/onlineboutique/shippingservice/weaver_gen.go
+++ b/examples/onlineboutique/shippingservice/weaver_gen.go
@@ -14,18 +14,19 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
-	"time"
 )
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T",
-		Iface:       reflect.TypeOf((*T)(nil)).Elem(),
-		Impl:        reflect.TypeOf(impl{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return t_local_stub{impl: impl.(T), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T",
+		Iface: reflect.TypeOf((*T)(nil)).Elem(),
+		Impl:  reflect.TypeOf(impl{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return t_local_stub{impl: impl.(T), tracer: tracer, getQuoteMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T", Method: "GetQuote", Remote: false}), shipOrderMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T", Method: "ShipOrder", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return t_client_stub{stub: stub, getQuoteMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T", Method: "GetQuote"}), shipOrderMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T", Method: "ShipOrder"})}
+			return t_client_stub{stub: stub, getQuoteMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T", Method: "GetQuote", Remote: true}), shipOrderMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice/T", Method: "ShipOrder", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return t_server_stub{impl: impl.(T), addLoad: addLoad}
@@ -43,14 +44,19 @@ var _ weaver.Unrouted = (*impl)(nil)
 // Local stub implementations.
 
 type t_local_stub struct {
-	impl   T
-	tracer trace.Tracer
+	impl             T
+	tracer           trace.Tracer
+	getQuoteMetrics  *codegen.MethodMetrics
+	shipOrderMetrics *codegen.MethodMetrics
 }
 
 // Check that t_local_stub implements the T interface.
 var _ T = (*t_local_stub)(nil)
 
 func (s t_local_stub) GetQuote(ctx context.Context, a0 Address, a1 []cartservice.CartItem) (r0 money.T, err error) {
+	// Update metrics.
+	begin := s.getQuoteMetrics.Begin()
+	defer func() { s.getQuoteMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -68,6 +74,9 @@ func (s t_local_stub) GetQuote(ctx context.Context, a0 Address, a1 []cartservice
 }
 
 func (s t_local_stub) ShipOrder(ctx context.Context, a0 Address, a1 []cartservice.CartItem) (r0 string, err error) {
+	// Update metrics.
+	begin := s.shipOrderMetrics.Begin()
+	defer func() { s.shipOrderMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -97,8 +106,9 @@ var _ T = (*t_client_stub)(nil)
 
 func (s t_client_stub) GetQuote(ctx context.Context, a0 Address, a1 []cartservice.CartItem) (r0 money.T, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.getQuoteMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.getQuoteMetrics.Begin()
+	defer func() { s.getQuoteMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -118,11 +128,9 @@ func (s t_client_stub) GetQuote(ctx context.Context, a0 Address, a1 []cartservic
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.getQuoteMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.getQuoteMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -132,14 +140,14 @@ func (s t_client_stub) GetQuote(ctx context.Context, a0 Address, a1 []cartservic
 	var shardKey uint64
 
 	// Call the remote method.
-	s.getQuoteMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.getQuoteMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -150,8 +158,9 @@ func (s t_client_stub) GetQuote(ctx context.Context, a0 Address, a1 []cartservic
 
 func (s t_client_stub) ShipOrder(ctx context.Context, a0 Address, a1 []cartservice.CartItem) (r0 string, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.shipOrderMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.shipOrderMetrics.Begin()
+	defer func() { s.shipOrderMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -171,11 +180,9 @@ func (s t_client_stub) ShipOrder(ctx context.Context, a0 Address, a1 []cartservi
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.shipOrderMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.shipOrderMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -185,14 +192,14 @@ func (s t_client_stub) ShipOrder(ctx context.Context, a0 Address, a1 []cartservi
 	var shardKey uint64
 
 	// Call the remote method.
-	s.shipOrderMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.shipOrderMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/examples/reverser/weaver_gen.go
+++ b/examples/reverser/weaver_gen.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
-	"time"
 )
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
@@ -21,7 +20,7 @@ func init() {
 		Iface:     reflect.TypeOf((*weaver.Main)(nil)).Elem(),
 		Impl:      reflect.TypeOf(server{}),
 		Listeners: []string{"reverser"},
-		LocalStubFn: func(impl any, tracer trace.Tracer) any {
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
 			return main_local_stub{impl: impl.(weaver.Main), tracer: tracer}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any { return main_client_stub{stub: stub} },
@@ -34,11 +33,11 @@ func init() {
 		Name:  "github.com/ServiceWeaver/weaver/examples/reverser/Reverser",
 		Iface: reflect.TypeOf((*Reverser)(nil)).Elem(),
 		Impl:  reflect.TypeOf(reverser{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any {
-			return reverser_local_stub{impl: impl.(Reverser), tracer: tracer}
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return reverser_local_stub{impl: impl.(Reverser), tracer: tracer, reverseMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/reverser/Reverser", Method: "Reverse", Remote: false})}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return reverser_client_stub{stub: stub, reverseMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/reverser/Reverser", Method: "Reverse"})}
+			return reverser_client_stub{stub: stub, reverseMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/reverser/Reverser", Method: "Reverse", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return reverser_server_stub{impl: impl.(Reverser), addLoad: addLoad}
@@ -66,14 +65,18 @@ type main_local_stub struct {
 var _ weaver.Main = (*main_local_stub)(nil)
 
 type reverser_local_stub struct {
-	impl   Reverser
-	tracer trace.Tracer
+	impl           Reverser
+	tracer         trace.Tracer
+	reverseMetrics *codegen.MethodMetrics
 }
 
 // Check that reverser_local_stub implements the Reverser interface.
 var _ Reverser = (*reverser_local_stub)(nil)
 
 func (s reverser_local_stub) Reverse(ctx context.Context, a0 string) (r0 string, err error) {
+	// Update metrics.
+	begin := s.reverseMetrics.Begin()
+	defer func() { s.reverseMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -109,8 +112,9 @@ var _ Reverser = (*reverser_client_stub)(nil)
 
 func (s reverser_client_stub) Reverse(ctx context.Context, a0 string) (r0 string, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.reverseMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.reverseMetrics.Begin()
+	defer func() { s.reverseMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -130,11 +134,9 @@ func (s reverser_client_stub) Reverse(ctx context.Context, a0 string) (r0 string
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.reverseMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.reverseMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -148,14 +150,14 @@ func (s reverser_client_stub) Reverse(ctx context.Context, a0 string) (r0 string
 	var shardKey uint64
 
 	// Call the remote method.
-	s.reverseMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.reverseMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/godeps.txt
+++ b/godeps.txt
@@ -134,7 +134,6 @@ github.com/ServiceWeaver/weaver/examples/collatz
     reflect
     strconv
     strings
-    time
 github.com/ServiceWeaver/weaver/examples/factors
     context
     errors
@@ -150,7 +149,6 @@ github.com/ServiceWeaver/weaver/examples/factors
     os
     reflect
     strconv
-    time
 github.com/ServiceWeaver/weaver/examples/hello
     context
     errors
@@ -162,7 +160,6 @@ github.com/ServiceWeaver/weaver/examples/hello
     log
     net/http
     reflect
-    time
 github.com/ServiceWeaver/weaver/examples/helloworld
     context
     fmt
@@ -190,7 +187,6 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice
     math/rand
     reflect
     strings
-    time
 github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice
     context
     errors
@@ -201,7 +197,6 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
     reflect
-    time
 github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice
     context
     errors
@@ -220,7 +215,6 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
     reflect
-    time
 github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice
     context
     embed
@@ -236,7 +230,6 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice
     math
     reflect
     strconv
-    time
 github.com/ServiceWeaver/weaver/examples/onlineboutique/emailservice
     bytes
     context
@@ -250,7 +243,6 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique/emailservice
     go.opentelemetry.io/otel/trace
     html/template
     reflect
-    time
 github.com/ServiceWeaver/weaver/examples/onlineboutique/frontend
     context
     embed
@@ -325,7 +317,6 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique/recommendationservice
     go.opentelemetry.io/otel/trace
     math/rand
     reflect
-    time
 github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice
     context
     errors
@@ -367,7 +358,6 @@ github.com/ServiceWeaver/weaver/examples/reverser
     log
     net/http
     reflect
-    time
 github.com/ServiceWeaver/weaver/internal/benchmarks
     context
     errors
@@ -380,7 +370,6 @@ github.com/ServiceWeaver/weaver/internal/benchmarks
     google.golang.org/protobuf/runtime/protoimpl
     reflect
     sync
-    time
 github.com/ServiceWeaver/weaver/internal/cond
     context
     sync
@@ -593,7 +582,6 @@ github.com/ServiceWeaver/weaver/internal/tool/generate/example
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
     reflect
-    time
 github.com/ServiceWeaver/weaver/internal/tool/multi
     context
     crypto
@@ -794,6 +782,7 @@ github.com/ServiceWeaver/weaver/runtime/codegen
     sort
     strings
     sync
+    time
 github.com/ServiceWeaver/weaver/runtime/colors
     fmt
     golang.org/x/term
@@ -978,7 +967,6 @@ github.com/ServiceWeaver/weaver/weavertest/internal/chain
     go.opentelemetry.io/otel/trace
     reflect
     sync
-    time
 github.com/ServiceWeaver/weaver/weavertest/internal/deploy
     context
     errors
@@ -991,7 +979,6 @@ github.com/ServiceWeaver/weaver/weavertest/internal/deploy
     os
     path/filepath
     reflect
-    time
 github.com/ServiceWeaver/weaver/weavertest/internal/diverge
     context
     errors
@@ -1001,7 +988,6 @@ github.com/ServiceWeaver/weaver/weavertest/internal/diverge
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
     reflect
-    time
 github.com/ServiceWeaver/weaver/weavertest/internal/generate
     context
     errors
@@ -1011,7 +997,6 @@ github.com/ServiceWeaver/weaver/weavertest/internal/generate
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
     reflect
-    time
 github.com/ServiceWeaver/weaver/weavertest/internal/protos
     context
     errors
@@ -1023,7 +1008,6 @@ github.com/ServiceWeaver/weaver/weavertest/internal/protos
     google.golang.org/protobuf/runtime/protoimpl
     reflect
     sync
-    time
 github.com/ServiceWeaver/weaver/weavertest/internal/simple
     context
     errors
@@ -1037,7 +1021,6 @@ github.com/ServiceWeaver/weaver/weavertest/internal/simple
     reflect
     strings
     sync
-    time
 github.com/ServiceWeaver/weaver/website/blog/deployers/multi
     context
     flag

--- a/internal/benchmarks/weaver_gen.go
+++ b/internal/benchmarks/weaver_gen.go
@@ -12,18 +12,19 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
-	"time"
 )
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping1",
-		Iface:       reflect.TypeOf((*Ping1)(nil)).Elem(),
-		Impl:        reflect.TypeOf(ping1{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping1_local_stub{impl: impl.(Ping1), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping1",
+		Iface: reflect.TypeOf((*Ping1)(nil)).Elem(),
+		Impl:  reflect.TypeOf(ping1{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return ping1_local_stub{impl: impl.(Ping1), tracer: tracer, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping1", Method: "PingC", Remote: false}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping1", Method: "PingS", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return ping1_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping1", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping1", Method: "PingS"})}
+			return ping1_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping1", Method: "PingC", Remote: true}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping1", Method: "PingS", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return ping1_server_stub{impl: impl.(Ping1), addLoad: addLoad}
@@ -31,12 +32,14 @@ func init() {
 		RefData: "⟦544443c5:wEaVeReDgE:github.com/ServiceWeaver/weaver/internal/benchmarks/Ping1→github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping10",
-		Iface:       reflect.TypeOf((*Ping10)(nil)).Elem(),
-		Impl:        reflect.TypeOf(ping10{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping10_local_stub{impl: impl.(Ping10), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping10",
+		Iface: reflect.TypeOf((*Ping10)(nil)).Elem(),
+		Impl:  reflect.TypeOf(ping10{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return ping10_local_stub{impl: impl.(Ping10), tracer: tracer, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping10", Method: "PingC", Remote: false}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping10", Method: "PingS", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return ping10_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping10", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping10", Method: "PingS"})}
+			return ping10_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping10", Method: "PingC", Remote: true}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping10", Method: "PingS", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return ping10_server_stub{impl: impl.(Ping10), addLoad: addLoad}
@@ -44,12 +47,14 @@ func init() {
 		RefData: "",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2",
-		Iface:       reflect.TypeOf((*Ping2)(nil)).Elem(),
-		Impl:        reflect.TypeOf(ping2{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping2_local_stub{impl: impl.(Ping2), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2",
+		Iface: reflect.TypeOf((*Ping2)(nil)).Elem(),
+		Impl:  reflect.TypeOf(ping2{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return ping2_local_stub{impl: impl.(Ping2), tracer: tracer, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2", Method: "PingC", Remote: false}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2", Method: "PingS", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return ping2_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2", Method: "PingS"})}
+			return ping2_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2", Method: "PingC", Remote: true}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2", Method: "PingS", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return ping2_server_stub{impl: impl.(Ping2), addLoad: addLoad}
@@ -57,12 +62,14 @@ func init() {
 		RefData: "⟦b42b173c:wEaVeReDgE:github.com/ServiceWeaver/weaver/internal/benchmarks/Ping2→github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3",
-		Iface:       reflect.TypeOf((*Ping3)(nil)).Elem(),
-		Impl:        reflect.TypeOf(ping3{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping3_local_stub{impl: impl.(Ping3), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3",
+		Iface: reflect.TypeOf((*Ping3)(nil)).Elem(),
+		Impl:  reflect.TypeOf(ping3{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return ping3_local_stub{impl: impl.(Ping3), tracer: tracer, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3", Method: "PingC", Remote: false}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3", Method: "PingS", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return ping3_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3", Method: "PingS"})}
+			return ping3_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3", Method: "PingC", Remote: true}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3", Method: "PingS", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return ping3_server_stub{impl: impl.(Ping3), addLoad: addLoad}
@@ -70,12 +77,14 @@ func init() {
 		RefData: "⟦8c498b47:wEaVeReDgE:github.com/ServiceWeaver/weaver/internal/benchmarks/Ping3→github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4",
-		Iface:       reflect.TypeOf((*Ping4)(nil)).Elem(),
-		Impl:        reflect.TypeOf(ping4{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping4_local_stub{impl: impl.(Ping4), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4",
+		Iface: reflect.TypeOf((*Ping4)(nil)).Elem(),
+		Impl:  reflect.TypeOf(ping4{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return ping4_local_stub{impl: impl.(Ping4), tracer: tracer, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4", Method: "PingC", Remote: false}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4", Method: "PingS", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return ping4_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4", Method: "PingS"})}
+			return ping4_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4", Method: "PingC", Remote: true}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4", Method: "PingS", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return ping4_server_stub{impl: impl.(Ping4), addLoad: addLoad}
@@ -83,12 +92,14 @@ func init() {
 		RefData: "⟦90669915:wEaVeReDgE:github.com/ServiceWeaver/weaver/internal/benchmarks/Ping4→github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5",
-		Iface:       reflect.TypeOf((*Ping5)(nil)).Elem(),
-		Impl:        reflect.TypeOf(ping5{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping5_local_stub{impl: impl.(Ping5), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5",
+		Iface: reflect.TypeOf((*Ping5)(nil)).Elem(),
+		Impl:  reflect.TypeOf(ping5{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return ping5_local_stub{impl: impl.(Ping5), tracer: tracer, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5", Method: "PingC", Remote: false}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5", Method: "PingS", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return ping5_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5", Method: "PingS"})}
+			return ping5_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5", Method: "PingC", Remote: true}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5", Method: "PingS", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return ping5_server_stub{impl: impl.(Ping5), addLoad: addLoad}
@@ -96,12 +107,14 @@ func init() {
 		RefData: "⟦a38d1914:wEaVeReDgE:github.com/ServiceWeaver/weaver/internal/benchmarks/Ping5→github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6",
-		Iface:       reflect.TypeOf((*Ping6)(nil)).Elem(),
-		Impl:        reflect.TypeOf(ping6{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping6_local_stub{impl: impl.(Ping6), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6",
+		Iface: reflect.TypeOf((*Ping6)(nil)).Elem(),
+		Impl:  reflect.TypeOf(ping6{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return ping6_local_stub{impl: impl.(Ping6), tracer: tracer, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6", Method: "PingC", Remote: false}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6", Method: "PingS", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return ping6_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6", Method: "PingS"})}
+			return ping6_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6", Method: "PingC", Remote: true}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6", Method: "PingS", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return ping6_server_stub{impl: impl.(Ping6), addLoad: addLoad}
@@ -109,12 +122,14 @@ func init() {
 		RefData: "⟦ebf8b6d3:wEaVeReDgE:github.com/ServiceWeaver/weaver/internal/benchmarks/Ping6→github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7",
-		Iface:       reflect.TypeOf((*Ping7)(nil)).Elem(),
-		Impl:        reflect.TypeOf(ping7{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping7_local_stub{impl: impl.(Ping7), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7",
+		Iface: reflect.TypeOf((*Ping7)(nil)).Elem(),
+		Impl:  reflect.TypeOf(ping7{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return ping7_local_stub{impl: impl.(Ping7), tracer: tracer, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7", Method: "PingC", Remote: false}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7", Method: "PingS", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return ping7_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7", Method: "PingS"})}
+			return ping7_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7", Method: "PingC", Remote: true}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7", Method: "PingS", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return ping7_server_stub{impl: impl.(Ping7), addLoad: addLoad}
@@ -122,12 +137,14 @@ func init() {
 		RefData: "⟦88d68418:wEaVeReDgE:github.com/ServiceWeaver/weaver/internal/benchmarks/Ping7→github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8",
-		Iface:       reflect.TypeOf((*Ping8)(nil)).Elem(),
-		Impl:        reflect.TypeOf(ping8{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping8_local_stub{impl: impl.(Ping8), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8",
+		Iface: reflect.TypeOf((*Ping8)(nil)).Elem(),
+		Impl:  reflect.TypeOf(ping8{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return ping8_local_stub{impl: impl.(Ping8), tracer: tracer, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8", Method: "PingC", Remote: false}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8", Method: "PingS", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return ping8_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8", Method: "PingS"})}
+			return ping8_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8", Method: "PingC", Remote: true}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8", Method: "PingS", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return ping8_server_stub{impl: impl.(Ping8), addLoad: addLoad}
@@ -135,12 +152,14 @@ func init() {
 		RefData: "⟦ed98271d:wEaVeReDgE:github.com/ServiceWeaver/weaver/internal/benchmarks/Ping8→github.com/ServiceWeaver/weaver/internal/benchmarks/Ping9⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping9",
-		Iface:       reflect.TypeOf((*Ping9)(nil)).Elem(),
-		Impl:        reflect.TypeOf(ping9{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return ping9_local_stub{impl: impl.(Ping9), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping9",
+		Iface: reflect.TypeOf((*Ping9)(nil)).Elem(),
+		Impl:  reflect.TypeOf(ping9{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return ping9_local_stub{impl: impl.(Ping9), tracer: tracer, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping9", Method: "PingC", Remote: false}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping9", Method: "PingS", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return ping9_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping9", Method: "PingC"}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping9", Method: "PingS"})}
+			return ping9_client_stub{stub: stub, pingCMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping9", Method: "PingC", Remote: true}), pingSMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/benchmarks/Ping9", Method: "PingS", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return ping9_server_stub{impl: impl.(Ping9), addLoad: addLoad}
@@ -176,14 +195,19 @@ var _ weaver.Unrouted = (*ping9)(nil)
 // Local stub implementations.
 
 type ping1_local_stub struct {
-	impl   Ping1
-	tracer trace.Tracer
+	impl         Ping1
+	tracer       trace.Tracer
+	pingCMetrics *codegen.MethodMetrics
+	pingSMetrics *codegen.MethodMetrics
 }
 
 // Check that ping1_local_stub implements the Ping1 interface.
 var _ Ping1 = (*ping1_local_stub)(nil)
 
 func (s ping1_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
+	// Update metrics.
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -201,6 +225,9 @@ func (s ping1_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 pa
 }
 
 func (s ping1_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
+	// Update metrics.
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -218,14 +245,19 @@ func (s ping1_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 pa
 }
 
 type ping10_local_stub struct {
-	impl   Ping10
-	tracer trace.Tracer
+	impl         Ping10
+	tracer       trace.Tracer
+	pingCMetrics *codegen.MethodMetrics
+	pingSMetrics *codegen.MethodMetrics
 }
 
 // Check that ping10_local_stub implements the Ping10 interface.
 var _ Ping10 = (*ping10_local_stub)(nil)
 
 func (s ping10_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
+	// Update metrics.
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -243,6 +275,9 @@ func (s ping10_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 }
 
 func (s ping10_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
+	// Update metrics.
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -260,14 +295,19 @@ func (s ping10_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 }
 
 type ping2_local_stub struct {
-	impl   Ping2
-	tracer trace.Tracer
+	impl         Ping2
+	tracer       trace.Tracer
+	pingCMetrics *codegen.MethodMetrics
+	pingSMetrics *codegen.MethodMetrics
 }
 
 // Check that ping2_local_stub implements the Ping2 interface.
 var _ Ping2 = (*ping2_local_stub)(nil)
 
 func (s ping2_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
+	// Update metrics.
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -285,6 +325,9 @@ func (s ping2_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 pa
 }
 
 func (s ping2_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
+	// Update metrics.
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -302,14 +345,19 @@ func (s ping2_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 pa
 }
 
 type ping3_local_stub struct {
-	impl   Ping3
-	tracer trace.Tracer
+	impl         Ping3
+	tracer       trace.Tracer
+	pingCMetrics *codegen.MethodMetrics
+	pingSMetrics *codegen.MethodMetrics
 }
 
 // Check that ping3_local_stub implements the Ping3 interface.
 var _ Ping3 = (*ping3_local_stub)(nil)
 
 func (s ping3_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
+	// Update metrics.
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -327,6 +375,9 @@ func (s ping3_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 pa
 }
 
 func (s ping3_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
+	// Update metrics.
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -344,14 +395,19 @@ func (s ping3_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 pa
 }
 
 type ping4_local_stub struct {
-	impl   Ping4
-	tracer trace.Tracer
+	impl         Ping4
+	tracer       trace.Tracer
+	pingCMetrics *codegen.MethodMetrics
+	pingSMetrics *codegen.MethodMetrics
 }
 
 // Check that ping4_local_stub implements the Ping4 interface.
 var _ Ping4 = (*ping4_local_stub)(nil)
 
 func (s ping4_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
+	// Update metrics.
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -369,6 +425,9 @@ func (s ping4_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 pa
 }
 
 func (s ping4_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
+	// Update metrics.
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -386,14 +445,19 @@ func (s ping4_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 pa
 }
 
 type ping5_local_stub struct {
-	impl   Ping5
-	tracer trace.Tracer
+	impl         Ping5
+	tracer       trace.Tracer
+	pingCMetrics *codegen.MethodMetrics
+	pingSMetrics *codegen.MethodMetrics
 }
 
 // Check that ping5_local_stub implements the Ping5 interface.
 var _ Ping5 = (*ping5_local_stub)(nil)
 
 func (s ping5_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
+	// Update metrics.
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -411,6 +475,9 @@ func (s ping5_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 pa
 }
 
 func (s ping5_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
+	// Update metrics.
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -428,14 +495,19 @@ func (s ping5_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 pa
 }
 
 type ping6_local_stub struct {
-	impl   Ping6
-	tracer trace.Tracer
+	impl         Ping6
+	tracer       trace.Tracer
+	pingCMetrics *codegen.MethodMetrics
+	pingSMetrics *codegen.MethodMetrics
 }
 
 // Check that ping6_local_stub implements the Ping6 interface.
 var _ Ping6 = (*ping6_local_stub)(nil)
 
 func (s ping6_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
+	// Update metrics.
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -453,6 +525,9 @@ func (s ping6_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 pa
 }
 
 func (s ping6_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
+	// Update metrics.
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -470,14 +545,19 @@ func (s ping6_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 pa
 }
 
 type ping7_local_stub struct {
-	impl   Ping7
-	tracer trace.Tracer
+	impl         Ping7
+	tracer       trace.Tracer
+	pingCMetrics *codegen.MethodMetrics
+	pingSMetrics *codegen.MethodMetrics
 }
 
 // Check that ping7_local_stub implements the Ping7 interface.
 var _ Ping7 = (*ping7_local_stub)(nil)
 
 func (s ping7_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
+	// Update metrics.
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -495,6 +575,9 @@ func (s ping7_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 pa
 }
 
 func (s ping7_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
+	// Update metrics.
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -512,14 +595,19 @@ func (s ping7_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 pa
 }
 
 type ping8_local_stub struct {
-	impl   Ping8
-	tracer trace.Tracer
+	impl         Ping8
+	tracer       trace.Tracer
+	pingCMetrics *codegen.MethodMetrics
+	pingSMetrics *codegen.MethodMetrics
 }
 
 // Check that ping8_local_stub implements the Ping8 interface.
 var _ Ping8 = (*ping8_local_stub)(nil)
 
 func (s ping8_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
+	// Update metrics.
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -537,6 +625,9 @@ func (s ping8_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 pa
 }
 
 func (s ping8_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
+	// Update metrics.
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -554,14 +645,19 @@ func (s ping8_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 pa
 }
 
 type ping9_local_stub struct {
-	impl   Ping9
-	tracer trace.Tracer
+	impl         Ping9
+	tracer       trace.Tracer
+	pingCMetrics *codegen.MethodMetrics
+	pingSMetrics *codegen.MethodMetrics
 }
 
 // Check that ping9_local_stub implements the Ping9 interface.
 var _ Ping9 = (*ping9_local_stub)(nil)
 
 func (s ping9_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
+	// Update metrics.
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -579,6 +675,9 @@ func (s ping9_local_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 pa
 }
 
 func (s ping9_local_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
+	// Update metrics.
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -608,8 +707,9 @@ var _ Ping1 = (*ping1_client_stub)(nil)
 
 func (s ping1_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingCMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -629,11 +729,9 @@ func (s ping1_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingCMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingCMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -649,14 +747,14 @@ func (s ping1_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingCMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingCMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -667,8 +765,9 @@ func (s ping1_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 
 func (s ping1_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingSMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -688,11 +787,9 @@ func (s ping1_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingSMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingSMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -702,14 +799,14 @@ func (s ping1_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingSMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingSMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -729,8 +826,9 @@ var _ Ping10 = (*ping10_client_stub)(nil)
 
 func (s ping10_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingCMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -750,11 +848,9 @@ func (s ping10_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingCMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingCMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -770,14 +866,14 @@ func (s ping10_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingCMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingCMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -788,8 +884,9 @@ func (s ping10_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 
 
 func (s ping10_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingSMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -809,11 +906,9 @@ func (s ping10_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingSMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingSMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -823,14 +918,14 @@ func (s ping10_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingSMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingSMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -850,8 +945,9 @@ var _ Ping2 = (*ping2_client_stub)(nil)
 
 func (s ping2_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingCMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -871,11 +967,9 @@ func (s ping2_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingCMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingCMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -891,14 +985,14 @@ func (s ping2_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingCMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingCMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -909,8 +1003,9 @@ func (s ping2_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 
 func (s ping2_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingSMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -930,11 +1025,9 @@ func (s ping2_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingSMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingSMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -944,14 +1037,14 @@ func (s ping2_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingSMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingSMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -971,8 +1064,9 @@ var _ Ping3 = (*ping3_client_stub)(nil)
 
 func (s ping3_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingCMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -992,11 +1086,9 @@ func (s ping3_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingCMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingCMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -1012,14 +1104,14 @@ func (s ping3_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingCMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingCMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1030,8 +1122,9 @@ func (s ping3_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 
 func (s ping3_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingSMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1051,11 +1144,9 @@ func (s ping3_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingSMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingSMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -1065,14 +1156,14 @@ func (s ping3_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingSMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingSMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1092,8 +1183,9 @@ var _ Ping4 = (*ping4_client_stub)(nil)
 
 func (s ping4_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingCMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1113,11 +1205,9 @@ func (s ping4_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingCMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingCMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -1133,14 +1223,14 @@ func (s ping4_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingCMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingCMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1151,8 +1241,9 @@ func (s ping4_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 
 func (s ping4_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingSMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1172,11 +1263,9 @@ func (s ping4_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingSMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingSMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -1186,14 +1275,14 @@ func (s ping4_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingSMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingSMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1213,8 +1302,9 @@ var _ Ping5 = (*ping5_client_stub)(nil)
 
 func (s ping5_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingCMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1234,11 +1324,9 @@ func (s ping5_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingCMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingCMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -1254,14 +1342,14 @@ func (s ping5_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingCMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingCMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1272,8 +1360,9 @@ func (s ping5_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 
 func (s ping5_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingSMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1293,11 +1382,9 @@ func (s ping5_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingSMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingSMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -1307,14 +1394,14 @@ func (s ping5_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingSMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingSMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1334,8 +1421,9 @@ var _ Ping6 = (*ping6_client_stub)(nil)
 
 func (s ping6_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingCMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1355,11 +1443,9 @@ func (s ping6_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingCMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingCMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -1375,14 +1461,14 @@ func (s ping6_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingCMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingCMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1393,8 +1479,9 @@ func (s ping6_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 
 func (s ping6_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingSMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1414,11 +1501,9 @@ func (s ping6_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingSMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingSMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -1428,14 +1513,14 @@ func (s ping6_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingSMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingSMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1455,8 +1540,9 @@ var _ Ping7 = (*ping7_client_stub)(nil)
 
 func (s ping7_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingCMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1476,11 +1562,9 @@ func (s ping7_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingCMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingCMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -1496,14 +1580,14 @@ func (s ping7_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingCMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingCMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1514,8 +1598,9 @@ func (s ping7_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 
 func (s ping7_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingSMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1535,11 +1620,9 @@ func (s ping7_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingSMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingSMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -1549,14 +1632,14 @@ func (s ping7_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingSMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingSMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1576,8 +1659,9 @@ var _ Ping8 = (*ping8_client_stub)(nil)
 
 func (s ping8_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingCMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1597,11 +1681,9 @@ func (s ping8_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingCMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingCMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -1617,14 +1699,14 @@ func (s ping8_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingCMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingCMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1635,8 +1717,9 @@ func (s ping8_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 
 func (s ping8_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingSMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1656,11 +1739,9 @@ func (s ping8_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingSMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingSMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -1670,14 +1751,14 @@ func (s ping8_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingSMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingSMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1697,8 +1778,9 @@ var _ Ping9 = (*ping9_client_stub)(nil)
 
 func (s ping9_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 payloadC, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingCMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingCMetrics.Begin()
+	defer func() { s.pingCMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1718,11 +1800,9 @@ func (s ping9_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingCMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingCMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -1738,14 +1818,14 @@ func (s ping9_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingCMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingCMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -1756,8 +1836,9 @@ func (s ping9_client_stub) PingC(ctx context.Context, a0 payloadC, a1 int) (r0 p
 
 func (s ping9_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 payloadS, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.pingSMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.pingSMetrics.Begin()
+	defer func() { s.pingSMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -1777,11 +1858,9 @@ func (s ping9_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.pingSMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.pingSMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -1791,14 +1870,14 @@ func (s ping9_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 	var shardKey uint64
 
 	// Call the remote method.
-	s.pingSMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.pingSMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/internal/envelope/conn/conn_test.go
+++ b/internal/envelope/conn/conn_test.go
@@ -198,7 +198,7 @@ func register[Intf, Impl any](name string) {
 		Name:         name,
 		Iface:        reflection.Type[Intf](),
 		Impl:         reflect.TypeOf(zero),
-		LocalStubFn:  func(any, trace.Tracer) any { return nil },
+		LocalStubFn:  func(any, string, trace.Tracer) any { return nil },
 		ClientStubFn: func(codegen.Stub, string) any { return nil },
 		ServerStubFn: func(any, func(uint64, float64)) codegen.Server { return nil },
 	})

--- a/internal/tool/generate/example/main.go
+++ b/internal/tool/generate/example/main.go
@@ -22,6 +22,8 @@ import (
 	"github.com/ServiceWeaver/weaver"
 )
 
+//go:generate ../../../../cmd/weaver/weaver generate
+
 type message struct {
 	weaver.AutoMarshal
 	a int

--- a/internal/tool/generate/example/weaver_gen.go
+++ b/internal/tool/generate/example/weaver_gen.go
@@ -12,20 +12,21 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
-	"time"
 )
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/internal/tool/generate/example/A",
-		Iface:       reflect.TypeOf((*A)(nil)).Elem(),
-		Impl:        reflect.TypeOf(a{}),
-		Routed:      true,
-		Listeners:   []string{"lis2", "renamed_listener"},
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return a_local_stub{impl: impl.(A), tracer: tracer} },
+		Name:      "github.com/ServiceWeaver/weaver/internal/tool/generate/example/A",
+		Iface:     reflect.TypeOf((*A)(nil)).Elem(),
+		Impl:      reflect.TypeOf(a{}),
+		Routed:    true,
+		Listeners: []string{"lis2", "renamed_listener"},
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return a_local_stub{impl: impl.(A), tracer: tracer, m1Metrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/tool/generate/example/A", Method: "M1", Remote: false}), m2Metrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/tool/generate/example/A", Method: "M2", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return a_client_stub{stub: stub, m1Metrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/tool/generate/example/A", Method: "M1"}), m2Metrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/tool/generate/example/A", Method: "M2"})}
+			return a_client_stub{stub: stub, m1Metrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/tool/generate/example/A", Method: "M1", Remote: true}), m2Metrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/tool/generate/example/A", Method: "M2", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return a_server_stub{impl: impl.(A), addLoad: addLoad}
@@ -33,14 +34,16 @@ func init() {
 		RefData: "⟦627f661b:wEaVeReDgE:github.com/ServiceWeaver/weaver/internal/tool/generate/example/A→github.com/ServiceWeaver/weaver/internal/tool/generate/example/B⟧\n⟦26168bd7:wEaVeRlIsTeNeRs:github.com/ServiceWeaver/weaver/internal/tool/generate/example/A→lis2,renamed_listener⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/internal/tool/generate/example/B",
-		Iface:       reflect.TypeOf((*B)(nil)).Elem(),
-		Impl:        reflect.TypeOf(b{}),
-		Routed:      true,
-		Listeners:   []string{"lis2", "renamed_listener"},
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return b_local_stub{impl: impl.(B), tracer: tracer} },
+		Name:      "github.com/ServiceWeaver/weaver/internal/tool/generate/example/B",
+		Iface:     reflect.TypeOf((*B)(nil)).Elem(),
+		Impl:      reflect.TypeOf(b{}),
+		Routed:    true,
+		Listeners: []string{"lis2", "renamed_listener"},
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return b_local_stub{impl: impl.(B), tracer: tracer, m1Metrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/tool/generate/example/B", Method: "M1", Remote: false}), m2Metrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/tool/generate/example/B", Method: "M2", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return b_client_stub{stub: stub, m1Metrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/tool/generate/example/B", Method: "M1"}), m2Metrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/tool/generate/example/B", Method: "M2"})}
+			return b_client_stub{stub: stub, m1Metrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/tool/generate/example/B", Method: "M1", Remote: true}), m2Metrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/tool/generate/example/B", Method: "M2", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return b_server_stub{impl: impl.(B), addLoad: addLoad}
@@ -67,14 +70,19 @@ var _ func(context.Context, int, string, bool, [10]int, []string, map[bool]int, 
 // Local stub implementations.
 
 type a_local_stub struct {
-	impl   A
-	tracer trace.Tracer
+	impl      A
+	tracer    trace.Tracer
+	m1Metrics *codegen.MethodMetrics
+	m2Metrics *codegen.MethodMetrics
 }
 
 // Check that a_local_stub implements the A interface.
 var _ A = (*a_local_stub)(nil)
 
 func (s a_local_stub) M1(ctx context.Context, a0 int, a1 string, a2 bool, a3 [10]int, a4 []string, a5 map[bool]int, a6 message) (r0 pair, err error) {
+	// Update metrics.
+	begin := s.m1Metrics.Begin()
+	defer func() { s.m1Metrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -92,6 +100,9 @@ func (s a_local_stub) M1(ctx context.Context, a0 int, a1 string, a2 bool, a3 [10
 }
 
 func (s a_local_stub) M2(ctx context.Context, a0 int, a1 string, a2 bool, a3 [10]int, a4 []string, a5 map[bool]int, a6 message) (r0 pair, err error) {
+	// Update metrics.
+	begin := s.m2Metrics.Begin()
+	defer func() { s.m2Metrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -109,14 +120,19 @@ func (s a_local_stub) M2(ctx context.Context, a0 int, a1 string, a2 bool, a3 [10
 }
 
 type b_local_stub struct {
-	impl   B
-	tracer trace.Tracer
+	impl      B
+	tracer    trace.Tracer
+	m1Metrics *codegen.MethodMetrics
+	m2Metrics *codegen.MethodMetrics
 }
 
 // Check that b_local_stub implements the B interface.
 var _ B = (*b_local_stub)(nil)
 
 func (s b_local_stub) M1(ctx context.Context, a0 int, a1 string, a2 bool, a3 [10]int, a4 []string, a5 map[bool]int, a6 message) (r0 pair, err error) {
+	// Update metrics.
+	begin := s.m1Metrics.Begin()
+	defer func() { s.m1Metrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -134,6 +150,9 @@ func (s b_local_stub) M1(ctx context.Context, a0 int, a1 string, a2 bool, a3 [10
 }
 
 func (s b_local_stub) M2(ctx context.Context, a0 int, a1 string, a2 bool, a3 [10]int, a4 []string, a5 map[bool]int, a6 message) (r0 pair, err error) {
+	// Update metrics.
+	begin := s.m2Metrics.Begin()
+	defer func() { s.m2Metrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -163,8 +182,9 @@ var _ A = (*a_client_stub)(nil)
 
 func (s a_client_stub) M1(ctx context.Context, a0 int, a1 string, a2 bool, a3 [10]int, a4 []string, a5 map[bool]int, a6 message) (r0 pair, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.m1Metrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.m1Metrics.Begin()
+	defer func() { s.m1Metrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -184,11 +204,9 @@ func (s a_client_stub) M1(ctx context.Context, a0 int, a1 string, a2 bool, a3 [1
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.m1Metrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.m1Metrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -206,14 +224,14 @@ func (s a_client_stub) M1(ctx context.Context, a0 int, a1 string, a2 bool, a3 [1
 	shardKey := _hashA(r.M1(ctx, a0, a1, a2, a3, a4, a5, a6))
 
 	// Call the remote method.
-	s.m1Metrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.m1Metrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -224,8 +242,9 @@ func (s a_client_stub) M1(ctx context.Context, a0 int, a1 string, a2 bool, a3 [1
 
 func (s a_client_stub) M2(ctx context.Context, a0 int, a1 string, a2 bool, a3 [10]int, a4 []string, a5 map[bool]int, a6 message) (r0 pair, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.m2Metrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.m2Metrics.Begin()
+	defer func() { s.m2Metrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -245,11 +264,9 @@ func (s a_client_stub) M2(ctx context.Context, a0 int, a1 string, a2 bool, a3 [1
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.m2Metrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.m2Metrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -267,14 +284,14 @@ func (s a_client_stub) M2(ctx context.Context, a0 int, a1 string, a2 bool, a3 [1
 	shardKey := _hashA(r.M2(ctx, a0, a1, a2, a3, a4, a5, a6))
 
 	// Call the remote method.
-	s.m2Metrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.m2Metrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -294,8 +311,9 @@ var _ B = (*b_client_stub)(nil)
 
 func (s b_client_stub) M1(ctx context.Context, a0 int, a1 string, a2 bool, a3 [10]int, a4 []string, a5 map[bool]int, a6 message) (r0 pair, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.m1Metrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.m1Metrics.Begin()
+	defer func() { s.m1Metrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -315,11 +333,9 @@ func (s b_client_stub) M1(ctx context.Context, a0 int, a1 string, a2 bool, a3 [1
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.m1Metrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.m1Metrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -337,14 +353,14 @@ func (s b_client_stub) M1(ctx context.Context, a0 int, a1 string, a2 bool, a3 [1
 	shardKey := _hashB(r.M1(ctx, a0, a1, a2, a3, a4, a5, a6))
 
 	// Call the remote method.
-	s.m1Metrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.m1Metrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -355,8 +371,9 @@ func (s b_client_stub) M1(ctx context.Context, a0 int, a1 string, a2 bool, a3 [1
 
 func (s b_client_stub) M2(ctx context.Context, a0 int, a1 string, a2 bool, a3 [10]int, a4 []string, a5 map[bool]int, a6 message) (r0 pair, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.m2Metrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.m2Metrics.Begin()
+	defer func() { s.m2Metrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -376,11 +393,9 @@ func (s b_client_stub) M2(ctx context.Context, a0 int, a1 string, a2 bool, a3 [1
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.m2Metrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.m2Metrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Encode arguments.
@@ -398,14 +413,14 @@ func (s b_client_stub) M2(ctx context.Context, a0 int, a1 string, a2 bool, a3 [1
 	shardKey := _hashB(r.M2(ctx, a0, a1, a2, a3, a4, a5, a6))
 
 	// Call the remote method.
-	s.m2Metrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.m2Metrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/internal/tool/generate/generator_test.go
+++ b/internal/tool/generate/generator_test.go
@@ -459,7 +459,7 @@ func TestExampleVersion(t *testing.T) {
 	got := fmt.Sprintf("%x", h.Sum(nil))
 
 	// If weaver_gen.go has changed, the codegen version may need updating.
-	const want = "b7b49b4f18514342edea9f1fbca422692b8f0f91c4258eb3b3ca45661b02e2c1"
+	const want = "986a14a9d781135207eafe3ed41448db62ba0c8e25c8a2bef28706bc83c41fe8"
 	if got != want {
 		t.Fatalf(`Unexpected SHA-256 hash of examples/weaver_gen.go: got %s, want %s. If this change is meaningful, REMEMBER TO UPDATE THE CODEGEN VERSION in runtime/version/version.go.`, got, want)
 	}

--- a/internal/tool/generate/testdata/metrics.go
+++ b/internal/tool/generate/testdata/metrics.go
@@ -13,13 +13,11 @@
 // limitations under the License.
 
 // EXPECTED
-// codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "foo/foo", Method: "Method"})
+// codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "foo/foo", Method: "Method", Remote: false})
+// codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "foo/foo", Method: "Method", Remote: true})
 // methodMetrics *codegen.MethodMetrics
-// start := time.Now()
-// s.methodMetrics.Count.Add(1)
-// s.methodMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
-// s.methodMetrics.BytesRequest.Put(float64(len(enc.Data())))
-// s.methodMetrics.BytesReply.Put(float64(len(results)))
+// begin := s.methodMetrics.Begin(
+// s.methodMetrics.End(begin
 
 package foo
 

--- a/runtime/bin/testprogram/weaver_gen.go
+++ b/runtime/bin/testprogram/weaver_gen.go
@@ -14,11 +14,13 @@ var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:         "github.com/ServiceWeaver/weaver/runtime/bin/testprogram/A",
-		Iface:        reflect.TypeOf((*A)(nil)).Elem(),
-		Impl:         reflect.TypeOf(a{}),
-		Listeners:    []string{"aLis1", "aLis2", "aLis3"},
-		LocalStubFn:  func(impl any, tracer trace.Tracer) any { return a_local_stub{impl: impl.(A), tracer: tracer} },
+		Name:      "github.com/ServiceWeaver/weaver/runtime/bin/testprogram/A",
+		Iface:     reflect.TypeOf((*A)(nil)).Elem(),
+		Impl:      reflect.TypeOf(a{}),
+		Listeners: []string{"aLis1", "aLis2", "aLis3"},
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return a_local_stub{impl: impl.(A), tracer: tracer}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any { return a_client_stub{stub: stub} },
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return a_server_stub{impl: impl.(A), addLoad: addLoad}
@@ -26,11 +28,13 @@ func init() {
 		RefData: "⟦193f6c94:wEaVeReDgE:github.com/ServiceWeaver/weaver/runtime/bin/testprogram/A→github.com/ServiceWeaver/weaver/runtime/bin/testprogram/B⟧\n⟦8cd483a3:wEaVeReDgE:github.com/ServiceWeaver/weaver/runtime/bin/testprogram/A→github.com/ServiceWeaver/weaver/runtime/bin/testprogram/C⟧\n⟦93cd9612:wEaVeRlIsTeNeRs:github.com/ServiceWeaver/weaver/runtime/bin/testprogram/A→aLis1,aLis2,aLis3⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:         "github.com/ServiceWeaver/weaver/runtime/bin/testprogram/B",
-		Iface:        reflect.TypeOf((*B)(nil)).Elem(),
-		Impl:         reflect.TypeOf(b{}),
-		Listeners:    []string{"Listener"},
-		LocalStubFn:  func(impl any, tracer trace.Tracer) any { return b_local_stub{impl: impl.(B), tracer: tracer} },
+		Name:      "github.com/ServiceWeaver/weaver/runtime/bin/testprogram/B",
+		Iface:     reflect.TypeOf((*B)(nil)).Elem(),
+		Impl:      reflect.TypeOf(b{}),
+		Listeners: []string{"Listener"},
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return b_local_stub{impl: impl.(B), tracer: tracer}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any { return b_client_stub{stub: stub} },
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return b_server_stub{impl: impl.(B), addLoad: addLoad}
@@ -38,11 +42,13 @@ func init() {
 		RefData: "⟦7551e870:wEaVeRlIsTeNeRs:github.com/ServiceWeaver/weaver/runtime/bin/testprogram/B→Listener⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:         "github.com/ServiceWeaver/weaver/runtime/bin/testprogram/C",
-		Iface:        reflect.TypeOf((*C)(nil)).Elem(),
-		Impl:         reflect.TypeOf(c{}),
-		Listeners:    []string{"cLis"},
-		LocalStubFn:  func(impl any, tracer trace.Tracer) any { return c_local_stub{impl: impl.(C), tracer: tracer} },
+		Name:      "github.com/ServiceWeaver/weaver/runtime/bin/testprogram/C",
+		Iface:     reflect.TypeOf((*C)(nil)).Elem(),
+		Impl:      reflect.TypeOf(c{}),
+		Listeners: []string{"cLis"},
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return c_local_stub{impl: impl.(C), tracer: tracer}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any { return c_client_stub{stub: stub} },
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return c_server_stub{impl: impl.(C), addLoad: addLoad}
@@ -54,7 +60,7 @@ func init() {
 		Iface:     reflect.TypeOf((*weaver.Main)(nil)).Elem(),
 		Impl:      reflect.TypeOf(app{}),
 		Listeners: []string{"appLis"},
-		LocalStubFn: func(impl any, tracer trace.Tracer) any {
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
 			return main_local_stub{impl: impl.(weaver.Main), tracer: tracer}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any { return main_client_stub{stub: stub} },

--- a/runtime/codegen/registry.go
+++ b/runtime/codegen/registry.go
@@ -60,7 +60,7 @@ type Registration struct {
 	Listeners []string     // the names of any weaver.Listeners
 
 	// Functions that return different types of stubs.
-	LocalStubFn  func(impl any, tracer trace.Tracer) any
+	LocalStubFn  func(impl any, caller string, tracer trace.Tracer) any
 	ClientStubFn func(stub Stub, caller string) any
 	ServerStubFn func(impl any, load func(key uint64, load float64)) Server
 

--- a/runtime/codegen/registry_test.go
+++ b/runtime/codegen/registry_test.go
@@ -123,7 +123,7 @@ func register[Intf, Impl any](name string) {
 		Name:         name,
 		Iface:        reflection.Type[Intf](),
 		Impl:         reflect.TypeOf(zero),
-		LocalStubFn:  func(any, trace.Tracer) any { return nil },
+		LocalStubFn:  func(any, string, trace.Tracer) any { return nil },
 		ClientStubFn: func(codegen.Stub, string) any { return nil },
 		ServerStubFn: func(any, func(uint64, float64)) codegen.Server { return nil },
 	})

--- a/runtime/envelope/envelope_test.go
+++ b/runtime/envelope/envelope_test.go
@@ -552,7 +552,7 @@ func register[Intf, Impl any](name string) {
 		Name:         name,
 		Iface:        reflection.Type[Intf](),
 		Impl:         reflect.TypeOf(zero),
-		LocalStubFn:  func(any, trace.Tracer) any { return nil },
+		LocalStubFn:  func(any, string, trace.Tracer) any { return nil },
 		ClientStubFn: func(codegen.Stub, string) any { return nil },
 		ServerStubFn: func(any, func(uint64, float64)) codegen.Server { return nil },
 	})

--- a/runtime/metrics/metrics.go
+++ b/runtime/metrics/metrics.go
@@ -24,10 +24,10 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/google/uuid"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
-	"github.com/ServiceWeaver/weaver/runtime/protos"
 )
 
 var (

--- a/weavelet.go
+++ b/weavelet.go
@@ -347,7 +347,7 @@ func (w *weavelet) getInstance(ctx context.Context, c *component, requester stri
 		if err != nil {
 			return nil, nil, err
 		}
-		return c.info.LocalStubFn(impl.impl, impl.component.tracer), impl.impl, nil
+		return c.info.LocalStubFn(impl.impl, requester, impl.component.tracer), impl.impl, nil
 	}
 
 	stub, err := w.getStub(c)

--- a/weavertest/internal/chain/weaver_gen.go
+++ b/weavertest/internal/chain/weaver_gen.go
@@ -11,18 +11,19 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
-	"time"
 )
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/weavertest/internal/chain/A",
-		Iface:       reflect.TypeOf((*A)(nil)).Elem(),
-		Impl:        reflect.TypeOf(a{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return a_local_stub{impl: impl.(A), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/weavertest/internal/chain/A",
+		Iface: reflect.TypeOf((*A)(nil)).Elem(),
+		Impl:  reflect.TypeOf(a{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return a_local_stub{impl: impl.(A), tracer: tracer, propagateMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/chain/A", Method: "Propagate", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return a_client_stub{stub: stub, propagateMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/chain/A", Method: "Propagate"})}
+			return a_client_stub{stub: stub, propagateMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/chain/A", Method: "Propagate", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return a_server_stub{impl: impl.(A), addLoad: addLoad}
@@ -30,12 +31,14 @@ func init() {
 		RefData: "⟦d3d93f6e:wEaVeReDgE:github.com/ServiceWeaver/weaver/weavertest/internal/chain/A→github.com/ServiceWeaver/weaver/weavertest/internal/chain/B⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/weavertest/internal/chain/B",
-		Iface:       reflect.TypeOf((*B)(nil)).Elem(),
-		Impl:        reflect.TypeOf(b{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return b_local_stub{impl: impl.(B), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/weavertest/internal/chain/B",
+		Iface: reflect.TypeOf((*B)(nil)).Elem(),
+		Impl:  reflect.TypeOf(b{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return b_local_stub{impl: impl.(B), tracer: tracer, propagateMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/chain/B", Method: "Propagate", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return b_client_stub{stub: stub, propagateMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/chain/B", Method: "Propagate"})}
+			return b_client_stub{stub: stub, propagateMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/chain/B", Method: "Propagate", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return b_server_stub{impl: impl.(B), addLoad: addLoad}
@@ -43,12 +46,14 @@ func init() {
 		RefData: "⟦08d612ad:wEaVeReDgE:github.com/ServiceWeaver/weaver/weavertest/internal/chain/B→github.com/ServiceWeaver/weaver/weavertest/internal/chain/C⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/weavertest/internal/chain/C",
-		Iface:       reflect.TypeOf((*C)(nil)).Elem(),
-		Impl:        reflect.TypeOf(c{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return c_local_stub{impl: impl.(C), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/weavertest/internal/chain/C",
+		Iface: reflect.TypeOf((*C)(nil)).Elem(),
+		Impl:  reflect.TypeOf(c{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return c_local_stub{impl: impl.(C), tracer: tracer, propagateMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/chain/C", Method: "Propagate", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return c_client_stub{stub: stub, propagateMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/chain/C", Method: "Propagate"})}
+			return c_client_stub{stub: stub, propagateMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/chain/C", Method: "Propagate", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return c_server_stub{impl: impl.(C), addLoad: addLoad}
@@ -70,14 +75,18 @@ var _ weaver.Unrouted = (*c)(nil)
 // Local stub implementations.
 
 type a_local_stub struct {
-	impl   A
-	tracer trace.Tracer
+	impl             A
+	tracer           trace.Tracer
+	propagateMetrics *codegen.MethodMetrics
 }
 
 // Check that a_local_stub implements the A interface.
 var _ A = (*a_local_stub)(nil)
 
 func (s a_local_stub) Propagate(ctx context.Context, a0 int) (err error) {
+	// Update metrics.
+	begin := s.propagateMetrics.Begin()
+	defer func() { s.propagateMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -95,14 +104,18 @@ func (s a_local_stub) Propagate(ctx context.Context, a0 int) (err error) {
 }
 
 type b_local_stub struct {
-	impl   B
-	tracer trace.Tracer
+	impl             B
+	tracer           trace.Tracer
+	propagateMetrics *codegen.MethodMetrics
 }
 
 // Check that b_local_stub implements the B interface.
 var _ B = (*b_local_stub)(nil)
 
 func (s b_local_stub) Propagate(ctx context.Context, a0 int) (err error) {
+	// Update metrics.
+	begin := s.propagateMetrics.Begin()
+	defer func() { s.propagateMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -120,14 +133,18 @@ func (s b_local_stub) Propagate(ctx context.Context, a0 int) (err error) {
 }
 
 type c_local_stub struct {
-	impl   C
-	tracer trace.Tracer
+	impl             C
+	tracer           trace.Tracer
+	propagateMetrics *codegen.MethodMetrics
 }
 
 // Check that c_local_stub implements the C interface.
 var _ C = (*c_local_stub)(nil)
 
 func (s c_local_stub) Propagate(ctx context.Context, a0 int) (err error) {
+	// Update metrics.
+	begin := s.propagateMetrics.Begin()
+	defer func() { s.propagateMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -156,8 +173,9 @@ var _ A = (*a_client_stub)(nil)
 
 func (s a_client_stub) Propagate(ctx context.Context, a0 int) (err error) {
 	// Update metrics.
-	start := time.Now()
-	s.propagateMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.propagateMetrics.Begin()
+	defer func() { s.propagateMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -177,11 +195,9 @@ func (s a_client_stub) Propagate(ctx context.Context, a0 int) (err error) {
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.propagateMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.propagateMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -195,14 +211,14 @@ func (s a_client_stub) Propagate(ctx context.Context, a0 int) (err error) {
 	var shardKey uint64
 
 	// Call the remote method.
-	s.propagateMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.propagateMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -220,8 +236,9 @@ var _ B = (*b_client_stub)(nil)
 
 func (s b_client_stub) Propagate(ctx context.Context, a0 int) (err error) {
 	// Update metrics.
-	start := time.Now()
-	s.propagateMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.propagateMetrics.Begin()
+	defer func() { s.propagateMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -241,11 +258,9 @@ func (s b_client_stub) Propagate(ctx context.Context, a0 int) (err error) {
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.propagateMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.propagateMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -259,14 +274,14 @@ func (s b_client_stub) Propagate(ctx context.Context, a0 int) (err error) {
 	var shardKey uint64
 
 	// Call the remote method.
-	s.propagateMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.propagateMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -284,8 +299,9 @@ var _ C = (*c_client_stub)(nil)
 
 func (s c_client_stub) Propagate(ctx context.Context, a0 int) (err error) {
 	// Update metrics.
-	start := time.Now()
-	s.propagateMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.propagateMetrics.Begin()
+	defer func() { s.propagateMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -305,11 +321,9 @@ func (s c_client_stub) Propagate(ctx context.Context, a0 int) (err error) {
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.propagateMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.propagateMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -323,14 +337,14 @@ func (s c_client_stub) Propagate(ctx context.Context, a0 int) (err error) {
 	var shardKey uint64
 
 	// Call the remote method.
-	s.propagateMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.propagateMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/weavertest/internal/simple/weaver_gen.go
+++ b/weavertest/internal/simple/weaver_gen.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
-	"time"
 )
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
 
@@ -21,11 +20,11 @@ func init() {
 		Iface:  reflect.TypeOf((*Destination)(nil)).Elem(),
 		Impl:   reflect.TypeOf(destination{}),
 		Routed: true,
-		LocalStubFn: func(impl any, tracer trace.Tracer) any {
-			return destination_local_stub{impl: impl.(Destination), tracer: tracer}
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return destination_local_stub{impl: impl.(Destination), tracer: tracer, getAllMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "GetAll", Remote: false}), getpidMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Getpid", Remote: false}), recordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Record", Remote: false}), routedRecordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "RoutedRecord", Remote: false})}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return destination_client_stub{stub: stub, getAllMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "GetAll"}), getpidMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Getpid"}), recordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Record"}), routedRecordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "RoutedRecord"})}
+			return destination_client_stub{stub: stub, getAllMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "GetAll", Remote: true}), getpidMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Getpid", Remote: true}), recordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Record", Remote: true}), routedRecordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "RoutedRecord", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return destination_server_stub{impl: impl.(Destination), addLoad: addLoad}
@@ -33,13 +32,15 @@ func init() {
 		RefData: "",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server",
-		Iface:       reflect.TypeOf((*Server)(nil)).Elem(),
-		Impl:        reflect.TypeOf(server{}),
-		Listeners:   []string{"hello"},
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return server_local_stub{impl: impl.(Server), tracer: tracer} },
+		Name:      "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server",
+		Iface:     reflect.TypeOf((*Server)(nil)).Elem(),
+		Impl:      reflect.TypeOf(server{}),
+		Listeners: []string{"hello"},
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return server_local_stub{impl: impl.(Server), tracer: tracer, addressMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server", Method: "Address", Remote: false}), proxyAddressMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server", Method: "ProxyAddress", Remote: false}), shutdownMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server", Method: "Shutdown", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return server_client_stub{stub: stub, addressMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server", Method: "Address"}), proxyAddressMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server", Method: "ProxyAddress"}), shutdownMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server", Method: "Shutdown"})}
+			return server_client_stub{stub: stub, addressMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server", Method: "Address", Remote: true}), proxyAddressMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server", Method: "ProxyAddress", Remote: true}), shutdownMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server", Method: "Shutdown", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return server_server_stub{impl: impl.(Server), addLoad: addLoad}
@@ -47,12 +48,14 @@ func init() {
 		RefData: "⟦1e2dce71:wEaVeRlIsTeNeRs:github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server→hello⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:        "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Source",
-		Iface:       reflect.TypeOf((*Source)(nil)).Elem(),
-		Impl:        reflect.TypeOf(source{}),
-		LocalStubFn: func(impl any, tracer trace.Tracer) any { return source_local_stub{impl: impl.(Source), tracer: tracer} },
+		Name:  "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Source",
+		Iface: reflect.TypeOf((*Source)(nil)).Elem(),
+		Impl:  reflect.TypeOf(source{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return source_local_stub{impl: impl.(Source), tracer: tracer, emitMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Source", Method: "Emit", Remote: false})}
+		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return source_client_stub{stub: stub, emitMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Source", Method: "Emit"})}
+			return source_client_stub{stub: stub, emitMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Source", Method: "Emit", Remote: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return source_server_stub{impl: impl.(Source), addLoad: addLoad}
@@ -91,14 +94,21 @@ var _ = (&__destination_destRouter_if_youre_seeing_this_you_probably_forgot_to_r
 // Local stub implementations.
 
 type destination_local_stub struct {
-	impl   Destination
-	tracer trace.Tracer
+	impl                Destination
+	tracer              trace.Tracer
+	getAllMetrics       *codegen.MethodMetrics
+	getpidMetrics       *codegen.MethodMetrics
+	recordMetrics       *codegen.MethodMetrics
+	routedRecordMetrics *codegen.MethodMetrics
 }
 
 // Check that destination_local_stub implements the Destination interface.
 var _ Destination = (*destination_local_stub)(nil)
 
 func (s destination_local_stub) GetAll(ctx context.Context, a0 string) (r0 []string, err error) {
+	// Update metrics.
+	begin := s.getAllMetrics.Begin()
+	defer func() { s.getAllMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -116,6 +126,9 @@ func (s destination_local_stub) GetAll(ctx context.Context, a0 string) (r0 []str
 }
 
 func (s destination_local_stub) Getpid(ctx context.Context) (r0 int, err error) {
+	// Update metrics.
+	begin := s.getpidMetrics.Begin()
+	defer func() { s.getpidMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -133,6 +146,9 @@ func (s destination_local_stub) Getpid(ctx context.Context) (r0 int, err error) 
 }
 
 func (s destination_local_stub) Record(ctx context.Context, a0 string, a1 string) (err error) {
+	// Update metrics.
+	begin := s.recordMetrics.Begin()
+	defer func() { s.recordMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -150,6 +166,9 @@ func (s destination_local_stub) Record(ctx context.Context, a0 string, a1 string
 }
 
 func (s destination_local_stub) RoutedRecord(ctx context.Context, a0 string, a1 string) (err error) {
+	// Update metrics.
+	begin := s.routedRecordMetrics.Begin()
+	defer func() { s.routedRecordMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -167,14 +186,20 @@ func (s destination_local_stub) RoutedRecord(ctx context.Context, a0 string, a1 
 }
 
 type server_local_stub struct {
-	impl   Server
-	tracer trace.Tracer
+	impl                Server
+	tracer              trace.Tracer
+	addressMetrics      *codegen.MethodMetrics
+	proxyAddressMetrics *codegen.MethodMetrics
+	shutdownMetrics     *codegen.MethodMetrics
 }
 
 // Check that server_local_stub implements the Server interface.
 var _ Server = (*server_local_stub)(nil)
 
 func (s server_local_stub) Address(ctx context.Context) (r0 string, err error) {
+	// Update metrics.
+	begin := s.addressMetrics.Begin()
+	defer func() { s.addressMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -192,6 +217,9 @@ func (s server_local_stub) Address(ctx context.Context) (r0 string, err error) {
 }
 
 func (s server_local_stub) ProxyAddress(ctx context.Context) (r0 string, err error) {
+	// Update metrics.
+	begin := s.proxyAddressMetrics.Begin()
+	defer func() { s.proxyAddressMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -209,6 +237,9 @@ func (s server_local_stub) ProxyAddress(ctx context.Context) (r0 string, err err
 }
 
 func (s server_local_stub) Shutdown(ctx context.Context) (err error) {
+	// Update metrics.
+	begin := s.shutdownMetrics.Begin()
+	defer func() { s.shutdownMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -226,14 +257,18 @@ func (s server_local_stub) Shutdown(ctx context.Context) (err error) {
 }
 
 type source_local_stub struct {
-	impl   Source
-	tracer trace.Tracer
+	impl        Source
+	tracer      trace.Tracer
+	emitMetrics *codegen.MethodMetrics
 }
 
 // Check that source_local_stub implements the Source interface.
 var _ Source = (*source_local_stub)(nil)
 
 func (s source_local_stub) Emit(ctx context.Context, a0 string, a1 string) (err error) {
+	// Update metrics.
+	begin := s.emitMetrics.Begin()
+	defer func() { s.emitMetrics.End(begin, err != nil, 0, 0) }()
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		// Create a child span for this method.
@@ -265,8 +300,9 @@ var _ Destination = (*destination_client_stub)(nil)
 
 func (s destination_client_stub) GetAll(ctx context.Context, a0 string) (r0 []string, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.getAllMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.getAllMetrics.Begin()
+	defer func() { s.getAllMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -286,11 +322,9 @@ func (s destination_client_stub) GetAll(ctx context.Context, a0 string) (r0 []st
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.getAllMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.getAllMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -304,14 +338,14 @@ func (s destination_client_stub) GetAll(ctx context.Context, a0 string) (r0 []st
 	var shardKey uint64
 
 	// Call the remote method.
-	s.getAllMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.getAllMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -322,8 +356,9 @@ func (s destination_client_stub) GetAll(ctx context.Context, a0 string) (r0 []st
 
 func (s destination_client_stub) Getpid(ctx context.Context) (r0 int, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.getpidMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.getpidMetrics.Begin()
+	defer func() { s.getpidMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -343,24 +378,21 @@ func (s destination_client_stub) Getpid(ctx context.Context) (r0 int, err error)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.getpidMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.getpidMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	var shardKey uint64
 
 	// Call the remote method.
-	s.getpidMetrics.BytesRequest.Put(0)
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, nil, shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.getpidMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -371,8 +403,9 @@ func (s destination_client_stub) Getpid(ctx context.Context) (r0 int, err error)
 
 func (s destination_client_stub) Record(ctx context.Context, a0 string, a1 string) (err error) {
 	// Update metrics.
-	start := time.Now()
-	s.recordMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.recordMetrics.Begin()
+	defer func() { s.recordMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -392,11 +425,9 @@ func (s destination_client_stub) Record(ctx context.Context, a0 string, a1 strin
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.recordMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.recordMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -412,14 +443,14 @@ func (s destination_client_stub) Record(ctx context.Context, a0 string, a1 strin
 	var shardKey uint64
 
 	// Call the remote method.
-	s.recordMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 2, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.recordMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -429,8 +460,9 @@ func (s destination_client_stub) Record(ctx context.Context, a0 string, a1 strin
 
 func (s destination_client_stub) RoutedRecord(ctx context.Context, a0 string, a1 string) (err error) {
 	// Update metrics.
-	start := time.Now()
-	s.routedRecordMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.routedRecordMetrics.Begin()
+	defer func() { s.routedRecordMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -450,11 +482,9 @@ func (s destination_client_stub) RoutedRecord(ctx context.Context, a0 string, a1
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.routedRecordMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.routedRecordMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -473,14 +503,14 @@ func (s destination_client_stub) RoutedRecord(ctx context.Context, a0 string, a1
 	shardKey := _hashDestination(r.RoutedRecord(ctx, a0, a1))
 
 	// Call the remote method.
-	s.routedRecordMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 3, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.routedRecordMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -500,8 +530,9 @@ var _ Server = (*server_client_stub)(nil)
 
 func (s server_client_stub) Address(ctx context.Context) (r0 string, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.addressMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.addressMetrics.Begin()
+	defer func() { s.addressMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -521,24 +552,21 @@ func (s server_client_stub) Address(ctx context.Context) (r0 string, err error) 
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.addressMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.addressMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	var shardKey uint64
 
 	// Call the remote method.
-	s.addressMetrics.BytesRequest.Put(0)
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, nil, shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.addressMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -549,8 +577,9 @@ func (s server_client_stub) Address(ctx context.Context) (r0 string, err error) 
 
 func (s server_client_stub) ProxyAddress(ctx context.Context) (r0 string, err error) {
 	// Update metrics.
-	start := time.Now()
-	s.proxyAddressMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.proxyAddressMetrics.Begin()
+	defer func() { s.proxyAddressMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -570,24 +599,21 @@ func (s server_client_stub) ProxyAddress(ctx context.Context) (r0 string, err er
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.proxyAddressMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.proxyAddressMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	var shardKey uint64
 
 	// Call the remote method.
-	s.proxyAddressMetrics.BytesRequest.Put(0)
 	var results []byte
 	results, err = s.stub.Run(ctx, 1, nil, shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.proxyAddressMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -598,8 +624,9 @@ func (s server_client_stub) ProxyAddress(ctx context.Context) (r0 string, err er
 
 func (s server_client_stub) Shutdown(ctx context.Context) (err error) {
 	// Update metrics.
-	start := time.Now()
-	s.shutdownMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.shutdownMetrics.Begin()
+	defer func() { s.shutdownMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -619,24 +646,21 @@ func (s server_client_stub) Shutdown(ctx context.Context) (err error) {
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.shutdownMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.shutdownMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	var shardKey uint64
 
 	// Call the remote method.
-	s.shutdownMetrics.BytesRequest.Put(0)
 	var results []byte
 	results, err = s.stub.Run(ctx, 2, nil, shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.shutdownMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)
@@ -654,8 +678,9 @@ var _ Source = (*source_client_stub)(nil)
 
 func (s source_client_stub) Emit(ctx context.Context, a0 string, a1 string) (err error) {
 	// Update metrics.
-	start := time.Now()
-	s.emitMetrics.Count.Add(1)
+	var requestBytes, replyBytes int
+	begin := s.emitMetrics.Begin()
+	defer func() { s.emitMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
 
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
@@ -675,11 +700,9 @@ func (s source_client_stub) Emit(ctx context.Context, a0 string, a1 string) (err
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			s.emitMetrics.ErrorCount.Add(1)
 		}
 		span.End()
 
-		s.emitMetrics.Latency.Put(float64(time.Since(start).Microseconds()))
 	}()
 
 	// Preallocate a buffer of the right size.
@@ -695,14 +718,14 @@ func (s source_client_stub) Emit(ctx context.Context, a0 string, a1 string) (err
 	var shardKey uint64
 
 	// Call the remote method.
-	s.emitMetrics.BytesRequest.Put(float64(len(enc.Data())))
+	requestBytes = len(enc.Data())
 	var results []byte
 	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
 		return
 	}
-	s.emitMetrics.BytesReply.Put(float64(len(results)))
 
 	// Decode the results.
 	dec := codegen.NewDecoder(results)

--- a/website/docs.md
+++ b/website/docs.md
@@ -1037,24 +1037,21 @@ type labels struct {
 
 ## Auto-Generated Metrics
 
-Service Weaver automatically creates and maintains the following set of metrics, which
-measure the count, latency, and chattiness of every remote component method
+Service Weaver automatically creates and maintains the following set of metrics,
+which measure the count, latency, and chattiness of every component method
 invocation. Every metric is labeled by the calling component as well as the
-invoked component and method.
+invoked component and method, and whether or not the call was local or remote.
 
--   `serviceweaver_remote_method_count`: Count of Service Weaver component
+-   `serviceweaver_method_count`: Count of Service Weaver component
     method invocations.
--   `serviceweaver_remote_method_error_count`: Count of Service Weaver component
+-   `serviceweaver_method_error_count`: Count of Service Weaver component
     method invocations that result in an error.
--   `serviceweaver_remote_method_latency_micros`: Duration, in microseconds, of
+-   `serviceweaver_method_latency_micros`: Duration, in microseconds, of
     Service Weaver component method execution.
--   `serviceweaver_remote_method_bytes_request`: Number of bytes in Service
-    Weaver component method requests.
--   `serviceweaver_remote_method_bytes_reply`: Number of bytes in Service Weaver
-    component method replies.
-
-**Note**: These metrics only measure *remote* method calls. Local method calls,
-like those between two co-located components, are not measured.
+-   `serviceweaver_method_bytes_request`: Number of bytes in Service
+    Weaver remote component method requests.
+-   `serviceweaver_method_bytes_reply`: Number of bytes in Service Weaver
+    remote component method replies.
 
 ## HTTP Metrics
 


### PR DESCRIPTION
We had previously restricted metric collection to just remote calls for performance reasons. We now collect metrics for local calls as well since it was problematic to hide things like call counts for local calls.

This has a performance impact: on a typical machine, a local call slows down by ~100ns. By comparison, a local call slows down by 1000ns when tracing is enabled for that call.  Future changes will attempt to speed up metric collection (we hope we can drop the penalty by 10x).

Changes the method metric names from "serviceweaver_remote_*" to "serviceweaver_*".

Include whether or not a call is remote in the metric label.

Updated the codegen metric collection API. Mainly, the responsibility for updating metrics is now in the codegen package as opposed to scattered throughout generated code.

Not updating the codegen version number since we have alread updated it since the last tagged release.