### PR TITLE
Example image name for kube to collatz

### DIFF
--- a/examples/collatz/weaver.toml
+++ b/examples/collatz/weaver.toml
@@ -18,3 +18,5 @@ listeners.collatz = {public_hostname = "collatz.example.com"}
 
 [kube]
 listeners.collatz = {public = true}
+# To upload the image to another registry, check `weaver kube deploy -h`.
+image = "docker.io/my_docker_hub_username/collatz"


### PR DESCRIPTION
I find it confusing to run the kube deployer, given that we don't have an example on how to set the image name, unless we run `weaver kube deploy -h`.