### PR TITLE
Preserve serializable custom errors from remote method calls.

### DIFF
--- a/internal/tool/generate/generator.go
+++ b/internal/tool/generate/generator.go
@@ -1898,6 +1898,14 @@ func (g *generator) generateAutoMarshalMethods(p printFn) {
 		for _, inner := range innerTypes {
 			g.generateEncDecMethodsFor(p, inner)
 		}
+
+		// Register the type so it can be sent when the compile time type
+		// is an interface (like error). For now, we only do so for types
+		// that implement error. We could conceivably allow other types to
+		// be sent around as interfaces in the future.
+		if g.tset.implementsError(t) {
+			p("func init() { %s[%s]() }", g.codegen().qualify("RegisterSerializable"), ts(t))
+		}
 	}
 }
 

--- a/internal/tool/generate/testdata/automarshal_embeddings.go
+++ b/internal/tool/generate/testdata/automarshal_embeddings.go
@@ -17,6 +17,13 @@
 // func (x *A) WeaverUnmarshal(dec *codegen.Decoder)
 // func (x *B) WeaverMarshal(enc *codegen.Encoder)
 // func (x *B) WeaverUnmarshal(dec *codegen.Decoder)
+// func (x *customError) WeaverMarshal(enc *codegen.Encoder)
+// func (x *customError) WeaverUnmarshal(dec *codegen.Decoder)
+// RegisterSerializable[customError]()
+
+// UNEXPECTED
+// RegisterSerializable[A]()
+// RegisterSerializable[B]()
 
 // Verify that AutoMarshal works on a struct with an embedded struct that also
 // embeds AutoMarshal.
@@ -36,6 +43,12 @@ type A struct {
 type B struct {
 	weaver.AutoMarshal
 }
+
+type customError struct {
+	weaver.AutoMarshal
+}
+
+func (c customError) Error() string { return "custom" }
 
 type foo interface {
 	M(context.Context, A, B) error

--- a/weavertest/internal/generate/app.go
+++ b/weavertest/internal/generate/app.go
@@ -31,8 +31,16 @@ type behaviorType int
 const (
 	appError behaviorType = iota
 	panicError
+	customError
 	noError
 )
+
+type customErrorValue struct {
+	weaver.AutoMarshal
+	key string
+}
+
+func (c customErrorValue) Error() string { return fmt.Sprintf("customError(%s)", c.key) }
 
 type testApp interface {
 	Get(_ context.Context, key string, behavior behaviorType) (int, error)
@@ -50,6 +58,8 @@ func (p *impl) Get(_ context.Context, key string, behavior behaviorType) (int, e
 		return 42, fmt.Errorf("key %v not found in the store", key)
 	case panicError:
 		panic("panic")
+	case customError:
+		return 0, customErrorValue{key: key}
 	case noError:
 		return 42, nil
 	}

--- a/weavertest/internal/generate/app_test.go
+++ b/weavertest/internal/generate/app_test.go
@@ -47,6 +47,18 @@ func TestErrors(t *testing.T) {
 			t.Fatalf("client.Get: got %d, want 42", x)
 		}
 
+		// Check custom error.
+		_, err = client.Get(ctx, "custom", customError)
+		if err == nil {
+			t.Fatal(err)
+		}
+		var c customErrorValue
+		if !errors.As(err, &c) {
+			t.Errorf("did not get customError, got error %v of type %T", err, err)
+		} else if c.key != "custom" {
+			t.Errorf("customError contained wrong key %q, expecting %q", c.key, "custom")
+		}
+
 		// Trigger a panic.
 		_, err = client.Get(ctx, "foo", panicError)
 		if err == nil || !errors.Is(err, weaver.RemoteCallError) {

--- a/weavertest/internal/generate/weaver_gen.go
+++ b/weavertest/internal/generate/weaver_gen.go
@@ -6,6 +6,7 @@ package generate
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/ServiceWeaver/weaver"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"go.opentelemetry.io/otel/codes"
@@ -307,6 +308,32 @@ func (s testApp_server_stub) incPointer(ctx context.Context, args []byte) (res [
 	enc.Error(appErr)
 	return enc.Data(), nil
 }
+
+// AutoMarshal implementations.
+
+var _ codegen.AutoMarshal = (*customErrorValue)(nil)
+
+type __is_customErrorValue[T ~struct {
+	weaver.AutoMarshal
+	key string
+}] struct{}
+
+var _ __is_customErrorValue[customErrorValue]
+
+func (x *customErrorValue) WeaverMarshal(enc *codegen.Encoder) {
+	if x == nil {
+		panic(fmt.Errorf("customErrorValue.WeaverMarshal: nil receiver"))
+	}
+	enc.String(x.key)
+}
+
+func (x *customErrorValue) WeaverUnmarshal(dec *codegen.Decoder) {
+	if x == nil {
+		panic(fmt.Errorf("customErrorValue.WeaverUnmarshal: nil receiver"))
+	}
+	x.key = dec.String()
+}
+func init() { codegen.RegisterSerializable[customErrorValue]() }
 
 // Encoding/decoding implementations.
 

--- a/website/docs.md
+++ b/website/docs.md
@@ -2755,10 +2755,17 @@ type Pair[A any] struct {
 To serialize generic structs, implement `BinaryMarshaler` and
 `BinaryUnmarshaler`.
 
-Finally note that while [Service Weaver requires every component method to
-return an `error`](#components-interfaces), `error` is not a
-serializable type. Service Weaver serializes `error`s in a way that does not
-preserve any custom `Is` or `As` methods.
+## Errors
+
+Service Weaver requires every component method to [return an
+error](#components-interfaces).  If a non-nil error is returned, Service Weaver
+by default transmits the textual representation of the error and therefore any
+custom information stored in the error value, or custom `Is` or `As` methods are
+not available to the caller.
+
+Applications that need custom error information can embed a `weaver.AutoMarshal`
+in their custom error type. Service Weaver will then serialize and deserialize
+such errors properly and make them available to the caller.
 
 # weaver generate
 

--- a/website/docs.md
+++ b/website/docs.md
@@ -2759,9 +2759,9 @@ To serialize generic structs, implement `BinaryMarshaler` and
 
 Service Weaver requires every component method to [return an
 error](#components-interfaces).  If a non-nil error is returned, Service Weaver
-by default transmits the textual representation of the error and therefore any
-custom information stored in the error value, or custom `Is` or `As` methods are
-not available to the caller.
+by default transmits the textual representation of the error. Therefore any
+custom information stored in the error value, or custom `Is` or `As` methods,
+are not available to the caller.
 
 Applications that need custom error information can embed a `weaver.AutoMarshal`
 in their custom error type. Service Weaver will then serialize and deserialize


### PR DESCRIPTION
The code generator emits code to keep track of all error types that contain an embedded weaver.AutoMarshal in a global table.  The sender sends such errors by prefixing their serialization with they corresponding key in the global table. The receiver looks up the key in its global table, creates a value of the correct type, and deserializes the error contents into that value.

This allows custom errors to be returned from remote methods without losing type information.