### PR TITLE
Display Perfetto UI from JavaScript.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -455,6 +455,7 @@ github.com/ServiceWeaver/weaver/internal/status
     github.com/ServiceWeaver/weaver/runtime/colors
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/metrics
+    github.com/ServiceWeaver/weaver/runtime/perfetto
     github.com/ServiceWeaver/weaver/runtime/prometheus
     github.com/ServiceWeaver/weaver/runtime/protomsg
     github.com/ServiceWeaver/weaver/runtime/protos
@@ -472,7 +473,6 @@ github.com/ServiceWeaver/weaver/internal/status
     io
     net
     net/http
-    net/url
     os
     path/filepath
     reflect
@@ -863,6 +863,18 @@ github.com/ServiceWeaver/weaver/runtime/metrics
     sync/atomic
     unicode
     unicode/utf8
+github.com/ServiceWeaver/weaver/runtime/perfetto
+    crypto/sha256
+    encoding/binary
+    encoding/json
+    github.com/ServiceWeaver/weaver/internal/traceio
+    github.com/ServiceWeaver/weaver/runtime/protos
+    github.com/ServiceWeaver/weaver/runtime/traces
+    go.opentelemetry.io/otel/sdk/trace
+    go.opentelemetry.io/otel/semconv/v1.4.0
+    go.opentelemetry.io/otel/trace
+    strconv
+    strings
 github.com/ServiceWeaver/weaver/runtime/profiling
     bytes
     errors
@@ -925,14 +937,10 @@ github.com/ServiceWeaver/weaver/runtime/tool
 github.com/ServiceWeaver/weaver/runtime/traces
     bytes
     context
-    crypto/sha256
     database/sql
-    encoding/binary
     encoding/hex
-    encoding/json
     errors
     fmt
-    github.com/ServiceWeaver/weaver/internal/traceio
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/ServiceWeaver/weaver/runtime/retry
     go.opentelemetry.io/otel/attribute
@@ -940,19 +948,14 @@ github.com/ServiceWeaver/weaver/runtime/traces
     go.opentelemetry.io/otel/sdk/instrumentation
     go.opentelemetry.io/otel/sdk/resource
     go.opentelemetry.io/otel/sdk/trace
-    go.opentelemetry.io/otel/semconv/v1.4.0
     go.opentelemetry.io/otel/trace
     google.golang.org/protobuf/proto
     math
     modernc.org/sqlite
     modernc.org/sqlite/lib
-    net
     net/http
     os
     path/filepath
-    strconv
-    strings
-    sync
     time
 github.com/ServiceWeaver/weaver/runtime/version
     fmt

--- a/internal/status/templates/traces.html
+++ b/internal/status/templates/traces.html
@@ -38,46 +38,83 @@
   <header class="navbar">
     <a href="/">{{.Tool}} dashboard</a>
   </header>
-
+  <script type="text/javascript">
+    // The code below largely taken from:
+    //   https://perfetto.dev/docs/visualization/deep-linking-to-perfetto-ui
+    const ORIGIN = 'https://ui.perfetto.dev';
+    
+    async function fetchAndOpen(traceUrl) {
+      const resp = await fetch(traceUrl);
+      const blob = await resp.blob();
+      const arrayBuffer = await blob.arrayBuffer();
+      openTrace(arrayBuffer, traceUrl);
+    }
+    
+    function openTrace(arrayBuffer, traceId, traceUrl) {
+      const win = window.open(ORIGIN);
+      if (!win) {
+        alert('Popups blocked. Please allow popups in order to be able to' +
+              'see traces');
+      }
+      const timer = setInterval(() => win.postMessage('PING', ORIGIN), 50);
+      const onMessageHandler = (evt) => {
+        if (evt.data !== 'PONG') return;
+    
+        // We got a PONG, the UI is ready.
+        window.clearInterval(timer);
+        window.removeEventListener('message', onMessageHandler);
+    
+        const reopenUrl = new URL(location.href);
+        reopenUrl.hash = `#reopen=${traceUrl}`;
+        win.postMessage({
+          perfetto: {
+            buffer: arrayBuffer,
+            title: 'Trace Id ' + traceId,
+            url: reopenUrl.toString(),
+        }}, ORIGIN);
+      };
+    
+      window.addEventListener('message', onMessageHandler);
+    }
+  </script>
   <div class="container">
