### PR TITLE
Validate registrations when app is launched.

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,59 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package weaver
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/ServiceWeaver/weaver/internal/reflection"
+	"github.com/ServiceWeaver/weaver/runtime/codegen"
+)
+
+// validateRegistrations validates the provided registrations, returning an
+// diagnostic error if they are invalid. Note that some validation is performed
+// by 'weaver generate', but because users can run a Service Weaver app after
+// forgetting to run 'weaver generate', some checks have to be done at runtime.
+func validateRegistrations(regs []*codegen.Registration) error {
+	// Gather the set of registered interfaces.
+	intfs := map[reflect.Type]struct{}{}
+	for _, reg := range regs {
+		intfs[reg.Iface] = struct{}{}
+	}
+
+	// Check that for every weaver.Ref[T] field in a component implementation
+	// struct, T is a registered interface.
+	var errs []error
+	for _, reg := range regs {
+		for i := 0; i < reg.Impl.NumField(); i++ {
+			f := reg.Impl.Field(i)
+			if !f.Type.Implements(reflection.Type[interface{ isRef() }]()) {
+				// f is not a Ref[T].
+				continue
+			}
+			v := f.Type.Field(0) // a Ref[T]'s value field
+			if _, ok := intfs[v.Type]; !ok {
+				// T is not a registered component interface.
+				err := fmt.Errorf(
+					"component implementation struct %v has field %v, but component %v was not registered; maybe you forgot to run 'weaver generate'",
+					reg.Impl, f.Type, v.Type,
+				)
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,78 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package weaver
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/ServiceWeaver/weaver/internal/reflection"
+	"github.com/ServiceWeaver/weaver/runtime/codegen"
+)
+
+// TestValidateNoRegistrations tests that validateRegistrations succeeds on an
+// empty set of registrations.
+func TestValidateNoRegistrations(t *testing.T) {
+	if err := validateRegistrations(nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestValidateValidRegistrations tests that validateRegistrations succeeds on
+// a set of valid registrations.
+func TestValidateValidRegistrations(t *testing.T) {
+	type foo struct{}
+	type bar struct{}
+	type fooImpl struct{ b Ref[bar] }
+	type barImpl struct{ f Ref[foo] }
+	regs := []*codegen.Registration{
+		{
+			Name:  "foo",
+			Iface: reflection.Type[foo](),
+			Impl:  reflection.Type[fooImpl](),
+		},
+		{
+			Name:  "bar",
+			Iface: reflection.Type[bar](),
+			Impl:  reflection.Type[barImpl](),
+		},
+	}
+	if err := validateRegistrations(regs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestValidateUnregisteredRef tests that validateRegistrations fails when a
+// component has a weaver.Ref on an unregistered component.
+func TestValidateUnregisteredRef(t *testing.T) {
+	type foo struct{}
+	type fooImpl struct{ unregistered Ref[io.Reader] }
+	regs := []*codegen.Registration{
+		{
+			Name:  "foo",
+			Iface: reflection.Type[foo](),
+			Impl:  reflection.Type[fooImpl](),
+		},
+	}
+	err := validateRegistrations(regs)
+	if err == nil {
+		t.Fatal("unexpected validateRegistrations success")
+	}
+	const want = "component io.Reader was not registered"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("validateRegistrations: got %q, want %q", err, want)
+	}
+}

--- a/weaver.go
+++ b/weaver.go
@@ -157,6 +157,10 @@ func runLocal[T any, _ PointerToMain[T]](ctx context.Context, app func(context.C
 	}
 
 	regs := codegen.Registered()
+	if err := validateRegistrations(regs); err != nil {
+		return err
+	}
+
 	runner, err := weaver.NewSingleWeavelet(ctx, regs, opts)
 	if err != nil {
 		return err
@@ -177,6 +181,10 @@ func runLocal[T any, _ PointerToMain[T]](ctx context.Context, app func(context.C
 
 func runRemote[T any, _ PointerToMain[T]](ctx context.Context, app func(context.Context, *T) error, bootstrap runtime.Bootstrap) error {
 	regs := codegen.Registered()
+	if err := validateRegistrations(regs); err != nil {
+		return err
+	}
+
 	opts := weaver.RemoteWeaveletOptions{}
 	runner, err := weaver.NewRemoteWeavelet(ctx, regs, bootstrap, opts)
 	if err != nil {


### PR DESCRIPTION
This PR introduces a `validateRegistrations` function that checks the validity of component registrations. For now, it simply checks that every `weaver.Ref[T]` field refers to a registered component interface `T`. This mistake is actually quite common, when you add a component and forget to run `weaver generate`.

Before this PR, if a non-main component had a `weaver.Ref[T]` to an unregistered component, the app would run but silently not work. With this change, all weavelets will imediately crash, and for `go run .` and `weaver multi deploy`, the app will terminate immediately with a helpful error message:

```shell
$ weaver multi deploy weaver.toml
start main process: NewEnvelope: connect to weavelet: read protobuf
length: EOF
-----BEGIN STDERR-----
2023/08/04 13:31:50 component implementation struct main.odd has field
weaver.Ref[main.this_is_not_a_registered_component], but component
main.this_is_not_a_registered_component was not registered; maybe you
forgot to run 'weaver generate'

-----END STDERR-----
exit status 1
```

## Alternatives

Srdjan had a great idea of checking the validity of `weaver.Ref[T]`s at compile time, but I couldn't think of any way to do that. If we do think of something, we should switch to it.

I did have one idea that turned out to be terrible. We could require users to embed a special `weaver.Interface` interace into their component interfaces:

```go
// In weaver package.
type Interface interface { isComponentInterface() }
type Ref[T Interface] struct { ... }
type Implements[T Interface] struct { ... }
func (Implements[T]) isComponentInterface()

// In user's code.
type ExampleComponent {
    weaver.Interface
    Foo(context.Context) error
}
```

This is not only ugly and super janky, it also doesn't work. It checks that a `weaver.Ref[T]` refers to a component interface `T`, but it doesn't check that `T` was actually registered.