### PR TITLE
Speed-up metric maintenance for component method calls.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -835,7 +835,6 @@ github.com/ServiceWeaver/weaver/runtime/logging
     time
 github.com/ServiceWeaver/weaver/runtime/metrics
     encoding/binary
-    expvar
     fmt
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/google/uuid

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -39,6 +39,11 @@ func (c *Counter) Name() string {
 	return c.impl.Name()
 }
 
+// Inc increases the counter by one.
+func (c *Counter) Inc() {
+	c.impl.Inc()
+}
+
 // Add increases the counter by delta. It panics if the delta is negative.
 func (c *Counter) Add(delta float64) {
 	c.impl.Add(delta)

--- a/runtime/codegen/metrics.go
+++ b/runtime/codegen/metrics.go
@@ -93,9 +93,9 @@ func (m *MethodMetrics) Begin() MethodCallHandle {
 // End ends metric update recording for a call to method m.
 func (m *MethodMetrics) End(h MethodCallHandle, failed bool, requestBytes, replyBytes int) {
 	latency := time.Now().UnixMicro() - h.start
-	m.Count.Add(1)
+	m.Count.Inc()
 	if failed {
-		m.ErrorCount.Add(1)
+		m.ErrorCount.Inc()
 	}
 	m.Latency.Put(float64(latency))
 	if m.remote {

--- a/runtime/metrics/atomic.go
+++ b/runtime/metrics/atomic.go
@@ -1,0 +1,44 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"math"
+	"sync/atomic"
+)
+
+// atomicFloat64 provides atomic storage for float64.
+type atomicFloat64 struct {
+	v atomic.Uint64 // stores result of math.Float64bits
+}
+
+// get returns the current value stored in f.
+func (f *atomicFloat64) get() float64 { return math.Float64frombits(f.v.Load()) }
+
+// set stores v in f.
+func (f *atomicFloat64) set(v float64) { f.v.Store(math.Float64bits(v)) }
+
+// add atomically adds v to f.
+func (f *atomicFloat64) add(v float64) {
+	// Use compare-and-swap to change the stored representation
+	// atomically from old value to old value + v.
+	for {
+		cur := f.v.Load()
+		next := math.Float64bits(math.Float64frombits(cur) + v)
+		if f.v.CompareAndSwap(cur, next) {
+			return
+		}
+	}
+}

--- a/runtime/metrics/atomic_test.go
+++ b/runtime/metrics/atomic_test.go
@@ -1,0 +1,75 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"math"
+	"sync"
+	"testing"
+)
+
+var testFloats = []float64{math.Inf(-1), -2, -1, 0.5, -0, 0, 0.5, 1, 2, math.Inf(1)}
+
+func TestAtomicFloat64GetSet(t *testing.T) {
+	var f atomicFloat64
+	for _, v := range testFloats {
+		f.set(v)
+		if got := f.get(); got != v {
+			t.Errorf("get(set(%v)) = %v", v, got)
+		}
+	}
+}
+
+func TestAtomicFloat64Add(t *testing.T) {
+	for _, a := range testFloats {
+		for _, b := range testFloats {
+			var v atomicFloat64
+			v.add(a)
+			v.add(b)
+			want := a + b
+			got := v.get()
+
+			same := (math.IsNaN(want) && math.IsNaN(got)) || (want == got)
+			if !same {
+				t.Errorf("Add(%v) to %v produced %v, expecting %v", b, a, got, want)
+			}
+		}
+	}
+}
+
+func TestAtomicFloat64Parallelism(t *testing.T) {
+	var f atomicFloat64
+
+	// Add to f from multiple goroutines in parallel.
+	const iters = 1000000
+	const parallelism = 8
+	var wg sync.WaitGroup
+	wg.Add(parallelism)
+	for i := 0; i < parallelism; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				f.add(1.0)
+			}
+		}()
+	}
+	wg.Wait()
+
+	want := float64(iters * parallelism)
+	got := f.get()
+	if got != want {
+		t.Errorf("concurrent adds produced %v, expecting %v", got, want)
+	}
+}

