### PR TITLE
Rename the runtime perfetto/ package into traces/.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -452,11 +452,11 @@ github.com/ServiceWeaver/weaver/internal/status
     github.com/ServiceWeaver/weaver/runtime/colors
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/metrics
-    github.com/ServiceWeaver/weaver/runtime/perfetto
     github.com/ServiceWeaver/weaver/runtime/prometheus
     github.com/ServiceWeaver/weaver/runtime/protomsg
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/tool
+    github.com/ServiceWeaver/weaver/runtime/traces
     github.com/google/pprof/profile
     github.com/pkg/browser
     golang.org/x/exp/maps
@@ -569,11 +569,11 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     github.com/ServiceWeaver/weaver/runtime/envelope
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/metrics
-    github.com/ServiceWeaver/weaver/runtime/perfetto
     github.com/ServiceWeaver/weaver/runtime/profiling
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/retry
     github.com/ServiceWeaver/weaver/runtime/tool
+    github.com/ServiceWeaver/weaver/runtime/traces
     github.com/ServiceWeaver/weaver/runtime/version
     github.com/google/uuid
     golang.org/x/exp/maps
@@ -658,10 +658,10 @@ github.com/ServiceWeaver/weaver/internal/tool/ssh/impl
     github.com/ServiceWeaver/weaver/runtime/envelope
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/metrics
-    github.com/ServiceWeaver/weaver/runtime/perfetto
     github.com/ServiceWeaver/weaver/runtime/protomsg
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/retry
+    github.com/ServiceWeaver/weaver/runtime/traces
     github.com/google/uuid
     golang.org/x/exp/maps
     golang.org/x/exp/slices
@@ -717,9 +717,9 @@ github.com/ServiceWeaver/weaver/internal/weaver
     github.com/ServiceWeaver/weaver/runtime/colors
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/metrics
-    github.com/ServiceWeaver/weaver/runtime/perfetto
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/retry
+    github.com/ServiceWeaver/weaver/runtime/traces
     github.com/google/uuid
     github.com/lightstep/varopt
     go.opentelemetry.io/otel
@@ -864,34 +864,6 @@ github.com/ServiceWeaver/weaver/runtime/metrics
     sync/atomic
     unicode
     unicode/utf8
-github.com/ServiceWeaver/weaver/runtime/perfetto
-    bytes
-    context
-    crypto/sha256
-    database/sql
-    encoding/binary
-    encoding/hex
-    encoding/json
-    errors
-    fmt
-    github.com/ServiceWeaver/weaver/internal/traceio
-    github.com/ServiceWeaver/weaver/runtime/protos
-    github.com/ServiceWeaver/weaver/runtime/retry
-    go.opentelemetry.io/otel/sdk/trace
-    go.opentelemetry.io/otel/semconv/v1.4.0
-    go.opentelemetry.io/otel/trace
-    google.golang.org/protobuf/proto
-    math
-    modernc.org/sqlite
-    modernc.org/sqlite/lib
-    net
-    net/http
-    os
-    path/filepath
-    strconv
-    strings
-    sync
-    time
 github.com/ServiceWeaver/weaver/runtime/profiling
     bytes
     errors
@@ -950,6 +922,38 @@ github.com/ServiceWeaver/weaver/runtime/tool
     sort
     strings
     text/template
+    time
+github.com/ServiceWeaver/weaver/runtime/traces
+    bytes
+    context
+    crypto/sha256
+    database/sql
+    encoding/binary
+    encoding/hex
+    encoding/json
+    errors
+    fmt
+    github.com/ServiceWeaver/weaver/internal/traceio
+    github.com/ServiceWeaver/weaver/runtime/protos
+    github.com/ServiceWeaver/weaver/runtime/retry
+    go.opentelemetry.io/otel/attribute
+    go.opentelemetry.io/otel/codes
+    go.opentelemetry.io/otel/sdk/instrumentation
+    go.opentelemetry.io/otel/sdk/resource
+    go.opentelemetry.io/otel/sdk/trace
+    go.opentelemetry.io/otel/semconv/v1.4.0
+    go.opentelemetry.io/otel/trace
+    google.golang.org/protobuf/proto
+    math
+    modernc.org/sqlite
+    modernc.org/sqlite/lib
+    net
+    net/http
+    os
+    path/filepath
+    strconv
+    strings
+    sync
     time
 github.com/ServiceWeaver/weaver/runtime/version
     fmt

