### PR TITLE
Expanded codegen version mismatch error.

### DIFF
--- a/examples/chat/weaver_gen.go
+++ b/examples/chat/weaver_gen.go
@@ -14,7 +14,26 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/collatz/weaver_gen.go
+++ b/examples/collatz/weaver_gen.go
@@ -12,7 +12,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/factors/weaver_gen.go
+++ b/examples/factors/weaver_gen.go
@@ -12,7 +12,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/fakes/weaver_gen.go
+++ b/examples/fakes/weaver_gen.go
@@ -12,7 +12,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/hello/weaver_gen.go
+++ b/examples/hello/weaver_gen.go
@@ -12,7 +12,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/helloworld/weaver_gen.go
+++ b/examples/helloworld/weaver_gen.go
@@ -10,7 +10,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/adservice/weaver_gen.go
+++ b/examples/onlineboutique/adservice/weaver_gen.go
@@ -13,7 +13,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/cartservice/weaver_gen.go
+++ b/examples/onlineboutique/cartservice/weaver_gen.go
@@ -13,7 +13,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/checkoutservice/weaver_gen.go
+++ b/examples/onlineboutique/checkoutservice/weaver_gen.go
@@ -16,7 +16,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/currencyservice/weaver_gen.go
+++ b/examples/onlineboutique/currencyservice/weaver_gen.go
@@ -13,7 +13,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/emailservice/weaver_gen.go
+++ b/examples/onlineboutique/emailservice/weaver_gen.go
@@ -13,7 +13,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/frontend/weaver_gen.go
+++ b/examples/onlineboutique/frontend/weaver_gen.go
@@ -10,7 +10,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/paymentservice/weaver_gen.go
+++ b/examples/onlineboutique/paymentservice/weaver_gen.go
@@ -15,7 +15,26 @@ import (
 	"reflect"
 	"time"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/productcatalogservice/weaver_gen.go
+++ b/examples/onlineboutique/productcatalogservice/weaver_gen.go
@@ -14,7 +14,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/recommendationservice/weaver_gen.go
+++ b/examples/onlineboutique/recommendationservice/weaver_gen.go
@@ -12,7 +12,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/shippingservice/weaver_gen.go
+++ b/examples/onlineboutique/shippingservice/weaver_gen.go
@@ -15,7 +15,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/examples/onlineboutique/types/money/weaver_gen.go
+++ b/examples/onlineboutique/types/money/weaver_gen.go
@@ -8,7 +8,26 @@ import (
 	"github.com/ServiceWeaver/weaver"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 // weaver.Instance checks.
 

--- a/examples/onlineboutique/types/weaver_gen.go
+++ b/examples/onlineboutique/types/weaver_gen.go
@@ -11,7 +11,26 @@ import (
 	"github.com/ServiceWeaver/weaver/examples/onlineboutique/types/money"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 // weaver.Instance checks.
 

--- a/examples/reverser/weaver_gen.go
+++ b/examples/reverser/weaver_gen.go
@@ -12,7 +12,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/internal/benchmarks/weaver_gen.go
+++ b/internal/benchmarks/weaver_gen.go
@@ -13,7 +13,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/internal/tool/generate/example/weaver_gen.go
+++ b/internal/tool/generate/example/weaver_gen.go
@@ -13,7 +13,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/internal/tool/generate/generator.go
+++ b/internal/tool/generate/generator.go
@@ -927,10 +927,30 @@ func (g *generator) generateVersionCheck(p printFn) {
 	// Example output when 'weaver generate' has codegen API version 0.1.0:
 	//
 	//     var _ codegen.LatestVersion = codegen.Version[[0][1]struct{}]("You used ...")
-	p(`var _ %s = %s[[%d][%d]struct{}](%q)`,
+	p(``)
+	p(`var _ %s = %s[[%d][%d]struct{}](%s)`,
 		g.codegen().qualify("LatestVersion"), g.codegen().qualify("Version"),
 		version.CodegenMajor, version.CodegenMinor,
-		fmt.Sprintf(`You used 'weaver generate' codegen version %d.%d.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.`, version.CodegenMajor, version.CodegenMinor),
+
+		fmt.Sprintf("`"+`
+
+ERROR: You generated this file with 'weaver generate' %s (codegen
+version %s). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`+"`", version.ModuleVersion, version.CodegenVersion),
 	)
 }
 

--- a/internal/tool/generate/generator_test.go
+++ b/internal/tool/generate/generator_test.go
@@ -459,7 +459,7 @@ func TestExampleVersion(t *testing.T) {
 	got := fmt.Sprintf("%x", h.Sum(nil))
 
 	// If weaver_gen.go has changed, the codegen version may need updating.
-	const want = "986a14a9d781135207eafe3ed41448db62ba0c8e25c8a2bef28706bc83c41fe8"
+	const want = "68b9c72fc095f4f9df483ee5c96fcafbfd76e4829e5229fef3bd337dbde06fd9"
 	if got != want {
 		t.Fatalf(`Unexpected SHA-256 hash of examples/weaver_gen.go: got %s, want %s. If this change is meaningful, REMEMBER TO UPDATE THE CODEGEN VERSION in runtime/version/version.go.`, got, want)
 	}

--- a/runtime/bin/testprogram/weaver_gen.go
+++ b/runtime/bin/testprogram/weaver_gen.go
@@ -10,7 +10,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/internal/chain/weaver_gen.go
+++ b/weavertest/internal/chain/weaver_gen.go
@@ -12,7 +12,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/internal/deploy/weaver_gen.go
+++ b/weavertest/internal/deploy/weaver_gen.go
@@ -12,7 +12,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/internal/diverge/weaver_gen.go
+++ b/weavertest/internal/diverge/weaver_gen.go
@@ -13,7 +13,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/internal/generate/weaver_gen.go
+++ b/weavertest/internal/generate/weaver_gen.go
@@ -12,7 +12,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/internal/protos/weaver_gen.go
+++ b/weavertest/internal/protos/weaver_gen.go
@@ -12,7 +12,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{

--- a/weavertest/internal/simple/weaver_gen.go
+++ b/weavertest/internal/simple/weaver_gen.go
@@ -12,7 +12,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"reflect"
 )
-var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}]("You used 'weaver generate' codegen version 0.17.0, but you built your code with an incompatible weaver module version. Try upgrading 'weaver generate' and re-running it.")
+
+var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
+
+ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
+version v0.17.0). The generated code is incompatible with the version of the
+github.com/ServiceWeaver/weaver module that you're using. The weaver module
+version can be found in your go.mod file or by running the following command.
+
+    go list -m github.com/ServiceWeaver/weaver
+
+We recommend updating the weaver module and the 'weaver generate' command by
+running the following.
+
+    go get github.com/ServiceWeaver/weaver@latest
+    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+Then, re-run 'weaver generate' and re-build your code. If the problem persists,
+please file an issue at https://github.com/ServiceWeaver/weaver/issues.
+
+`)
 
 func init() {
 	codegen.Register(codegen.Registration{


### PR DESCRIPTION
Recall that `weaver generate` embeds its codegen API version in the `weaver_gen.go` files it generates. If these files are compiled with a different codegen API version, the code fails to build, and a helpful error message is shown to the user. Before this PR, the error message looked like this:

```
You used 'weaver generate' codegen version 0.17.0, but you built your
code with an incompatible weaver module version. Try upgrading 'weaver
generate' and re-running it.
```

Now, it looks like this:

```
ERROR: You generated this file with 'weaver generate' v0.17.0 (codegen
version v0.17.0). The generated code is incompatible with the version of the
github.com/ServiceWeaver/weaver module that you're using. The weaver module
version can be found in your go.mod file or by running the following command.

    go list -m github.com/ServiceWeaver/weaver

We recommend updating the weaver module and the 'weaver generate' command by
running the following.

    go get github.com/ServiceWeaver/weaver@latest
    go install github.com/ServiceWeaver/weaver/cmd/weaver@latest

Then, re-run 'weaver generate' and re-build your code. If the problem persists,
please file an issue at https://github.com/ServiceWeaver/weaver/issues.
```

The old error message allowed people to ask us for help, and we could tell them how to fix it. The new error message should hopefully allow people to understand and fix the bug on their own.