--- a/runtime/metrics/io.go
+++ b/runtime/metrics/io.go
@@ -17,8 +17,8 @@ package metrics
 import (
 	"fmt"
 
-	"golang.org/x/exp/maps"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
+	"golang.org/x/exp/maps"
 )
 
 // An Exporter produces MetricUpdates summarizing the change in metrics over
@@ -42,13 +42,13 @@ func (e *Exporter) Export() *protos.MetricUpdate {
 		metric.Init()
 		latest, ok := e.versions[metric.id]
 		if !ok {
-			e.versions[metric.id] = metric.Version()
+			e.versions[metric.id] = metric.version.Load()
 			update.Defs = append(update.Defs, metric.MetricDef())
 			update.Values = append(update.Values, metric.MetricValue())
 			continue
 		}
 
-		version := metric.Version()
+		version := metric.version.Load()
 		if version == latest {
 			continue
 		}

--- a/runtime/metrics/metrics_test.go
+++ b/runtime/metrics/metrics_test.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/ServiceWeaver/weaver/runtime/protos"
 )
 
 const (
@@ -287,7 +287,7 @@ func BenchmarkCounter(b *testing.B) {
 	c := Register(counterType, "BenchmarkCounter/count", "", nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.Add(1)
+		c.Inc()
 	}
 }
 
@@ -323,7 +323,7 @@ func BenchmarkCounterMap1(b *testing.B) {
 	c := l.Get(labels1{"xxxxxxxxxx"})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.Add(1)
+		c.Inc()
 	}
 }
 
@@ -333,7 +333,7 @@ func BenchmarkCounterMap2(b *testing.B) {
 	c := l.Get(labels2{"xxxxxxxxxx", "xxxxxxxxxx"})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.Add(1)
+		c.Inc()
 	}
 }
 
@@ -346,7 +346,7 @@ func BenchmarkCounterMap5(b *testing.B) {
 	})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.Add(1)
+		c.Inc()
 	}
 }
 
@@ -361,7 +361,7 @@ func BenchmarkCounterMap10(b *testing.B) {
 	})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.Add(1)
+		c.Inc()
 	}
 }
 
@@ -389,7 +389,7 @@ func BenchmarkCounterMap50(b *testing.B) {
 	})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.Add(1)
+		c.Inc()
 	}
 }
 
@@ -399,7 +399,7 @@ func BenchmarkCounterGet1(b *testing.B) {
 	labels := labels1{"xxxxxxxxxx"}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		l.Get(labels).Add(1)
+		l.Get(labels).Inc()
 	}
 }
 
@@ -409,7 +409,7 @@ func BenchmarkCounterGet2(b *testing.B) {
 	labels := labels2{"xxxxxxxxxx", "xxxxxxxxxx"}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		l.Get(labels).Add(1)
+		l.Get(labels).Inc()
 	}
 }
 
@@ -422,7 +422,7 @@ func BenchmarkCounterGet5(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		l.Get(labels).Add(1)
+		l.Get(labels).Inc()
 	}
 }
 
@@ -437,7 +437,7 @@ func BenchmarkCounterGet10(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		l.Get(labels).Add(1)
+		l.Get(labels).Inc()
 	}
 }
 
@@ -465,7 +465,7 @@ func BenchmarkCounterGet50(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		l.Get(labels).Add(1)
+		l.Get(labels).Inc()
 	}
 }
 


### PR DESCRIPTION
```
name           old time/op  new time/op  delta
Call/Local-12   119ns ± 2%    96ns ± 1%  -19.32%  (p=0.008 n=5+5)
```

Removed the use of expvar in Metrics implementation. We are mostly doing this so that we can drop the promise that Service Weaver metrics are reflected in expvars. That frees us to speed things up by using a better representation.

Introduced an atomicFloat64 value so we can atomically add a float64. (This functionality was previously provided by expvar.)

Atomic storage for all metrics (though used just for counters) is now split into a float64 and a uint64. Integer increments are applied to the uint64 so we can avoid a more expensive compare-and-swap. The stored values are added together on a read. Doubles counter metric increment speed (from ~9.2ns to ~4.1ns).

Add a fast-path for histogram updates for small values by avoiding binary search.

Add a fast-path for histogram updates of zero by avoiding an atomic add.