### PR TITLE
Moved WeaveletHandler to Serve method.

### DIFF
--- a/internal/envelope/conn/conn_test.go
+++ b/internal/envelope/conn/conn_test.go
@@ -118,11 +118,11 @@ func makeConnections(t *testing.T, handler conn.EnvelopeHandler) (*conn.Envelope
 	weaveletDone := make(chan error)
 	go func() {
 		var err error
-		if w, err = conn.NewWeaveletConn(wReader, wWriter, nil /*handler*/); err != nil {
+		if w, err = conn.NewWeaveletConn(wReader, wWriter); err != nil {
 			panic(err)
 		}
 		created <- struct{}{}
-		err = w.Serve()
+		err = w.Serve(nil)
 		weaveletDone <- err
 
 	}()

--- a/internal/weaver/remoteweavelet.go
+++ b/internal/weaver/remoteweavelet.go
@@ -128,7 +128,7 @@ func NewRemoteWeavelet(ctx context.Context, regs []*codegen.Registration, bootst
 		return nil, err
 	}
 	// TODO(mwhittaker): Pass handler to Serve, not NewWeaveletConn.
-	w.conn, err = conn.NewWeaveletConn(toWeavelet, toEnvelope, w)
+	w.conn, err = conn.NewWeaveletConn(toWeavelet, toEnvelope)
 	if err != nil {
 		return nil, fmt.Errorf("new weavelet conn: %w", err)
 	}
@@ -174,7 +174,9 @@ func NewRemoteWeavelet(ctx context.Context, regs []*codegen.Registration, bootst
 	}
 
 	// Serve deployer API requests on the weavelet conn.
-	runAndDie(ctx, "serve weavelet conn", w.conn.Serve)
+	runAndDie(ctx, "serve weavelet conn", func() error {
+		return w.conn.Serve(w)
+	})
 
 	// Serve RPC requests from other weavelets.
 	server := &server{Listener: w.conn.Listener(), wlet: w}

--- a/runtime/envelope/envelope_test.go
+++ b/runtime/envelope/envelope_test.go
@@ -86,7 +86,7 @@ func TestMain(m *testing.M) {
 				return nil
 			},
 			"writetraces": func() error { return writeTraces(conn) },
-			"serve_conn":  func() error { return conn.Serve() },
+			"serve_conn":  func() error { return conn.Serve(nil) },
 		}
 		fn, ok := cmds[cmd]
 		if !ok {
@@ -99,7 +99,7 @@ func TestMain(m *testing.M) {
 			fmt.Fprintf(os.Stderr, "subprocess: %v\n", err)
 			os.Exit(1)
 		}
-		conn.Serve()
+		conn.Serve(nil)
 	}
 
 	var err error
@@ -335,7 +335,7 @@ func createWeaveletConn() (*conn.WeaveletConn, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable make weavelet<->envelope pipes: %w", err)
 	}
-	return conn.NewWeaveletConn(toWeavelet, toEnvelope, nil /*handler*/)
+	return conn.NewWeaveletConn(toWeavelet, toEnvelope)
 }
 
 func writeTraces(conn *conn.WeaveletConn) error {


### PR DESCRIPTION
This PR moves the WeaveletHandler argument from the NewWeaveletConn constructor to the Serve method. This avoids an awkwardness we used to have where a handler was passed to NewWeaveletConn, but the handler itself needed the returned conn.