### PR TITLE
Allow registered serializable types to be pointers.

### DIFF
--- a/internal/tool/generate/generator.go
+++ b/internal/tool/generate/generator.go
@@ -1904,7 +1904,7 @@ func (g *generator) generateAutoMarshalMethods(p printFn) {
 		// that implement error. We could conceivably allow other types to
 		// be sent around as interfaces in the future.
 		if g.tset.implementsError(t) {
-			p("func init() { %s[%s]() }", g.codegen().qualify("RegisterSerializable"), ts(t))
+			p("func init() { %s[*%s]() }", g.codegen().qualify("RegisterSerializable"), ts(t))
 		}
 	}
 }

--- a/internal/tool/generate/testdata/automarshal_embeddings.go
+++ b/internal/tool/generate/testdata/automarshal_embeddings.go
@@ -19,11 +19,11 @@
 // func (x *B) WeaverUnmarshal(dec *codegen.Decoder)
 // func (x *customError) WeaverMarshal(enc *codegen.Encoder)
 // func (x *customError) WeaverUnmarshal(dec *codegen.Decoder)
-// RegisterSerializable[customError]()
+// RegisterSerializable[*customError]()
 
 // UNEXPECTED
-// RegisterSerializable[A]()
-// RegisterSerializable[B]()
+// RegisterSerializable[*A]()
+// RegisterSerializable[*B]()
 
 // Verify that AutoMarshal works on a struct with an embedded struct that also
 // embeds AutoMarshal.

--- a/weavertest/internal/generate/weaver_gen.go
+++ b/weavertest/internal/generate/weaver_gen.go
@@ -333,7 +333,7 @@ func (x *customErrorValue) WeaverUnmarshal(dec *codegen.Decoder) {
 	}
 	x.key = dec.String()
 }
-func init() { codegen.RegisterSerializable[customErrorValue]() }
+func init() { codegen.RegisterSerializable[*customErrorValue]() }
 
 // Encoding/decoding implementations.
 


### PR DESCRIPTION
Remove type constraint from RegisterSerializable[T] and instead check at runtime that either T or *T implements AutoMarshal.