### PR TITLE
runtime/envelope: report the error from weavelet

### DIFF
--- a/runtime/envelope/envelope_test.go
+++ b/runtime/envelope/envelope_test.go
@@ -192,6 +192,18 @@ func (*handlerForTest) VerifyServerCertificate(context.Context, *protos.VerifySe
 	panic("unused")
 }
 
+func TestWeaveletExit(t *testing.T) {
+	ctx := context.Background()
+	wlet, config := wlet("/usr/bin/env", "bash", "-c", `echo "foo error" >&2 && exit 1`)
+	_, err := NewEnvelope(ctx, wlet, config)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "foo error") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestStartStop(t *testing.T) {
 	filename := filepath.Join(t.TempDir(), "file.txt")
 	if _, err := os.Create(filename); err != nil {


### PR DESCRIPTION
Before this change, the error from `NewEnvelope` look like bellow, which isn't helpful to debug why the progress crash.

```
read protobuf length: EOF
```
or
```
write protobuf length: write |1: broken pipe
```

I ran into real case that caused by invalid `GLIBC`, and the process already print the error like below but I can't see it in output of container.
```
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /weaver/collatz)
```