### PR TITLE
Improve call.go logging and errors.

### DIFF
--- a/internal/net/call/call_test.go
+++ b/internal/net/call/call_test.go
@@ -986,7 +986,8 @@ func TestCloseDraining(t *testing.T) {
 		t.Fatalf("bad error: got %v, want %v", err, call.CommunicationError)
 	}
 
-	// Make sure the connection was closed.
+	// Make sure the connection is closed soon.
+	time.Sleep(shortDelay)
 	if !m.Closed() {
 		t.Fatalf("draining connection not closed")
 	}


### PR DESCRIPTION
* Pass appropriate details to endCalls for better call failure errors.
* Drop connection and balancer addresses from log messages. These were intended to be temporary debugging aids.