### PR TITLE
Rename Metric.Init to Metric.initIdAndLabel.

### DIFF
--- a/runtime/metrics/io.go
+++ b/runtime/metrics/io.go
@@ -42,7 +42,7 @@ func (e *Exporter) Export() *protos.MetricUpdate {
 
 	update := &protos.MetricUpdate{}
 	for _, metric := range metrics {
-		metric.Init()
+		metric.initIdAndLabels()
 
 		// Send metric definition first time we are exporting metric.
 		last, ok := e.last[metric.id]


### PR DESCRIPTION
Clarify via a comment and a more appropriate method name as to why we defer initialization of metric id and labels.