### PR TITLE
Fixed bug in metric version management.

### DIFF
--- a/runtime/codegen/metrics.go
+++ b/runtime/codegen/metrics.go
@@ -82,17 +82,17 @@ func MethodMetricsFor(labels MethodLabels) *MethodMetrics {
 // MethodCallHandle holds information needed to finalize metric
 // updates for a method call.
 type MethodCallHandle struct {
-	start int64 // Microsecond timestamp
+	start time.Time
 }
 
 // Begin starts metric update recording for a call to method m.
 func (m *MethodMetrics) Begin() MethodCallHandle {
-	return MethodCallHandle{time.Now().UnixMicro()}
+	return MethodCallHandle{time.Now()}
 }
 
 // End ends metric update recording for a call to method m.
 func (m *MethodMetrics) End(h MethodCallHandle, failed bool, requestBytes, replyBytes int) {
-	latency := time.Now().UnixMicro() - h.start
+	latency := time.Since(h.start).Microseconds()
 	m.Count.Inc()
 	if failed {
 		m.ErrorCount.Inc()


### PR DESCRIPTION
Previous change forgot to update Metric.version on an Inc() call. Fixed by removing Metric.version and using the actual metric value to decide whether or not to export the metric.

Histograms gain a special putCount field that is used to determine whether or not to export since the histogram state does not fit into a single floating point value.

Further speed-up of local call metric maintenance: we now convert to microseconds once after finding the elapsed duration, instead of twice (once on the starting time, and once on the ending time).  This speeds up a local call from ~96ns to ~85ns.

Added test that Inc() call is reflected in subsequent export.