-    <div class="card">
-      <div class="card-title">Traces</div>
-      <div class="card-body">
-        <table id = buckets class = "data-table">
-            <tbody>
-                <tr>
-                    <td><a href="/traces?id={{.ID}}&lat_hi=1ms">0-1ms</a></td>
-                    <td><a href="/traces?id={{.ID}}&lat_low=1ms&lat_hi=10ms">1-10ms</a></td>
-                    <td><a href="/traces?id={{.ID}}&lat_low=10ms&lat_hi=100ms">10-100ms</a></td>
-                    <td><a href="/traces?id={{.ID}}&lat_low=100ms&lat_hi=1s">100ms-1s</a></td>
-                    <td><a href="/traces?id={{.ID}}&lat_low=1s&lat_hi=10s">1-10s</a></td>
-                    <td><a href="/traces?id={{.ID}}">all</a></td>
-                    <td><a href="/traces?id={{.ID}}&errs=true">errors</a></td>
-                </tr>
-            </tbody>
-        </table>
-        <br>
-        <table id="traces" class="data-table">
-          <thead>
+  <div class="card">
+    <div class="card-title">Traces</div>
+    <div class="card-body">
+    <table id = buckets class = "data-table">
+        <tbody>
             <tr>
-              <th scope="col">Trace URL</th>
-              <th scope="col">Start Time</th>
-              <th scope="col">Latency</th>
-              <th scope="col">Status</th>
+                <td><a href="/traces?id={{.ID}}&lat_hi=1ms">0-1ms</a></td>
+                <td><a href="/traces?id={{.ID}}&lat_low=1ms&lat_hi=10ms">1-10ms</a></td>
+                <td><a href="/traces?id={{.ID}}&lat_low=10ms&lat_hi=100ms">10-100ms</a></td>
+                <td><a href="/traces?id={{.ID}}&lat_low=100ms&lat_hi=1s">100ms-1s</a></td>
+                <td><a href="/traces?id={{.ID}}&lat_low=1s&lat_hi=10s">1-10s</a></td>
+                <td><a href="/traces?id={{.ID}}">all</a></td>
+                <td><a href="/traces?id={{.ID}}&errs=true">errors</a></td>
             </tr>
-          </thead>
-          <tbody>
-            {{range .Traces}}
-              <tr>
-                <td><a href="{{traceurl .TraceID}}">link</a></td>
-                <td>{{.StartTime}}</td>
-                <td>{{sub .EndTime .StartTime}}</td>
-                <td>{{.Status}}</td>
-              </tr>
-            {{end}}
-          </tbody>
-        </table>
-      </div>
+        </tbody>
+    </table>
+    <br>
+    <table id="traces" class="data-table">
+        <thead>
+        <tr>
+            <th scope="col">Trace URL</th>
+            <th scope="col">Start Time</th>
+            <th scope="col">Latency</th>
+            <th scope="col">Status</th>
+        </tr>
+        </thead>
+        <tbody>
+        {{range .Traces}}
+            <tr>
+            <td><a href="javascript:fetchAndOpen('/tracefetch?trace_id={{.TraceID}}')">link</a></td>
+            <td>{{.StartTime}}</td>
+            <td>{{sub .EndTime .StartTime}}</td>
+            <td>{{.Status}}</td>
+            </tr>
+        {{end}}
+        </tbody>
+    </table>
     </div>
   </div>
 </body>

