### PR TITLE
Removed unused weaver.Instance type.

### DIFF
--- a/examples/chat/weaver_gen.go
+++ b/examples/chat/weaver_gen.go
@@ -97,7 +97,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[ImageScaler] = (*scaler)(nil)
 var _ weaver.InstanceOf[LocalCache] = (*localCache)(nil)
 var _ weaver.InstanceOf[weaver.Main] = (*server)(nil)

--- a/examples/collatz/weaver_gen.go
+++ b/examples/collatz/weaver_gen.go
@@ -80,7 +80,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[Even] = (*even)(nil)
 var _ weaver.InstanceOf[weaver.Main] = (*server)(nil)
 var _ weaver.InstanceOf[Odd] = (*odd)(nil)

--- a/examples/factors/weaver_gen.go
+++ b/examples/factors/weaver_gen.go
@@ -66,7 +66,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[Factorer] = (*factorer)(nil)
 var _ weaver.InstanceOf[weaver.Main] = (*server)(nil)
 

--- a/examples/fakes/weaver_gen.go
+++ b/examples/fakes/weaver_gen.go
@@ -51,7 +51,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[Clock] = (*clock)(nil)
 
 // weaver.Router checks.

--- a/examples/hello/weaver_gen.go
+++ b/examples/hello/weaver_gen.go
@@ -65,7 +65,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[weaver.Main] = (*app)(nil)
 var _ weaver.InstanceOf[Reverser] = (*reverser)(nil)
 

--- a/examples/helloworld/weaver_gen.go
+++ b/examples/helloworld/weaver_gen.go
@@ -47,7 +47,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[weaver.Main] = (*app)(nil)
 
 // weaver.Router checks.

--- a/examples/onlineboutique/adservice/weaver_gen.go
+++ b/examples/onlineboutique/adservice/weaver_gen.go
@@ -52,7 +52,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.

--- a/examples/onlineboutique/cartservice/service.go
+++ b/examples/onlineboutique/cartservice/service.go
@@ -39,7 +39,7 @@ type impl struct {
 }
 
 func (s *impl) Init(context.Context) error {
-	store, err := newCartStore(s, s.cache.Get())
+	store, err := newCartStore(s.Logger(), s.cache.Get())
 	s.store = store
 	return err
 }

--- a/examples/onlineboutique/cartservice/store.go
+++ b/examples/onlineboutique/cartservice/store.go
@@ -18,20 +18,20 @@ import (
 	"context"
 	"errors"
 
-	"github.com/ServiceWeaver/weaver"
+	"golang.org/x/exp/slog"
 )
 
 type cartStore struct {
-	component weaver.Instance
-	cache     cartCache
+	logger *slog.Logger
+	cache  cartCache
 }
 
