### PR TITLE
Use a small traces table for querying.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -854,6 +854,7 @@ github.com/ServiceWeaver/weaver/runtime/metrics
     unicode
     unicode/utf8
 github.com/ServiceWeaver/weaver/runtime/perfetto
+    bytes
     context
     crypto/sha256
     database/sql

--- a/internal/status/templates/traces.html
+++ b/internal/status/templates/traces.html
@@ -48,7 +48,7 @@
             <tr>
               <th scope="col">Trace URL</th>
               <th scope="col">Start Time</th>
-              <th scope="col">Duration</th>
+              <th scope="col">Latency</th>
             </tr>
           </thead>
           <tbody>

--- a/runtime/perfetto/db.go
+++ b/runtime/perfetto/db.go
@@ -157,7 +157,7 @@ func (d *DB) Store(ctx context.Context, app, version string, spans *protos.Trace
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback() //nolint:errcheck supplanted by errs below
+	defer tx.Rollback() //nolint:errcheck // supplanted by errs below
 	var errs []error
 	for _, span := range spans.Span {
 		if isRootSpan(span) {


### PR DESCRIPTION
Suggested by @ghemawat.

The traces table now contains only the information requied for querying. The new format is more space efficient and leads to faster querying.

Also, insert all trace data into the database in a single transaction, as it is significantly  more efficient:

Before:
cpu: Intel(R) Xeon(R) Gold 6154 CPU @ 3.00GHz
BenchmarkStore
BenchmarkStore/1
BenchmarkStore/1-72  	     100	  10763759 ns/op
BenchmarkStore/10
BenchmarkStore/10-72 	      10	 108713097 ns/op
BenchmarkStore/100
BenchmarkStore/100-72         	       1	1055861276 ns/op

After:
BenchmarkStore
BenchmarkStore/1
BenchmarkStore/1-72  	     100	  10609201 ns/op
BenchmarkStore/10
BenchmarkStore/10-72 	     100	  10700368 ns/op
BenchmarkStore/100
BenchmarkStore/100-72         	      96	  13052743 ns/op