--- a/internal/status/templates/traces.html
+++ b/internal/status/templates/traces.html
@@ -55,6 +55,7 @@
       if (!win) {
         alert('Popups blocked. Please allow popups in order to be able to' +
               'see traces');
+        return
       }
       const timer = setInterval(() => win.postMessage('PING', ORIGIN), 50);
       const onMessageHandler = (evt) => {

--- a/runtime/perfetto/perfetto.go
+++ b/runtime/perfetto/perfetto.go
@@ -12,119 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package traces
+// Package perfetto provides utilities for encoding trace spans in a format that
+// can be read by the Perfetto UI.
+package perfetto
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"net"
-	"net/http"
-	"os"
 	"strconv"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/ServiceWeaver/weaver/internal/traceio"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
+	"github.com/ServiceWeaver/weaver/runtime/traces"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
-// ServePerfetto runs an HTTP server that serves traces stored in the database
-// to the Chrome Browser's Perfetto UI.
-//
-// In order to view the traces, open the following URL in a Chrome browser:
-//
-//	https://ui.perfetto.dev/#!/?url=http://<hostname>:9001?trace_id=<trace_id>
-//
-// , where <hostname> is the hostname of the machine running this server
-// (e.g., "127.0.0.1"), and <trace_id> is the trace ID in hexadecimal format.
-//
-// Perfetto UI requires that the server runs on local port 9001. For that
-// reason, this method will block until port 9001 becomes available.
-func ServePerfetto(ctx context.Context, db *DB) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte("OK")) //nolint:errcheck // response write error
-	})
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// Set access control according to:
-		//   https://perfetto.dev/docs/visualization/deep-linking-to-perfetto-ui.
-		w.Header().Set("Access-Control-Allow-Origin", "https://ui.perfetto.dev")
-		traceID := r.URL.Query().Get("trace_id")
-		data, err := fetchSpans(r.Context(), db, traceID)
-		if err != nil {
-			http.Error(w, "cannot fetch trace", http.StatusInternalServerError)
-			return
-		}
-		w.Write(data) //nolint:errcheck // response write error
-	})
-	server := http.Server{Handler: mux}
-
-	// Repeatedly try to start a Perfetto HTTP server on port 9001. As long as
-	// we fail, it means that some other OS process is serving database
-	// traces on that port, and is serving "our" traces as well.
-	// TODO(spetrovic): With recent "purge" changes, this is no longer the case,
-	// as we now have a separate database for single, multi, and GKE-local
-	// deployers. We should fix this, possibly by using these instructions [1].
-	//
-	// [1]: https://perfetto.dev/docs/visualization/deep-linking-to-perfetto-ui
-	ticker := time.NewTicker(time.Second)
-	var warnOnce sync.Once
-	for {
-		select {
-		case <-ticker.C:
-			lis, err := net.Listen("tcp", "localhost:9001")
-			if err != nil {
-				warnOnce.Do(func() {
-					fmt.Fprintf(os.Stderr, "Perfetto server failed to listen on port 9001: %v\n", err)
-					fmt.Fprintf(os.Stderr, "Perfetto server will retry until port 9001 is available\n")
-				})
-				continue
-			}
-
-			ticker.Stop()
-			err = server.Serve(lis)
-			if !errors.Is(err, http.ErrServerClosed) {
-				fmt.Fprintf(os.Stderr, "Failed to serve perfetto backend: %v\n", err)
-			}
-			return
-
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-// fetchSpans retrieves and encodes the spans in a format that can be read
-// by the Perfetto UI.
-func fetchSpans(ctx context.Context, db *DB, traceID string) ([]byte, error) {
-	if traceID == "" {
-		return nil, fmt.Errorf("invalid trace id %q", traceID)
-	}
-	spans, err := db.FetchSpans(ctx, traceID)
-	if err != nil {
-		return nil, fmt.Errorf("cannot fetch spans: %w", err)
-	}
-	if len(spans) == 0 {
-		return nil, fmt.Errorf("cannot find span")
-	}
-	data, err := encodeSpans(spans)
-	if err != nil {
-		return nil, fmt.Errorf("cannot encode spans: %w", err)
-	}
-	return data, nil
-}
-
-// encodeSpans encodes the given spans in a format that can be read by the
+// EncodeSpans encodes the given spans in a format that can be read by the
 // Perfetto UI.
-func encodeSpans(spans []*protos.Span) ([]byte, error) {
+func EncodeSpans(spans []*protos.Span) ([]byte, error) {
 	var buf strings.Builder
 
 	// We are returning a JSON array, so surround everything in [].
@@ -136,7 +45,7 @@ func encodeSpans(spans []*protos.Span) ([]byte, error) {
 		buf.Write(event)
 	}
 	for _, span := range spans {
-		s := &ReadSpan{Span: span}
+		s := &traces.ReadSpan{Span: span}
 		events, err := encodeSpanEvents(s)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This fixes the issue where the Perfetto server has to run on port 9001 and serve traces on the "/" path.

Now, the dashboard serves traces on its local server. This simplifies trace serving and allows multiple
dashboard commands to serve traces independently.

Other changes:
  * Moved the perfetto code into a separate runtime package.

[cast2.webm](https://github.com/ServiceWeaver/weaver/assets/5449850/ced37aae-83e3-4054-ba65-c949a3f37e0c)
