### PR TITLE
Introduce a size limit to the Perfetto database.

### DIFF
--- a/internal/status/dashboard.go
+++ b/internal/status/dashboard.go
@@ -133,7 +133,7 @@ Flags:
 			}
 			url := "http://" + lis.Addr().String()
 
-			traceDB, err := perfetto.Open(ctx, spec.PerfettoFile)
+			traceDB, err := perfetto.Open(ctx, spec.PerfettoFile, perfetto.DBOptions{})
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "cannot open Perfetto database: %v\n", err)
 			} else {

--- a/internal/tool/multi/deployer.go
+++ b/internal/tool/multi/deployer.go
@@ -133,7 +133,11 @@ func newDeployer(ctx context.Context, deploymentId string, config *MultiConfig) 
 	}
 
 	// Create the trace saver.
-	traceDB, err := perfetto.Open(ctx, perfettoFile)
+	traceDB, err := perfetto.Open(ctx, perfettoFile, perfetto.DBOptions{
+		// 100MB limit, which allows for storage of upto 200k traces at 500
+		// bytes each.
+		MaxTraceBytes: 100 * 1024 * 1024,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot open Perfetto database: %w", err)
 	}

--- a/internal/tool/ssh/impl/manager.go
+++ b/internal/tool/ssh/impl/manager.go
@@ -170,7 +170,11 @@ func RunManager(ctx context.Context, config *SshConfig, locations map[string]str
 	})
 
 	// Create the trace saver.
-	traceDB, err := perfetto.Open(ctx, PerfettoFile)
+	traceDB, err := perfetto.Open(ctx, PerfettoFile, perfetto.DBOptions{
+		// 100MB limit, which allows for storage of upto 200k traces at 500
+		// bytes each.
+		MaxTraceBytes: 100 * 1024 * 1024,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot open Perfetto database: %w", err)
 	}

--- a/singleprocess.go
+++ b/singleprocess.go
@@ -127,7 +127,11 @@ func newSingleprocessEnv(bootstrap runtime.Bootstrap) (*singleprocessEnv, error)
 		return nil, err
 	}
 
-	traceDB, err := perfetto.Open(ctx, single.PerfettoFile)
+	traceDB, err := perfetto.Open(ctx, single.PerfettoFile, perfetto.DBOptions{
+		// 100MB limit, which allows for storage of upto 200k traces at 500
+		// bytes each.
+		MaxTraceBytes: 100 * 1024 * 1024,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot open Perfetto database: %w", err)
 	}


### PR DESCRIPTION
If the trace data exceeds this limit, we garbage-collect the oldest
trace entry.
    
DB size is computed using the database file size (thanks sanjay@),
in order to be able to compute the size efficiently.
    
When the DB limit is reached, the trace store operation takes 2x time
(but not more than that).
    
    ```
    cpu: Intel(R) Xeon(R) Gold 6154 CPU @ 3.00GHz
    BenchmarkStore
    BenchmarkStore/nolimit_small
    BenchmarkStore/nolimit_small-72                      100          10830029 ns/op
    BenchmarkStore/limit_small
    BenchmarkStore/limit_small-72                         54          21509631 ns/op
    BenchmarkStore/nolimit_medium
    BenchmarkStore/nolimit_medium-72                     100          10694646 ns/op
    BenchmarkStore/limit_medium
    BenchmarkStore/limit_medium-72                        54          22720641 ns/op
    BenchmarkStore/nolimit_big
    BenchmarkStore/nolimit_big-72                        100          11460602 ns/op
    BenchmarkStore/limit_big
    BenchmarkStore/limit_big-72                           54          21542238 ns/op
    ```
    
NOTE:
We tried the trigger-based mechanism (thanks mwhittaker@ !) but the complex
SQL logic expressed in the trigger was way too expensive to perform on
every insertion.