### PR TITLE
Validate listener names at application startup.

### DIFF
--- a/fill.go
+++ b/fill.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net"
 	"reflect"
-	"unicode"
 
 	"github.com/ServiceWeaver/weaver/internal/reflection"
 	"github.com/ServiceWeaver/weaver/internal/weaver"
@@ -101,7 +100,7 @@ func fillListeners(impl any, get func(name string) (net.Listener, string, error)
 
 		// The listener's name is the field name, unless a tag is present.
 		name := t.Name
-		if tag := t.Tag.Get("weaver"); tag != "" {
+		if tag, ok := t.Tag.Lookup("weaver"); ok {
 			if !isValidListenerName(tag) {
 				return fmt.Errorf("FillListeners: listener tag %s is not a valid Go identifier", tag)
 			}
@@ -121,24 +120,6 @@ func fillListeners(impl any, get func(name string) (net.Listener, string, error)
 		l.proxyAddr = proxyAddr
 	}
 	return nil
-}
-
-// isValidListenerName returns whether the provided name is a valid
-// weaver.Listener name.
-func isValidListenerName(name string) bool {
-	// We allow valid Go identifiers [1]. This code is taken from [2].
-	//
-	// [1]: https://go.dev/ref/spec#Identifiers
-	// [2]: https://cs.opensource.google/go/go/+/refs/tags/go1.20.6:src/go/token/token.go;l=331-341;drc=19309779ac5e2f5a2fd3cbb34421dafb2855ac21
-	if name == "" {
-		return false
-	}
-	for i, c := range name {
-		if !unicode.IsLetter(c) && c != '_' && (i == 0 || !unicode.IsDigit(c)) {
-			return false
-		}
-	}
-	return true
 }
 
 // setPossiblyUnexported sets dst to value. It is equivalent to

--- a/website/docs.md
+++ b/website/docs.md
@@ -342,6 +342,10 @@ type app struct {
 }
 ```
 
+Listener names must be valid [Go identifiers][identifiers]. For example, the
+names `"foo"`, `"bar42"`, and `"_moo"` are legal, while `""`, `"foo bar"`, and
+`"foo-bar"` are illegal.
+
 Run `go mod tidy` and then `SERVICEWEAVER_CONFIG=weaver.toml go run .`.
 The program should print out the name of the application and a unique
 deployment id. It should then block serving HTTP requests on `localhost:12345`.
@@ -2969,6 +2973,7 @@ runtime benefits of microservices.
 [go_interfaces]: https://go.dev/tour/methods/9
 [hello_app]: https://github.com/ServiceWeaver/weaver/tree/main/examples/hello
 [http_pprof]: https://pkg.go.dev/net/http/pprof
+[identifiers]: https://go.dev/ref/spec#Identifiers
 [isolation]: https://sre.google/workbook/canarying-releases/#dependencies-and-isolation
 [kubernetes]: https://kubernetes.io/
 [logs_explorer]: https://cloud.google.com/logging/docs/view/logs-explorer-interface


### PR DESCRIPTION
This PR extends the `validateRegistrations` function to also validate listener names when a Service Weaver application begins. As with PR #500, this PR aims to catch permanent and easily avoidable programming errors immediately.

I also fixed a small bug in listener name validation. Previously, if a listener had a `weaver:""` annotation, it was being ignored. Now, it is being rejected (since `""` is not a valid listener name).

I also updated the website documentation to describe legal listener names.