### PR TITLE
Dim attributes in pretty printed logs.

### DIFF
--- a/runtime/logging/pretty.go
+++ b/runtime/logging/pretty.go
@@ -28,9 +28,10 @@ import (
 )
 
 var (
-	dimColor      = colors.Color256(245) // dimmed text color (a light gray)
-	errorColor    = colors.Color256(9)   // error color (a light red)
-	attrNameColor = colors.Color256(141) // attribute name color (a light purple))
+	dimColor       = colors.Color256(245) // dimmed text color (a light gray)
+	errorColor     = colors.Color256(9)   // error color (a light red)
+	attrNameColor  = colors.Color256(245) // attribute name color (a light gray)
+	attrValueColor = colors.Color256(245) // attribute name color (a light gray)
 )
 
 // PrettyPrinter pretty prints log entries. You can safely use a PrettyPrinter
@@ -191,8 +192,8 @@ func (pp *PrettyPrinter) Format(e *protos.LogEntry) string {
 
 		for _, attr := range attrs {
 			pp.b.WriteString(" ")
-			pp.b.WriteString(pp.colorize(attrNameColor, attr.name))
-			fmt.Fprintf(&pp.b, "=%q", attr.value)
+			pp.b.WriteString(pp.colorize(attrNameColor, attr.name+"="))
+			pp.b.WriteString(pp.colorize(attrValueColor, fmt.Sprintf("%q", attr.value)))
 		}
 	}
 


### PR DESCRIPTION
Before this PR, log attribute names were purple and attribute values were white. This PR dims both a light gray. This draws more attention to the body of the log compared to the attributes.

I think we were also putting way too much stuff in the attributes which was making the logs hard to read. In theory, you can use attributes to query logs, but I don't think we ever did this. And even if we did, the attributes we had were awkward to query.

| Before | After |
| - | - |
| ![not_dimmed](https://github.com/ServiceWeaver/weaver/assets/3654277/44f07fc9-b6cd-4a80-99f2-b7b27da6033b) | ![dimmed](https://github.com/ServiceWeaver/weaver/assets/3654277/73fe89e1-1fb1-4e8f-9c37-739653af4423) |
