### PR TITLE
Fix race in weavertest multi shutdown.

### DIFF
--- a/weavertest/internal/generate/app_test.go
+++ b/weavertest/internal/generate/app_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ServiceWeaver/weaver"
 	"github.com/ServiceWeaver/weaver/weavertest"
@@ -64,6 +65,9 @@ func TestErrors(t *testing.T) {
 		if err == nil || !errors.Is(err, weaver.RemoteCallError) {
 			t.Fatalf("expected a weaver.RemoteCallError; got: %v", err)
 		}
+		// Delay a little bit to capture a potential shutdown race caused
+		// when the process hosting the remote component exits.
+		time.Sleep(100 * time.Millisecond)
 	})
 }
 


### PR DESCRIPTION
Previously, if a remote weavelet paniced, it's exit raced with weavertest cleanup. If the code reading from the remote weavelet detected the broken connection before weavertest got a chance to mark the test as done, we would print an error message and exit the test process. This interacted poorly with the weavertest/internal/generate test that intentionally triggers a panic in a remote component.

We now just log the error and do not exit. Furthermore, the message is written to the system logger, not to stderr, so it is suppressed unless -test.v is supplied.

Made the race more likely to be triggered by putting a short sloop in the test that triggers a remote panic.