### PR TITLE
Color log messages based on component.

### DIFF
--- a/runtime/logging/pretty.go
+++ b/runtime/logging/pretty.go
@@ -175,7 +175,7 @@ func (pp *PrettyPrinter) Format(e *protos.LogEntry) string {
 
 	// Write the message.
 	pp.b.WriteString("] ")
-	pp.b.WriteString(pp.colorize(levelColor, e.Msg))
+	pp.b.WriteString(pp.colorize(colors.ColorHash(c), e.Msg))
 
 	// Write the attributes, if present.
 	if len(e.Attrs) > 0 {


### PR DESCRIPTION

Before this PR, log messages were printed white. This PR changes them to show in the same color as the component. I think this makes the logs look uglier, but it is useful to be able to visually track the logs from a particular weavelet or component.

| Before | After |
| - | - |
| ![dimmed](https://github.com/ServiceWeaver/weaver/assets/3654277/751be352-9cbd-4e52-bb51-d7bdc1bb413b) | ![colored](https://github.com/ServiceWeaver/weaver/assets/3654277/de6bc8ec-00d6-47de-a85b-22166a3dcbb2) |