--- a/internal/envelope/conn/trace_readwrite_test.go
+++ b/internal/envelope/conn/trace_readwrite_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	sdk "go.opentelemetry.io/otel/sdk/trace"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -79,7 +78,7 @@ func (*pipeForTest) VerifyServerCertificate(context.Context, *protos.VerifyServe
 func writeAndRead(in *protos.Span, pipe *pipeForTest) (*protos.Span, error) {
 	pipe.waitToExportSpans.Add(1)
 	writer := traceio.NewWriter(pipe.wletConn.SendTraceSpans)
-	if err := writer.ExportSpans(context.Background(), []sdk.ReadOnlySpan{&traceio.ReadSpan{Span: in}}); err != nil {
+	if err := writer.ExportSpansProto(&protos.TraceSpans{Span: []*protos.Span{in}}); err != nil {
 		return nil, err
 	}
 	pipe.waitToExportSpans.Wait()

--- a/internal/tool/multi/deployer.go
+++ b/internal/tool/multi/deployer.go
@@ -36,9 +36,9 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/envelope"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
-	"github.com/ServiceWeaver/weaver/runtime/perfetto"
 	"github.com/ServiceWeaver/weaver/runtime/profiling"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
+	"github.com/ServiceWeaver/weaver/runtime/traces"
 	"github.com/google/uuid"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
@@ -62,7 +62,7 @@ type deployer struct {
 	caKey        crypto.PrivateKey
 	running      errgroup.Group
 	logsDB       *logging.FileStore
-	traceDB      *perfetto.DB
+	traceDB      *traces.DB
 
 	// statsProcessor tracks and computes stats to be rendered on the /statusz page.
 	statsProcessor *imetrics.StatsProcessor
@@ -132,7 +132,7 @@ func newDeployer(ctx context.Context, deploymentId string, config *MultiConfig) 
 	}
 
 	// Create the trace saver.
-	traceDB, err := perfetto.Open(ctx, perfettoFile)
+	traceDB, err := traces.OpenDB(ctx, perfettoFile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open Perfetto database: %w", err)
 	}

--- a/internal/tool/multi/multi.go
+++ b/internal/tool/multi/multi.go
@@ -32,7 +32,7 @@ var (
 	logDir       = filepath.Join(runtime.LogsDir(), "multi")
 	dataDir      = filepath.Join(must.Must(runtime.DataDir()), "multi")
 	registryDir  = filepath.Join(dataDir, "registry")
-	perfettoFile = filepath.Join(dataDir, "perfetto.db")
+	perfettoFile = filepath.Join(dataDir, "traces.DB")
 
 	dashboardSpec = &status.DashboardSpec{
 		Tool:         "weaver multi",

--- a/internal/tool/single/single.go
+++ b/internal/tool/single/single.go
@@ -30,7 +30,7 @@ var (
 	// The directories and files where the single process deployer stores data.
 	dataDir      = filepath.Join(must.Must(runtime.DataDir()), "single")
 	RegistryDir  = filepath.Join(dataDir, "registry")
-	PerfettoFile = filepath.Join(dataDir, "perfetto.db")
+	PerfettoFile = filepath.Join(dataDir, "traces.DB")
 
 	dashboardSpec = &status.DashboardSpec{
 		Tool:         "weaver single",

--- a/internal/tool/ssh/impl/manager.go
+++ b/internal/tool/ssh/impl/manager.go
@@ -32,8 +32,8 @@ import (
 	"github.com/ServiceWeaver/weaver/internal/routing"
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
-	"github.com/ServiceWeaver/weaver/runtime/perfetto"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
+	"github.com/ServiceWeaver/weaver/runtime/traces"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"golang.org/x/exp/slog"
@@ -72,7 +72,7 @@ var (
 	LogDir       = filepath.Join(runtime.LogsDir(), "ssh")
 	dataDir      = filepath.Join(must.Must(runtime.DataDir()), "ssh")
 	registryDir  = filepath.Join(dataDir, "registry")
-	PerfettoFile = filepath.Join(dataDir, "perfetto.db")
+	PerfettoFile = filepath.Join(dataDir, "traces.DB")
 )
 
 // manager manages an application version deployment across a set of locations,
@@ -168,7 +168,7 @@ func RunManager(ctx context.Context, config *SshConfig, locations map[string]str
 	})
 
 	// Create the trace saver.
-	traceDB, err := perfetto.Open(ctx, PerfettoFile)
+	traceDB, err := traces.OpenDB(ctx, PerfettoFile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open Perfetto database: %w", err)
 	}

--- a/internal/traceio/exporter.go
+++ b/internal/traceio/exporter.go
@@ -53,9 +53,15 @@ func (w *Writer) ExportSpans(_ context.Context, spans []sdk.ReadOnlySpan) error 
 	for i, span := range spans {
 		msg.Span[i] = toProtoSpan(span)
 	}
+	return w.ExportSpansProto(msg)
+}
+
+// ExportSpansProto is like ExportSpans, but it exports spans in the
+// *protos.TraceSpans format.
+func (w *Writer) ExportSpansProto(spans *protos.TraceSpans) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	return w.export(msg)
+	return w.export(spans)
 }
 
 // Shutdown implements the sdk.SpanExporter interface.

--- a/internal/weaver/singleprocess.go
+++ b/internal/weaver/singleprocess.go
@@ -38,9 +38,9 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/colors"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
-	"github.com/ServiceWeaver/weaver/runtime/perfetto"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/ServiceWeaver/weaver/runtime/retry"
+	"github.com/ServiceWeaver/weaver/runtime/traces"
 	"github.com/google/uuid"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"golang.org/x/exp/slog"
@@ -127,7 +127,7 @@ func newSingleprocessEnv(bootstrap runtime.Bootstrap) (*singleprocessEnv, error)
 		return nil, err
 	}
 
-	traceDB, err := perfetto.Open(ctx, single.PerfettoFile)
+	traceDB, err := traces.OpenDB(ctx, single.PerfettoFile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open Perfetto database: %w", err)
 	}

--- a/runtime/envelope/envelope_test.go
+++ b/runtime/envelope/envelope_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/retry"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -343,25 +342,25 @@ func writeTraces(conn *conn.WeaveletConn) error {
 	w := traceio.NewWriter(conn.SendTraceSpans)
 	defer w.Shutdown(context.Background())
 
-	span := func(name string) sdktrace.ReadOnlySpan {
+	span := func(name string) *protos.Span {
 		rnd := uuid.New()
-		return &traceio.ReadSpan{Span: &protos.Span{
+		return &protos.Span{
 			Name:         name,
 			TraceId:      rnd[:16],
 			SpanId:       rnd[:8],
 			ParentSpanId: rnd[:8],
-		}}
+		}
 	}
-	if err := w.ExportSpans(context.Background(), []sdktrace.ReadOnlySpan{
+	if err := w.ExportSpansProto(&protos.TraceSpans{Span: []*protos.Span{
 		span("span1"),
 		span("span2"),
-	}); err != nil {
+	}}); err != nil {
 		return err
 	}
-	if err := w.ExportSpans(context.Background(), []sdktrace.ReadOnlySpan{
+	if err := w.ExportSpansProto(&protos.TraceSpans{Span: []*protos.Span{
 		span("span3"),
 		span("span4"),
-	}); err != nil {
+	}}); err != nil {
 		return err
 	}
 	return nil

--- a/runtime/traces/db.go
+++ b/runtime/traces/db.go
@@ -14,66 +14,29 @@
 
 // Package perfetto contains libraries for displaying trace information in the
 // Perfetto UI.
-//
-// TODO(spetrovic): Move this package to internal/
-package perfetto
+package traces
 
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
-	"sync"
 	"time"
 
-	"github.com/ServiceWeaver/weaver/internal/traceio"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/ServiceWeaver/weaver/runtime/retry"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
-	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 	"modernc.org/sqlite"
 	sqlite3 "modernc.org/sqlite/lib"
 )
 
-// completeEvent renders an event that contains a start time and a duration.
-type completeEvent struct {
-	Ph   string                       `json:"ph"`   // the event type
-	Name string                       `json:"name"` // name of the event
-	Cat  string                       `json:"cat"`  // category of the event
-	Pid  int                          `json:"pid"`  // the id of the process that output the event
-	Tid  int                          `json:"tid"`  // the thread id of the thread that output the event
-	Ts   int64                        `json:"ts"`   // start time of the event
-	Dur  int64                        `json:"dur"`  // duration of the event
-	Args map[string]map[string]string `json:"args"` // arguments provided for the event
-}
-
-// metadataEvent renders an event that contains metadata information for a completeEvent.
-type metadataEvent struct {
-	Ph   string            `json:"ph"`   // the event type
-	Name string            `json:"name"` // name of the event
-	Cat  string            `json:"cat"`  // category of the event
-	Pid  int               `json:"pid"`  // the id of the process that output the event
-	Tid  int               `json:"tid"`  // the thread id of the thread that output the event
-	Args map[string]string `json:"args"` // arguments provided for the event
-}
-
 // DB is a trace database that stores traces on the local file system.
-//
-// TODO(spetrovic): Separate the database from the Pefetto serving code.
 type DB struct {
 	// Trace data is stored in a sqlite DB spread across two tables:
 	// (1) traces:         serialized trace data, used for querying.
@@ -83,9 +46,9 @@ type DB struct {
 	db    *sql.DB
 }
 
-// Open opens the default trace database on the local machine, which is
-// persisted in the provided file.
-func Open(ctx context.Context, fname string) (*DB, error) {
+// OpenDB opens the trace database persisted in the provided file. If the
+// file doesn't exist, this call creates it.
+func OpenDB(ctx context.Context, fname string) (*DB, error) {
 	if err := os.MkdirAll(filepath.Dir(fname), 0700); err != nil {
 		return nil, err
 	}
@@ -157,7 +120,7 @@ func (d *DB) Close() error {
 	return d.db.Close()
 }
 
-// Store stores the given traces in the database.
+// Store stores the given trace spans in the database.
 func (d *DB) Store(ctx context.Context, app, version string, spans *protos.TraceSpans) error {
 	// NOTE: we insert all rows transactionally, as it is significantly faster
 	// than inserting one row at a time [1].
@@ -218,8 +181,6 @@ type TraceSummary struct {
 //
 // Any query argument that has a zero value (e.g., empty app or version,
 // zero endTime) is ignored, i.e., it matches all spans.
-//
-// TODO(spetrovic): Add attribute matching.
 func (d *DB) QueryTraces(ctx context.Context, app, version string, startTime, endTime time.Time, durationLower, durationUpper time.Duration, onlyErrors bool, limit int64) ([]TraceSummary, error) {
 	const query = `
 SELECT trace_id, start_time_unix_us, end_time_unix_us, status
@@ -275,7 +236,8 @@ LIMIT ?
 	return traces, nil
 }
 
-func (d *DB) fetchSpans(ctx context.Context, traceID string) ([]*protos.Span, error) {
+// FetchSpans returns all of the spans that have a given trace id.
+func (d *DB) FetchSpans(ctx context.Context, traceID string) ([]*protos.Span, error) {
 	const query = `SELECT data FROM encoded_spans WHERE trace_id=?`
 	rows, err := d.queryDB(ctx, query, traceID)
 	if err != nil {
@@ -324,225 +286,6 @@ func (d *DB) execDB(ctx context.Context, query string, args ...any) (sql.Result,
 	return nil, ctx.Err()
 }
 
-// Serve runs an HTTP server that serves traces stored in the database.
-// In order to view the traces, open the following URL in a Chrome browser:
-//
-//	https://ui.perfetto.dev/#!/?url=http://<hostname>:9001?trace_id=<trace_id>
-//
-// , where <hostname> is the hostname of the machine running this server
-// (e.g., "127.0.0.1"), and <trace_id> is the trace ID in hexadecimal format.
-//
-// Perfetto UI requires that the server runs on the local port 9001. For that
-// reason, this method will block until port 9001 becomes available.
-func (d *DB) Serve(ctx context.Context) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte("OK")) //nolint:errcheck // response write error
-	})
-	mux.HandleFunc("/", d.fetchTrace)
-	server := http.Server{Handler: mux}
-
-	// Repeatedly try to start a Perfetto HTTP server on port 9001. As long as
-	// we fail, it means that some other OS process is serving database
-	// traces on that port, and is serving "our" traces as well.
-	// TODO(spetrovic): With recent "purge" changes, this is no longer the case,
-	// as we now have a separate database for single, multi, and GKE-local
-	// deployers. We should fix this.
-	ticker := time.NewTicker(time.Second)
-	var warnOnce sync.Once
-	for {
-		select {
-		case <-ticker.C:
-			lis, err := net.Listen("tcp", "localhost:9001")
-			if err != nil {
-				warnOnce.Do(func() {
-					fmt.Fprintf(os.Stderr, "Perfetto server failed to listen on port 9001: %v\n", err)
-					fmt.Fprintf(os.Stderr, "Perfetto server will retry until port 9001 is available\n")
-				})
-				continue
-			}
-
-			ticker.Stop()
-			err = server.Serve(lis)
-			if !errors.Is(err, http.ErrServerClosed) {
-				fmt.Fprintf(os.Stderr, "Failed to serve perfetto backend: %v\n", err)
-			}
-			return
-
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-func (d *DB) fetchTrace(w http.ResponseWriter, r *http.Request) {
-	// Set access control according to:
-	//   https://perfetto.dev/docs/visualization/deep-linking-to-perfetto-ui.
-	w.Header().Set("Access-Control-Allow-Origin", "https://ui.perfetto.dev")
-	traceID := r.URL.Query().Get("trace_id")
-	if traceID == "" {
-		http.Error(w, "no trace id provided", http.StatusBadRequest)
-		return
-	}
-	spans, err := d.fetchSpans(r.Context(), traceID)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("cannot fetch spans: %v", err), http.StatusInternalServerError)
-		return
-	}
-	if len(spans) == 0 {
-		http.Error(w, "cannot find span", http.StatusNotFound)
-		return
-	}
-	traces, err := encodeSpans(spans)
-	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-	w.Write(traces) //nolint:errcheck // response write error
-}
-
-// encodeSpans encodes the given spans in a format that can be read by the
-// Perfetto UI.
-func encodeSpans(spans []*protos.Span) ([]byte, error) {
-	var buf strings.Builder
-
-	// We are returning a JSON array, so surround everything in [].
-	buf.WriteByte('[')
-	addEvent := func(event []byte) {
-		if buf.Len() > 1 { // NOTE: buf always starts with a '['
-			buf.WriteByte(',')
-		}
-		buf.Write(event)
-	}
-	for _, span := range spans {
-		s := &traceio.ReadSpan{Span: span}
-		events, err := encodeSpanEvents(s)
-		if err != nil {
-			return nil, err
-		}
-		for _, event := range events {
-			addEvent(event)
-		}
-	}
-	buf.WriteByte(']')
-	return []byte(buf.String()), nil
-}
-
-// encodeSpanEvents encodes the given span into a series of Perfetto events.
-func encodeSpanEvents(span sdktrace.ReadOnlySpan) ([][]byte, error) {
-	var ret [][]byte
-	appendEvent := func(event any) error {
-		b, err := json.Marshal(event)
-		if err != nil {
-			return err
-		}
-		ret = append(ret, b)
-		return nil
-	}
-
-	// Extract information from the span attributes.
-	var pid int
-	var weaveletId string
-	for _, a := range span.Resource().Attributes() {
-		switch a.Key {
-		case semconv.ProcessPIDKey:
-			pid = int(a.Value.AsInt64())
-		case traceio.WeaveletIdTraceKey:
-			weaveletId = a.Value.AsString()
-		}
-	}
-
-	// The span name contains the name of the method that is called. Based
-	// on the span kind, we attach an additional label to identify whether
-	// the event happened at the client, server, or locally.
-	eventName := span.Name()
-	switch span.SpanKind() {
-	case trace.SpanKindServer:
-		eventName = eventName + " [server]"
-	case trace.SpanKindClient:
-		eventName = eventName + " [client]"
-	case trace.SpanKindInternal:
-		eventName = eventName + " [local]"
-	}
-
-	// Build the attributes map.
-	attrs := map[string]string{}
-	for _, a := range span.Attributes() {
-		attrs[string(a.Key)] = a.Value.Emit()
-	}
-
-	// Build the arguments.
-	args := map[string]map[string]string{
-		"ids": {
-			"spanID":        span.SpanContext().SpanID().String(),
-			"traceID":       span.SpanContext().TraceID().String(),
-			"parentSpanID":  span.Parent().SpanID().String(),
-			"parentTraceID": span.Parent().TraceID().String(),
-			"processID":     strconv.Itoa(pid),
-		},
-		"attributes": attrs,
-	}
-
-	// Generate a complete event and a series of metadata events.
-	weaveletFP := fp(weaveletId)
-
-	// Build two metadata events for each colocation group (one to replace the
-	// process name label and one for the thread name).
-	if err := appendEvent(&metadataEvent{
-		Ph:   "M", // make it a metadata event
-		Name: "process_name",
-		Cat:  span.SpanKind().String(),
-		Pid:  weaveletFP,
-		Tid:  weaveletFP,
-		Args: map[string]string{"name": "Weavelet"},
-	}); err != nil {
-		return nil, err
-	}
-	if err := appendEvent(&metadataEvent{
-		Ph:   "M", // make it a metadata event
-		Name: "thread_name",
-		Cat:  span.SpanKind().String(),
-		Pid:  weaveletFP,
-		Tid:  weaveletFP,
-		Args: map[string]string{"name": "Weavelet"},
-	}); err != nil {
-		return nil, err
-	}
-
-	// Build a complete event.
-	if err := appendEvent(&completeEvent{
-		Ph:   "X", // make it a complete event
-		Name: eventName,
-		Cat:  span.SpanKind().String(),
-		Pid:  weaveletFP,
-		Tid:  weaveletFP,
-		Args: args,
-		Ts:   span.StartTime().UnixMicro(),
-		Dur:  span.EndTime().UnixMicro() - span.StartTime().UnixMicro(),
-	}); err != nil {
-		return nil, err
-	}
-
-	// For each span event, create a corresponding metadata event.
-	for _, e := range span.Events() {
-		attrs := map[string]string{}
-		for _, a := range e.Attributes {
-			attrs[string(a.Key)] = a.Value.Emit()
-		}
-		if err := appendEvent(&metadataEvent{
-			Ph:   "M", // make it a metadata event
-			Name: e.Name,
-			Cat:  span.SpanKind().String(),
-			Pid:  weaveletFP,
-			Tid:  weaveletFP,
-			Args: attrs,
-		}); err != nil {
-			return nil, err
-		}
-	}
-	return ret, nil
-}
-
 // isLocked returns whether the error is a "database is locked" error.
 func isLocked(err error) bool {
 	sqlError := &sqlite.Error{}
@@ -586,10 +329,4 @@ func spanStatus(span *protos.Span) string {
 
 	// No errors found.
 	return ""
-}
-
-func fp(name string) int {
-	hasher := sha256.New()
-	hasher.Write([]byte(name))
-	return int(binary.LittleEndian.Uint32(hasher.Sum(nil)))
 }

--- a/runtime/traces/perfetto.go
+++ b/runtime/traces/perfetto.go
@@ -1,0 +1,295 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traces
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ServiceWeaver/weaver/internal/traceio"
+	"github.com/ServiceWeaver/weaver/runtime/protos"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// ServePerfetto runs an HTTP server that serves traces stored in the database
+// to the Chrome Browser's Perfetto UI.
+//
+// In order to view the traces, open the following URL in a Chrome browser:
+//
+//	https://ui.perfetto.dev/#!/?url=http://<hostname>:9001?trace_id=<trace_id>
+//
+// , where <hostname> is the hostname of the machine running this server
+// (e.g., "127.0.0.1"), and <trace_id> is the trace ID in hexadecimal format.
+//
+// Perfetto UI requires that the server runs on local port 9001. For that
+// reason, this method will block until port 9001 becomes available.
+func ServePerfetto(ctx context.Context, db *DB) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("OK")) //nolint:errcheck // response write error
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Set access control according to:
+		//   https://perfetto.dev/docs/visualization/deep-linking-to-perfetto-ui.
+		w.Header().Set("Access-Control-Allow-Origin", "https://ui.perfetto.dev")
+		traceID := r.URL.Query().Get("trace_id")
+		data, err := fetchSpans(r.Context(), db, traceID)
+		if err != nil {
+			http.Error(w, "cannot fetch trace", http.StatusInternalServerError)
+			return
+		}
+		w.Write(data) //nolint:errcheck // response write error
+	})
+	server := http.Server{Handler: mux}
+
+	// Repeatedly try to start a Perfetto HTTP server on port 9001. As long as
+	// we fail, it means that some other OS process is serving database
+	// traces on that port, and is serving "our" traces as well.
+	// TODO(spetrovic): With recent "purge" changes, this is no longer the case,
+	// as we now have a separate database for single, multi, and GKE-local
+	// deployers. We should fix this, possibly by using these instructions [1].
+	//
+	// [1]: https://perfetto.dev/docs/visualization/deep-linking-to-perfetto-ui
+	ticker := time.NewTicker(time.Second)
+	var warnOnce sync.Once
+	for {
+		select {
+		case <-ticker.C:
+			lis, err := net.Listen("tcp", "localhost:9001")
+			if err != nil {
+				warnOnce.Do(func() {
+					fmt.Fprintf(os.Stderr, "Perfetto server failed to listen on port 9001: %v\n", err)
+					fmt.Fprintf(os.Stderr, "Perfetto server will retry until port 9001 is available\n")
+				})
+				continue
+			}
+
+			ticker.Stop()
+			err = server.Serve(lis)
+			if !errors.Is(err, http.ErrServerClosed) {
+				fmt.Fprintf(os.Stderr, "Failed to serve perfetto backend: %v\n", err)
+			}
+			return
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// fetchSpans retrieves and encodes the spans in a format that can be read
+// by the Perfetto UI.
+func fetchSpans(ctx context.Context, db *DB, traceID string) ([]byte, error) {
+	if traceID == "" {
+		return nil, fmt.Errorf("invalid trace id %q", traceID)
+	}
+	spans, err := db.FetchSpans(ctx, traceID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot fetch spans: %w", err)
+	}
+	if len(spans) == 0 {
+		return nil, fmt.Errorf("cannot find span")
+	}
+	data, err := encodeSpans(spans)
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode spans: %w", err)
+	}
+	return data, nil
+}
+
+// encodeSpans encodes the given spans in a format that can be read by the
+// Perfetto UI.
+func encodeSpans(spans []*protos.Span) ([]byte, error) {
+	var buf strings.Builder
+
+	// We are returning a JSON array, so surround everything in [].
+	buf.WriteByte('[')
+	addEvent := func(event []byte) {
+		if buf.Len() > 1 { // NOTE: buf always starts with a '['
+			buf.WriteByte(',')
+		}
+		buf.Write(event)
+	}
+	for _, span := range spans {
+		s := &ReadSpan{Span: span}
+		events, err := encodeSpanEvents(s)
+		if err != nil {
+			return nil, err
+		}
+		for _, event := range events {
+			addEvent(event)
+		}
+	}
+	buf.WriteByte(']')
+	return []byte(buf.String()), nil
+}
+
+// encodeSpanEvents encodes the given span into a series of Perfetto events.
+func encodeSpanEvents(span sdktrace.ReadOnlySpan) ([][]byte, error) {
+	var ret [][]byte
+	appendEvent := func(event any) error {
+		b, err := json.Marshal(event)
+		if err != nil {
+			return err
+		}
+		ret = append(ret, b)
+		return nil
+	}
+
+	// Extract information from the span attributes.
+	var pid int
+	var weaveletId string
+	for _, a := range span.Resource().Attributes() {
+		switch a.Key {
+		case semconv.ProcessPIDKey:
+			pid = int(a.Value.AsInt64())
+		case traceio.WeaveletIdTraceKey:
+			weaveletId = a.Value.AsString()
+		}
+	}
+
+	// The span name contains the name of the method that is called. Based
+	// on the span kind, we attach an additional label to identify whether
+	// the event happened at the client, server, or locally.
+	eventName := span.Name()
+	switch span.SpanKind() {
+	case trace.SpanKindServer:
+		eventName = eventName + " [server]"
+	case trace.SpanKindClient:
+		eventName = eventName + " [client]"
+	case trace.SpanKindInternal:
+		eventName = eventName + " [local]"
+	}
+
+	// Build the attributes map.
+	attrs := map[string]string{}
+	for _, a := range span.Attributes() {
+		attrs[string(a.Key)] = a.Value.Emit()
+	}
+
+	// Build the arguments.
+	args := map[string]map[string]string{
+		"ids": {
+			"spanID":        span.SpanContext().SpanID().String(),
+			"traceID":       span.SpanContext().TraceID().String(),
+			"parentSpanID":  span.Parent().SpanID().String(),
+			"parentTraceID": span.Parent().TraceID().String(),
+			"processID":     strconv.Itoa(pid),
+		},
+		"attributes": attrs,
+	}
+
+	// Generate a complete event and a series of metadata events.
+	weaveletFP := fp(weaveletId)
+
+	// Build two metadata events for each colocation group (one to replace the
+	// process name label and one for the thread name).
+	if err := appendEvent(&metadataEvent{
+		Ph:   "M", // make it a metadata event
+		Name: "process_name",
+		Cat:  span.SpanKind().String(),
+		Pid:  weaveletFP,
+		Tid:  weaveletFP,
+		Args: map[string]string{"name": "Weavelet"},
+	}); err != nil {
+		return nil, err
+	}
+	if err := appendEvent(&metadataEvent{
+		Ph:   "M", // make it a metadata event
+		Name: "thread_name",
+		Cat:  span.SpanKind().String(),
+		Pid:  weaveletFP,
+		Tid:  weaveletFP,
+		Args: map[string]string{"name": "Weavelet"},
+	}); err != nil {
+		return nil, err
+	}
+
+	// Build a complete event.
+	if err := appendEvent(&completeEvent{
+		Ph:   "X", // make it a complete event
+		Name: eventName,
+		Cat:  span.SpanKind().String(),
+		Pid:  weaveletFP,
+		Tid:  weaveletFP,
+		Args: args,
+		Ts:   span.StartTime().UnixMicro(),
+		Dur:  span.EndTime().UnixMicro() - span.StartTime().UnixMicro(),
+	}); err != nil {
+		return nil, err
+	}
+
+	// For each span event, create a corresponding metadata event.
+	for _, e := range span.Events() {
+		attrs := map[string]string{}
+		for _, a := range e.Attributes {
+			attrs[string(a.Key)] = a.Value.Emit()
+		}
+		if err := appendEvent(&metadataEvent{
+			Ph:   "M", // make it a metadata event
+			Name: e.Name,
+			Cat:  span.SpanKind().String(),
+			Pid:  weaveletFP,
+			Tid:  weaveletFP,
+			Args: attrs,
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return ret, nil
+}
+
+// completeEvent renders a Perfetto event that contains a start time and a
+// duration.
+type completeEvent struct {
+	Ph   string                       `json:"ph"`   // the event type
+	Name string                       `json:"name"` // name of the event
+	Cat  string                       `json:"cat"`  // category of the event
+	Pid  int                          `json:"pid"`  // the id of the process that output the event
+	Tid  int                          `json:"tid"`  // the thread id of the thread that output the event
+	Ts   int64                        `json:"ts"`   // start time of the event
+	Dur  int64                        `json:"dur"`  // duration of the event
+	Args map[string]map[string]string `json:"args"` // arguments provided for the event
+}
+
+// metadataEvent renders a Perfetto event that contains metadata information
+// for a completeEvent.
+type metadataEvent struct {
+	Ph   string            `json:"ph"`   // the event type
+	Name string            `json:"name"` // name of the event
+	Cat  string            `json:"cat"`  // category of the event
+	Pid  int               `json:"pid"`  // the id of the process that output the event
+	Tid  int               `json:"tid"`  // the thread id of the thread that output the event
+	Args map[string]string `json:"args"` // arguments provided for the event
+}
+
+func fp(name string) int {
+	hasher := sha256.New()
+	hasher.Write([]byte(name))
+	return int(binary.LittleEndian.Uint32(hasher.Sum(nil)))
+}

--- a/runtime/traces/read_span.go
+++ b/runtime/traces/read_span.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package traceio
+package traces
 
 import (
 	"math"
@@ -27,8 +27,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// ReadSpan is a wrapper around a Span that implements the sdk.ReadOnlySpan
-// interface.
+// ReadSpan is a wrapper around *protos.Span that implements the
+// Open Telemetry ReadOnlySpan interface.
 type ReadSpan struct {
 	sdk.ReadOnlySpan
 	Span *protos.Span
@@ -36,54 +36,87 @@ type ReadSpan struct {
 
 var _ sdk.ReadOnlySpan = &ReadSpan{}
 
+// Name implements the ReadOnlySpan interface.
 func (s *ReadSpan) Name() string {
 	return s.Span.Name
 }
+
+// SpanContext implements the ReadOnlySpan interface.
 func (s *ReadSpan) SpanContext() trace.SpanContext {
 	return fromProtoContext(s.Span.TraceId, s.Span.SpanId)
 }
+
+// Parent implements the ReadOnlySpan interface.
 func (s *ReadSpan) Parent() trace.SpanContext {
 	return fromProtoContext(s.Span.TraceId, s.Span.ParentSpanId)
 }
+
+// SpanKind implements the ReadOnlySpan interface.
 func (s *ReadSpan) SpanKind() trace.SpanKind {
 	return fromProtoKind(s.Span.Kind)
 }
+
+// StartTime implements the ReadOnlySpan interface.
 func (s *ReadSpan) StartTime() time.Time {
 	return time.UnixMicro(s.Span.StartMicros)
 }
+
+// EndTime implements the ReadOnlySpan interface.
 func (s *ReadSpan) EndTime() time.Time {
 	return time.UnixMicro(s.Span.EndMicros)
 }
+
+// Attributes implements the ReadOnlySpan interface.
 func (s *ReadSpan) Attributes() []attribute.KeyValue {
 	return fromProtoAttrs(s.Span.Attributes)
 }
+
+// Links implements the ReadOnlySpan interface.
 func (s *ReadSpan) Links() []sdk.Link {
 	return fromProtoLinks(s.Span.Links)
 }
+
+// Events implements the ReadOnlySpan interface.
 func (s *ReadSpan) Events() []sdk.Event {
 	return fromProtoEvents(s.Span.Events)
 }
+
+// Status implements the ReadOnlySpan interface.
 func (s *ReadSpan) Status() sdk.Status {
 	return fromProtoStatus(s.Span.Status)
 }
+
+// InstrumentationScope implements the ReadOnlySpan interface.
 func (s *ReadSpan) InstrumentationScope() instrumentation.Scope {
 	return fromProtoScope(s.Span.Scope)
 }
+
+// InstrumentationLibrary implements the ReadOnlySpan interface.
 func (s *ReadSpan) InstrumentationLibrary() instrumentation.Scope {
 	return fromProtoLibrary(s.Span.Library)
 }
+
+// Resource implements the ReadOnlySpan interface.
 func (s *ReadSpan) Resource() *resource.Resource {
 	return fromProtoResource(s.Span.Resource)
 }
+
+// DroppedAttributes implements the ReadOnlySpan interface.
 func (s *ReadSpan) DroppedAttributes() int {
 	return int(s.Span.DroppedAttributeCount)
 }
+
+// DroppedLinks implements the ReadOnlySpan interface.
 func (s *ReadSpan) DroppedLinks() int {
 	return int(s.Span.DroppedLinkCount)
 }
+
+// DroppedEvents implements the ReadOnlySpan interface.
 func (s *ReadSpan) DroppedEvents() int {
 	return int(s.Span.DroppedEventCount)
 }
+
+// ChildSpanCount implements the ReadOnlySpan interface.
 func (s *ReadSpan) ChildSpanCount() int {
 	return int(s.Span.ChildSpanCount)
 }


### PR DESCRIPTION
Some deployers may wish to use the trace database without relying on the Perfetto UI.

Other changes:
  * Move the ReadSpan into the traces/ package, as we now send the proto across the wire, and some deployers (e.g,. GKE, Kube) will want to convert back to the OTel ReadOnlySpan format.
  * Move the perfetto UI code into a separate file.
  * Minor cleanups.