### PR TITLE
Make method metrics objects private.

### DIFF
--- a/internal/metrics/stats.go
+++ b/internal/metrics/stats.go
@@ -176,13 +176,13 @@ func (s *StatsProcessor) getSnapshot(snapshot []*metrics.MetricSnapshot) {
 		// Aggregate stats within a bucket, based on metric values from different
 		// replicas for the method.
 		switch m.Name {
-		case codegen.MethodCounts.Name():
+		case codegen.MethodCountsName:
 			bucket.calls += m.Value
-		case codegen.MethodBytesReply.Name():
+		case codegen.MethodBytesReplyName:
 			bucket.kbSent += m.Value / 1024 // B to KB
-		case codegen.MethodBytesRequest.Name():
+		case codegen.MethodBytesRequestName:
 			bucket.kbRecvd += m.Value / 1024 // B to KB
-		case codegen.MethodLatencies.Name():
+		case codegen.MethodLatenciesName:
 			bucket.latencyMs += m.Value / 1000 // µs to ms
 
 			var count uint64

--- a/internal/status/dashboard.go
+++ b/internal/status/dashboard.go
@@ -259,7 +259,7 @@ func computeTraffic(status *Status, metrics []*protos.MetricSnapshot) []edge {
 	}
 	byPair := map[pair]int{}
 	for _, metric := range metrics {
-		if metric.Name != codegen.MethodCounts.Name() {
+		if metric.Name != codegen.MethodCountsName {
 			continue
 		}
 		call := pair{

--- a/runtime/codegen/metrics.go
+++ b/runtime/codegen/metrics.go
@@ -20,31 +20,37 @@ import (
 	"github.com/ServiceWeaver/weaver/metrics"
 )
 
+// Names of automatically populated metrics.
+const (
+	MethodCountsName       = "serviceweaver_method_count"
+	MethodErrorsName       = "serviceweaver_method_error_count"
+	MethodLatenciesName    = "serviceweaver_method_latency_micros"
+	MethodBytesRequestName = "serviceweaver_method_bytes_request"
+	MethodBytesReplyName   = "serviceweaver_method_bytes_reply"
+)
+
 var (
 	// The following metrics are automatically populated for the user.
-	//
-	// TODO(mwhittaker): Allow the user to disable these metrics.
-	// It adds ~169ns of latency per method call.
-	MethodCounts = metrics.NewCounterMap[MethodLabels](
-		"serviceweaver_method_count",
+	methodCounts = metrics.NewCounterMap[MethodLabels](
+		MethodCountsName,
 		"Count of Service Weaver component method invocations",
 	)
-	MethodErrors = metrics.NewCounterMap[MethodLabels](
-		"serviceweaver_method_error_count",
+	methodErrors = metrics.NewCounterMap[MethodLabels](
+		MethodErrorsName,
 		"Count of Service Weaver component method invocations that result in an error",
 	)
-	MethodLatencies = metrics.NewHistogramMap[MethodLabels](
-		"serviceweaver_method_latency_micros",
+	methodLatencies = metrics.NewHistogramMap[MethodLabels](
+		MethodLatenciesName,
 		"Duration, in microseconds, of Service Weaver component method execution",
 		metrics.NonNegativeBuckets,
 	)
-	MethodBytesRequest = metrics.NewHistogramMap[MethodLabels](
-		"serviceweaver_method_bytes_request",
+	methodBytesRequest = metrics.NewHistogramMap[MethodLabels](
+		MethodBytesRequestName,
 		"Number of bytes in Service Weaver component method requests",
 		metrics.NonNegativeBuckets,
 	)
-	MethodBytesReply = metrics.NewHistogramMap[MethodLabels](
-		"serviceweaver_method_bytes_reply",
+	methodBytesReply = metrics.NewHistogramMap[MethodLabels](
+		MethodBytesReplyName,
 		"Number of bytes in Service Weaver component method replies",
 		metrics.NonNegativeBuckets,
 	)
@@ -71,11 +77,11 @@ type MethodMetrics struct {
 func MethodMetricsFor(labels MethodLabels) *MethodMetrics {
 	return &MethodMetrics{
 		remote:       labels.Remote,
-		Count:        MethodCounts.Get(labels),
-		ErrorCount:   MethodErrors.Get(labels),
-		Latency:      MethodLatencies.Get(labels),
-		BytesRequest: MethodBytesRequest.Get(labels),
-		BytesReply:   MethodBytesReply.Get(labels),
+		Count:        methodCounts.Get(labels),
+		ErrorCount:   methodErrors.Get(labels),
+		Latency:      methodLatencies.Get(labels),
+		BytesRequest: methodBytesRequest.Get(labels),
+		BytesReply:   methodBytesReply.Get(labels),
 	}
 }
 

--- a/runtime/codegen/metrics.go
+++ b/runtime/codegen/metrics.go
@@ -66,22 +66,22 @@ type MethodLabels struct {
 // MethodMetrics contains metrics for a single Service Weaver component method.
 type MethodMetrics struct {
 	remote       bool
-	Count        *metrics.Counter   // See MethodCounts.
-	ErrorCount   *metrics.Counter   // See MethodErrors.
-	Latency      *metrics.Histogram // See MethodLatencies.
-	BytesRequest *metrics.Histogram // See MethodBytesRequest.
-	BytesReply   *metrics.Histogram // See MethodBytesReply.
+	count        *metrics.Counter   // See MethodCounts.
+	errorCount   *metrics.Counter   // See MethodErrors.
+	latency      *metrics.Histogram // See MethodLatencies.
+	bytesRequest *metrics.Histogram // See MethodBytesRequest.
+	bytesReply   *metrics.Histogram // See MethodBytesReply.
 }
 
 // MethodMetricsFor returns metrics for the specified method.
 func MethodMetricsFor(labels MethodLabels) *MethodMetrics {
 	return &MethodMetrics{
 		remote:       labels.Remote,
-		Count:        methodCounts.Get(labels),
-		ErrorCount:   methodErrors.Get(labels),
-		Latency:      methodLatencies.Get(labels),
-		BytesRequest: methodBytesRequest.Get(labels),
-		BytesReply:   methodBytesReply.Get(labels),
+		count:        methodCounts.Get(labels),
+		errorCount:   methodErrors.Get(labels),
+		latency:      methodLatencies.Get(labels),
+		bytesRequest: methodBytesRequest.Get(labels),
+		bytesReply:   methodBytesReply.Get(labels),
 	}
 }
 
@@ -99,13 +99,13 @@ func (m *MethodMetrics) Begin() MethodCallHandle {
 // End ends metric update recording for a call to method m.
 func (m *MethodMetrics) End(h MethodCallHandle, failed bool, requestBytes, replyBytes int) {
 	latency := time.Since(h.start).Microseconds()
-	m.Count.Inc()
+	m.count.Inc()
 	if failed {
-		m.ErrorCount.Inc()
+		m.errorCount.Inc()
 	}
-	m.Latency.Put(float64(latency))
+	m.latency.Put(float64(latency))
 	if m.remote {
-		m.BytesRequest.Put(float64(requestBytes))
-		m.BytesReply.Put(float64(replyBytes))
+		m.bytesRequest.Put(float64(requestBytes))
+		m.bytesReply.Put(float64(replyBytes))
 	}
 }

--- a/runtime/codegen/metrics_test.go
+++ b/runtime/codegen/metrics_test.go
@@ -25,42 +25,15 @@ func BenchmarkMetrics(b *testing.B) {
 		Component: "component",
 		Method:    "method",
 	})
-
 	b.Run("Everything", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			// NOTE(mwhittaker): We don't include metrics.Error.Add(1) because
-			// the metric is updated infrequently.
-			start := time.Now()
-			metrics.Count.Add(1)
-			metrics.Latency.Put(float64(time.Since(start).Microseconds()))
-			metrics.BytesRequest.Put(100)
-			metrics.BytesReply.Put(100)
+			metrics.End(metrics.Begin(), false, 0, 0)
 		}
 	})
-
 	b.Run("Time", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			start := time.Now()
 			time.Since(start).Microseconds()
-		}
-	})
-
-	b.Run("Counter", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			metrics.Count.Add(1)
-		}
-	})
-
-	b.Run("Latency", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			metrics.Latency.Put(100)
-		}
-	})
-
-	b.Run("Bytes", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			metrics.BytesRequest.Put(100)
-			metrics.BytesReply.Put(100)
 		}
 	})
 }


### PR DESCRIPTION
There is no reason for method metric objects to show up in the codegen API. We do export the names of these objects since status/dashboard code uses these names to extract metric values.