### PR TITLE
Removed dependency on token package.

### DIFF
--- a/fill.go
+++ b/fill.go
@@ -102,7 +102,7 @@ func fillListeners(impl any, get func(name string) (net.Listener, string, error)
 		// The listener's name is the field name, unless a tag is present.
 		name := t.Name
 		if tag := t.Tag.Get("weaver"); tag != "" {
-			if !isIdentifier(tag) {
+			if !isValidListenerName(tag) {
 				return fmt.Errorf("FillListeners: listener tag %s is not a valid Go identifier", tag)
 			}
 			name = tag
@@ -123,11 +123,13 @@ func fillListeners(impl any, get func(name string) (net.Listener, string, error)
 	return nil
 }
 
-// isIdentifier returns whether the provided string is a valid Go identifier,
-// including keywords. It is taken from [1].
-//
-// [1]: https://cs.opensource.google/go/go/+/refs/tags/go1.20.6:src/go/token/token.go;l=331-341;drc=19309779ac5e2f5a2fd3cbb34421dafb2855ac21
-func isIdentifier(name string) bool {
+// isValidListenerName returns whether the provided name is a valid
+// weaver.Listener name.
+func isValidListenerName(name string) bool {
+	// We allow valid Go identifiers [1]. This code is taken from [2].
+	//
+	// [1]: https://go.dev/ref/spec#Identifiers
+	// [2]: https://cs.opensource.google/go/go/+/refs/tags/go1.20.6:src/go/token/token.go;l=331-341;drc=19309779ac5e2f5a2fd3cbb34421dafb2855ac21
 	if name == "" {
 		return false
 	}

--- a/fill.go
+++ b/fill.go
@@ -16,9 +16,9 @@ package weaver
 
 import (
 	"fmt"
-	"go/token"
 	"net"
 	"reflect"
+	"unicode"
 
 	"github.com/ServiceWeaver/weaver/internal/reflection"
 	"github.com/ServiceWeaver/weaver/internal/weaver"
@@ -102,7 +102,7 @@ func fillListeners(impl any, get func(name string) (net.Listener, string, error)
 		// The listener's name is the field name, unless a tag is present.
 		name := t.Name
 		if tag := t.Tag.Get("weaver"); tag != "" {
-			if !token.IsIdentifier(tag) {
+			if !isIdentifier(tag) {
 				return fmt.Errorf("FillListeners: listener tag %s is not a valid Go identifier", tag)
 			}
 			name = tag
@@ -121,6 +121,22 @@ func fillListeners(impl any, get func(name string) (net.Listener, string, error)
 		l.proxyAddr = proxyAddr
 	}
 	return nil
+}
+
+// isIdentifier returns whether the provided string is a valid Go identifier,
+// including keywords. It is taken from [1].
+//
+// [1]: https://cs.opensource.google/go/go/+/refs/tags/go1.20.6:src/go/token/token.go;l=331-341;drc=19309779ac5e2f5a2fd3cbb34421dafb2855ac21
+func isIdentifier(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, c := range name {
+		if !unicode.IsLetter(c) && c != '_' && (i == 0 || !unicode.IsDigit(c)) {
+			return false
+		}
+	}
+	return true
 }
 
 // setPossiblyUnexported sets dst to value. It is equivalent to

--- a/godeps.txt
+++ b/godeps.txt
@@ -9,7 +9,6 @@ github.com/ServiceWeaver/weaver
     github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/codegen
     go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
-    go/token
     golang.org/x/exp/slog
     math/rand
     net
@@ -19,6 +18,7 @@ github.com/ServiceWeaver/weaver
     sync
     sync/atomic
     time
+    unicode
 github.com/ServiceWeaver/weaver/cmd/weaver
     context
     errors

--- a/weaver.go
+++ b/weaver.go
@@ -298,10 +298,11 @@ func (r Ref[T]) isRef() {}
 //	    myOtherListener weaver.Listener `weaver:"mylistener2"`
 //	}
 //
-// Listener names must be unique inside a given application binary, regardless
-// of which components they are specified in. For example, it is illegal to
-// declare a Listener field "foo" in two different component implementation
-// structs, unless one is renamed using the `weaver:"name"` struct tag.
+// Listener names must be valid Go identifier names. Listener names must be
+// unique inside a given application binary, regardless of which components
+// they are specified in. For example, it is illegal to declare a Listener
+// field "foo" in two different component implementation structs, unless one is
+// renamed using the `weaver:"name"` struct tag.
 //
 // HTTP servers constructed using this listener are expected to perform health
 // checks on the reserved HealthzURL path. (Note that this URL path is


### PR DESCRIPTION
This PR replaces token.IsIdentifier with a custom implementation to remove the dependency on the token package.

Note that this PR now allows listener names to be go keywords, but I think that's okay. I don't think we intended to disallow these names in the first place.