-func newCartStore(component weaver.Instance, cache cartCache) (*cartStore, error) {
-	return &cartStore{component: component, cache: cache}, nil
+func newCartStore(logger *slog.Logger, cache cartCache) (*cartStore, error) {
+	return &cartStore{logger: logger, cache: cache}, nil
 }
 
 func (c *cartStore) AddItem(ctx context.Context, userID, productID string, quantity int32) error {
-	c.component.Logger().Info("AddItem called", "userID", userID, "productID", productID, "quantity", quantity)
+	c.logger.Info("AddItem called", "userID", userID, "productID", productID, "quantity", quantity)
 	// Get the cart from the cache.
 	cart, err := c.cache.Get(ctx, userID)
 	if err != nil {
@@ -64,13 +64,13 @@ func (c *cartStore) AddItem(ctx context.Context, userID, productID string, quant
 }
 
 func (c *cartStore) EmptyCart(ctx context.Context, userID string) error {
-	c.component.Logger().Info("EmptyCart called", "userID", userID)
+	c.logger.Info("EmptyCart called", "userID", userID)
 	_, err := c.cache.Remove(ctx, userID)
 	return err
 }
 
 func (c *cartStore) GetCart(ctx context.Context, userID string) ([]CartItem, error) {
-	c.component.Logger().Info("GetCart called", "userID", userID)
+	c.logger.Info("GetCart called", "userID", userID)
 	cart, err := c.cache.Get(ctx, userID)
 	if err != nil && errors.Is(err, errNotFound{}) {
 		return []CartItem{}, nil

--- a/examples/onlineboutique/cartservice/weaver_gen.go
+++ b/examples/onlineboutique/cartservice/weaver_gen.go
@@ -68,7 +68,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[T] = (*impl)(nil)
 var _ weaver.InstanceOf[cartCache] = (*cartCacheImpl)(nil)
 

--- a/examples/onlineboutique/checkoutservice/weaver_gen.go
+++ b/examples/onlineboutique/checkoutservice/weaver_gen.go
@@ -55,7 +55,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.

--- a/examples/onlineboutique/currencyservice/weaver_gen.go
+++ b/examples/onlineboutique/currencyservice/weaver_gen.go
@@ -52,7 +52,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.

--- a/examples/onlineboutique/emailservice/weaver_gen.go
+++ b/examples/onlineboutique/emailservice/weaver_gen.go
@@ -52,7 +52,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.

--- a/examples/onlineboutique/frontend/frontend.go
+++ b/examples/onlineboutique/frontend/frontend.go
@@ -154,8 +154,8 @@ func Serve(ctx context.Context, s *Server) error {
 	var handler http.Handler = r
 	// TODO(spetrovic): Use the Service Weaver per-component config to provisionaly
 	// add these stats.
-	handler = ensureSessionID(handler)  // add session ID
-	handler = newLogHandler(s, handler) // add logging
+	handler = ensureSessionID(handler)           // add session ID
+	handler = newLogHandler(s.Logger(), handler) // add logging
 	s.handler = handler
 
 	s.Logger().Debug("Frontend available", "addr", s.boutique)

--- a/examples/onlineboutique/frontend/middleware.go
+++ b/examples/onlineboutique/frontend/middleware.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ServiceWeaver/weaver"
 	"github.com/google/uuid"
 	"golang.org/x/exp/slog"
 )
@@ -55,8 +54,8 @@ type logHandler struct {
 	next   http.Handler
 }
 
-func newLogHandler(component weaver.Instance, next http.Handler) http.Handler {
-	return &logHandler{logger: component.Logger(), next: next}
+func newLogHandler(logger *slog.Logger, next http.Handler) http.Handler {
+	return &logHandler{logger: logger, next: next}
 }
 
 func (lh *logHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/examples/onlineboutique/frontend/weaver_gen.go
+++ b/examples/onlineboutique/frontend/weaver_gen.go
@@ -48,7 +48,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[weaver.Main] = (*Server)(nil)
 
 // weaver.Router checks.

--- a/examples/onlineboutique/paymentservice/weaver_gen.go
+++ b/examples/onlineboutique/paymentservice/weaver_gen.go
@@ -54,7 +54,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.

--- a/examples/onlineboutique/productcatalogservice/weaver_gen.go
+++ b/examples/onlineboutique/productcatalogservice/weaver_gen.go
@@ -53,7 +53,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.

--- a/examples/onlineboutique/recommendationservice/weaver_gen.go
+++ b/examples/onlineboutique/recommendationservice/weaver_gen.go
@@ -51,7 +51,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.

--- a/examples/onlineboutique/shippingservice/weaver_gen.go
+++ b/examples/onlineboutique/shippingservice/weaver_gen.go
@@ -54,7 +54,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[T] = (*impl)(nil)
 
 // weaver.Router checks.

--- a/examples/onlineboutique/types/money/weaver_gen.go
+++ b/examples/onlineboutique/types/money/weaver_gen.go
@@ -29,7 +29,7 @@ please file an issue at https://github.com/ServiceWeaver/weaver/issues.
 
 `)
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 
 // weaver.Router checks.
 

--- a/examples/onlineboutique/types/weaver_gen.go
+++ b/examples/onlineboutique/types/weaver_gen.go
@@ -32,7 +32,7 @@ please file an issue at https://github.com/ServiceWeaver/weaver/issues.
 
 `)
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 
 // weaver.Router checks.
 

--- a/examples/reverser/weaver_gen.go
+++ b/examples/reverser/weaver_gen.go
@@ -65,7 +65,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[weaver.Main] = (*server)(nil)
 var _ weaver.InstanceOf[Reverser] = (*reverser)(nil)
 

--- a/godeps.txt
+++ b/godeps.txt
@@ -206,6 +206,7 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique/cartservice
     github.com/hashicorp/golang-lru/v2
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
+    golang.org/x/exp/slog
     reflect
 github.com/ServiceWeaver/weaver/examples/onlineboutique/checkoutservice
     context

--- a/internal/benchmarks/weaver_gen.go
+++ b/internal/benchmarks/weaver_gen.go
@@ -187,7 +187,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[Ping1] = (*ping1)(nil)
 var _ weaver.InstanceOf[Ping10] = (*ping10)(nil)
 var _ weaver.InstanceOf[Ping2] = (*ping2)(nil)

--- a/internal/tool/generate/example/weaver_gen.go
+++ b/internal/tool/generate/example/weaver_gen.go
@@ -71,7 +71,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[A] = (*a)(nil)
 var _ weaver.InstanceOf[B] = (*b)(nil)
 

--- a/internal/tool/generate/generator.go
+++ b/internal/tool/generate/generator.go
@@ -955,14 +955,14 @@ please file an issue at https://github.com/ServiceWeaver/weaver/issues.
 }
 
 // generateInstanceChecks generates code that checks that every component
-// implementation type implements weaver.Instance.
+// implementation type implements weaver.InstanceOf[T] for the appropriate T.
 func (g *generator) generateInstanceChecks(p printFn) {
 	// If someone deletes a weaver.Implements annotation and forgets to re-run
 	// `weaver generate`, these checks will fail to build. Similarly, if a user
 	// changes the interface in a weaver.Implements and forgets to re-run
 	// `weaver generate`, these checks will fail to build.
 	p(``)
-	p(`// weaver.Instance checks.`)
+	p(`// weaver.InstanceOf checks.`)
 	for _, c := range g.components {
 		// e.g., var _ weaver.InstanceOf[Odd] = &odd{}
 		p(`var _ %s[%s] = (*%s)(nil)`, g.weaver().qualify("InstanceOf"), g.tset.genTypeString(c.intf), g.tset.genTypeString(c.impl))

--- a/internal/tool/generate/generator_test.go
+++ b/internal/tool/generate/generator_test.go
@@ -459,7 +459,7 @@ func TestExampleVersion(t *testing.T) {
 	got := fmt.Sprintf("%x", h.Sum(nil))
 
 	// If weaver_gen.go has changed, the codegen version may need updating.
-	const want = "68b9c72fc095f4f9df483ee5c96fcafbfd76e4829e5229fef3bd337dbde06fd9"
+	const want = "149188524b7639a9470071875e68668c38b3145cd5f7d98559e1158da7761e4e"
 	if got != want {
 		t.Fatalf(`Unexpected SHA-256 hash of examples/weaver_gen.go: got %s, want %s. If this change is meaningful, REMEMBER TO UPDATE THE CODEGEN VERSION in runtime/version/version.go.`, got, want)
 	}

--- a/runtime/bin/testprogram/weaver_gen.go
+++ b/runtime/bin/testprogram/weaver_gen.go
@@ -90,7 +90,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[A] = (*a)(nil)
 var _ weaver.InstanceOf[B] = (*b)(nil)
 var _ weaver.InstanceOf[C] = (*c)(nil)

--- a/weavertest/internal/chain/weaver_gen.go
+++ b/weavertest/internal/chain/weaver_gen.go
@@ -81,7 +81,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[A] = (*a)(nil)
 var _ weaver.InstanceOf[B] = (*b)(nil)
 var _ weaver.InstanceOf[C] = (*c)(nil)

--- a/weavertest/internal/deploy/weaver_gen.go
+++ b/weavertest/internal/deploy/weaver_gen.go
@@ -66,7 +66,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[Started] = (*started)(nil)
 var _ weaver.InstanceOf[Widget] = (*widget)(nil)
 

--- a/weavertest/internal/diverge/weaver_gen.go
+++ b/weavertest/internal/diverge/weaver_gen.go
@@ -67,7 +67,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[Errer] = (*errer)(nil)
 var _ weaver.InstanceOf[Pointer] = (*pointer)(nil)
 

--- a/weavertest/internal/generate/weaver_gen.go
+++ b/weavertest/internal/generate/weaver_gen.go
@@ -52,7 +52,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[testApp] = (*impl)(nil)
 
 // weaver.Router checks.

--- a/weavertest/internal/protos/weaver_gen.go
+++ b/weavertest/internal/protos/weaver_gen.go
@@ -51,7 +51,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[PingPonger] = (*impl)(nil)
 
 // weaver.Router checks.

--- a/weavertest/internal/simple/weaver_gen.go
+++ b/weavertest/internal/simple/weaver_gen.go
@@ -83,7 +83,7 @@ func init() {
 	})
 }
 
-// weaver.Instance checks.
+// weaver.InstanceOf checks.
 var _ weaver.InstanceOf[Destination] = (*destination)(nil)
 var _ weaver.InstanceOf[Server] = (*server)(nil)
 var _ weaver.InstanceOf[Source] = (*source)(nil)

--- a/website/blog/deployers.md
+++ b/website/blog/deployers.md
@@ -621,7 +621,7 @@ sending protobufs over a pair of pipes. For even more details, refer to
 [GetLoad]: https://pkg.go.dev/github.com/ServiceWeaver/weaver/runtime/envelope#Envelope.GetLoad
 [Run]: https://pkg.go.dev/github.com/ServiceWeaver/weaver#Run
 [ListenerOptions]: https://pkg.go.dev/github.com/ServiceWeaver/weaver#ListenerOptions
-[Listener]: https://pkg.go.dev/github.com/ServiceWeaver/weaver#Instance
+[Listener]: https://pkg.go.dev/github.com/ServiceWeaver/weaver#Listener
 [NewEnvelope]: https://pkg.go.dev/github.com/ServiceWeaver/weaver/runtime/envelope#NewEnvelope
 [ReplicaToRegister]: https://pkg.go.dev/github.com/ServiceWeaver/weaver/runtime/protos#ReplicaToRegister
 [WeaveletInfo]: https://pkg.go.dev/github.com/ServiceWeaver/weaver/runtime/protos#WeaveletInfo

--- a/website/docs.md
+++ b/website/docs.md
@@ -616,10 +616,6 @@ type foo struct{
 -   It must embed a `weaver.Implements[T]` field where `T` is the component
     interface it implements.
 
-`weaver.Implements[T]` implements the `weaver.Instance` interface and therefore
-every component implementation (including `foo`) also implements
-`weaver.Instance`.
-
 If a component implementation implements an `Init(context.Context) error`
 method, it will be called when an instance of the component is created.
 
@@ -1112,7 +1108,7 @@ mux.Handle("/foo", weaver.InstrumentHandler("foo", fooHandler))
 ```
 
 Alternatively, you can enable tracing manually using the [OpenTelemetry][otel]
-libraries: 
+libraries:
 
 ```go
 import (


### PR DESCRIPTION
This PR removes the unused `weaver.Instance` type. I believe that `weaver.Instance` became obsolete when we introduced `weaver.InstanceOf[T]`.

Note that onlineboutique was using `weaver.Instance`, but not in a meaningful way.