### PR TITLE
Use new slog, slices, maps packages in Go 1.21.

### DIFF
--- a/examples/onlineboutique/adservice/service.go
+++ b/examples/onlineboutique/adservice/service.go
@@ -19,7 +19,7 @@ import (
 	"math/rand"
 	"strings"
 
-	"golang.org/x/exp/maps"
+	"maps"
 
 	"github.com/ServiceWeaver/weaver"
 	"go.opentelemetry.io/otel/attribute"

--- a/examples/onlineboutique/currencyservice/service.go
+++ b/examples/onlineboutique/currencyservice/service.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/ServiceWeaver/weaver"
 	"github.com/ServiceWeaver/weaver/examples/onlineboutique/types/money"
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 var (

--- a/examples/onlineboutique/frontend/handlers.go
+++ b/examples/onlineboutique/frontend/handlers.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ServiceWeaver/weaver/examples/onlineboutique/productcatalogservice"
 	"github.com/ServiceWeaver/weaver/examples/onlineboutique/shippingservice"
 	"github.com/ServiceWeaver/weaver/examples/onlineboutique/types/money"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 const (

--- a/examples/onlineboutique/frontend/middleware.go
+++ b/examples/onlineboutique/frontend/middleware.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type ctxKeyLogger struct{}

--- a/examples/onlineboutique/paymentservice/charge.go
+++ b/examples/onlineboutique/paymentservice/charge.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/ServiceWeaver/weaver/examples/onlineboutique/types/money"
 	"github.com/google/uuid"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type InvalidCreditCardErr struct{}

--- a/fill.go
+++ b/fill.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/ServiceWeaver/weaver/internal/reflection"
 	"github.com/ServiceWeaver/weaver/internal/weaver"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.16.0
 	go.opentelemetry.io/otel/sdk v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0
-	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/image v0.5.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/term v0.10.0
@@ -46,6 +45,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
+	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/godeps.txt
+++ b/godeps.txt
@@ -10,7 +10,7 @@ github.com/ServiceWeaver/weaver
     github.com/ServiceWeaver/weaver/runtime/codegen
     go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
     go.opentelemetry.io/otel/trace
-    golang.org/x/exp/slog
+    log/slog
     math/rand
     net
     net/http
@@ -157,7 +157,7 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique/adservice
     go.opentelemetry.io/otel/attribute
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
-    golang.org/x/exp/maps
+    maps
     math/rand
     reflect
     strings
@@ -200,7 +200,7 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique/currencyservice
     github.com/ServiceWeaver/weaver/runtime/codegen
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
-    golang.org/x/exp/maps
+    maps
     math
     reflect
     strconv
@@ -235,9 +235,9 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique/frontend
     github.com/ServiceWeaver/weaver/runtime/codegen
     github.com/google/uuid
     go.opentelemetry.io/otel/trace
-    golang.org/x/exp/slog
     html/template
     io/fs
+    log/slog
     math/rand
     net
     net/http
@@ -258,7 +258,7 @@ github.com/ServiceWeaver/weaver/examples/onlineboutique/paymentservice
     github.com/google/uuid
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
-    golang.org/x/exp/slog
+    log/slog
     reflect
     strings
     time
@@ -400,8 +400,8 @@ github.com/ServiceWeaver/weaver/internal/net/call
     github.com/ServiceWeaver/weaver/runtime/retry
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
-    golang.org/x/exp/slog
     io
+    log/slog
     net
     strings
     sync
@@ -418,7 +418,7 @@ github.com/ServiceWeaver/weaver/internal/proto
     google.golang.org/protobuf/proto
 github.com/ServiceWeaver/weaver/internal/proxy
     errors
-    golang.org/x/exp/slog
+    log/slog
     math/rand
     net/http
     net/http/httputil
@@ -435,8 +435,8 @@ github.com/ServiceWeaver/weaver/internal/register
 github.com/ServiceWeaver/weaver/internal/routing
     fmt
     github.com/ServiceWeaver/weaver/runtime/protos
-    golang.org/x/exp/slices
     math
+    slices
     sort
     strings
 github.com/ServiceWeaver/weaver/internal/status
@@ -461,20 +461,20 @@ github.com/ServiceWeaver/weaver/internal/status
     github.com/ServiceWeaver/weaver/runtime/traces
     github.com/google/pprof/profile
     github.com/pkg/browser
-    golang.org/x/exp/maps
-    golang.org/x/exp/slices
-    golang.org/x/exp/slog
     google.golang.org/protobuf/reflect/protoreflect
     google.golang.org/protobuf/runtime/protoimpl
     google.golang.org/protobuf/types/known/timestamppb
     html/template
     io
+    log/slog
+    maps
     net
     net/http
     os
     path/filepath
     reflect
     regexp
+    slices
     sort
     strings
     sync
@@ -492,7 +492,7 @@ github.com/ServiceWeaver/weaver/internal/tool/callgraph
     fmt
     github.com/ServiceWeaver/weaver/runtime/bin
     github.com/ServiceWeaver/weaver/runtime/logging
-    golang.org/x/exp/maps
+    maps
     sort
     strings
 github.com/ServiceWeaver/weaver/internal/tool/certs
@@ -527,10 +527,10 @@ github.com/ServiceWeaver/weaver/internal/tool/generate
     go/parser
     go/token
     go/types
-    golang.org/x/exp/maps
     golang.org/x/tools/go/packages
     golang.org/x/tools/go/types/typeutil
     io
+    maps
     os
     path
     path/filepath
@@ -577,20 +577,20 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     github.com/ServiceWeaver/weaver/runtime/traces
     github.com/ServiceWeaver/weaver/runtime/version
     github.com/google/uuid
-    golang.org/x/exp/maps
-    golang.org/x/exp/slices
-    golang.org/x/exp/slog
     golang.org/x/sync/errgroup
     google.golang.org/protobuf/reflect/protoreflect
     google.golang.org/protobuf/runtime/protoimpl
     google.golang.org/protobuf/types/known/timestamppb
     io
+    log/slog
+    maps
     net
     net/http
     os
     os/signal
     path/filepath
     reflect
+    slices
     sync
     syscall
     time
@@ -635,8 +635,8 @@ github.com/ServiceWeaver/weaver/internal/tool/ssh
     github.com/ServiceWeaver/weaver/runtime/tool
     github.com/ServiceWeaver/weaver/runtime/version
     github.com/google/uuid
-    golang.org/x/exp/maps
     io
+    maps
     os
     os/exec
     os/signal
@@ -664,18 +664,18 @@ github.com/ServiceWeaver/weaver/internal/tool/ssh/impl
     github.com/ServiceWeaver/weaver/runtime/retry
     github.com/ServiceWeaver/weaver/runtime/traces
     github.com/google/uuid
-    golang.org/x/exp/maps
-    golang.org/x/exp/slices
-    golang.org/x/exp/slog
     google.golang.org/protobuf/reflect/protoreflect
     google.golang.org/protobuf/runtime/protoimpl
     google.golang.org/protobuf/types/known/timestamppb
+    log/slog
+    maps
     net
     net/http
     os
     os/exec
     path/filepath
     reflect
+    slices
     sync
     syscall
     time
@@ -727,10 +727,9 @@ github.com/ServiceWeaver/weaver/internal/weaver
     go.opentelemetry.io/otel/sdk/trace
     go.opentelemetry.io/otel/semconv/v1.4.0
     go.opentelemetry.io/otel/trace
-    golang.org/x/exp/maps
-    golang.org/x/exp/slices
-    golang.org/x/exp/slog
     google.golang.org/protobuf/types/known/timestamppb
+    log/slog
+    maps
     math
     math/rand
     net
@@ -739,6 +738,7 @@ github.com/ServiceWeaver/weaver/internal/weaver
     os/signal
     path/filepath
     reflect
+    slices
     sort
     strings
     sync
@@ -834,11 +834,11 @@ github.com/ServiceWeaver/weaver/runtime/logging
     github.com/google/cel-go/checker/decls
     github.com/google/cel-go/common/operators
     github.com/google/uuid
-    golang.org/x/exp/slog
     google.golang.org/genproto/googleapis/api/expr/v1alpha1
     google.golang.org/protobuf/proto
     google.golang.org/protobuf/types/known/timestamppb
     io
+    log/slog
     os
     path/filepath
     reflect
@@ -853,10 +853,10 @@ github.com/ServiceWeaver/weaver/runtime/metrics
     fmt
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/google/uuid
-    golang.org/x/exp/maps
-    golang.org/x/exp/slices
+    maps
     math
     reflect
+    slices
     sort
     sync
     sync/atomic
@@ -886,7 +886,7 @@ github.com/ServiceWeaver/weaver/runtime/prometheus
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/metrics
     github.com/ServiceWeaver/weaver/runtime/protos
-    golang.org/x/exp/maps
+    maps
     math
     sort
     strconv
@@ -899,9 +899,9 @@ github.com/ServiceWeaver/weaver/runtime/protomsg
     fmt
     github.com/ServiceWeaver/weaver/metrics
     github.com/ServiceWeaver/weaver/runtime/codegen
-    golang.org/x/exp/slog
     google.golang.org/protobuf/proto
     io
+    log/slog
     math
     net/http
     runtime/debug
@@ -971,13 +971,13 @@ github.com/ServiceWeaver/weaver/weavertest
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/protos
     github.com/google/uuid
-    golang.org/x/exp/maps
-    golang.org/x/exp/slices
     golang.org/x/sync/errgroup
+    maps
     os
     reflect
     regexp
     runtime
+    slices
     strings
     sync
     testing

--- a/internal/net/call/call.go
+++ b/internal/net/call/call.go
@@ -81,7 +81,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/retry"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 const (

--- a/internal/net/call/call_test.go
+++ b/internal/net/call/call_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type resolverMaker func(...call.Endpoint) call.Resolver

--- a/internal/net/call/options.go
+++ b/internal/net/call/options.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ServiceWeaver/weaver/internal/traceio"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 // ClientOptions are the options to configure an RPC client.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -21,7 +21,7 @@ import (
 	"net/http/httputil"
 	"sync"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 // Proxy is an HTTP proxy that forwards traffic to a set of backends.

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/ServiceWeaver/weaver/runtime/protos"
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // FormatAssignment pretty formats the provided assignment.

--- a/internal/status/metrics.go
+++ b/internal/status/metrics.go
@@ -27,8 +27,8 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	dtool "github.com/ServiceWeaver/weaver/runtime/tool"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
+	"maps"
+	"slices"
 )
 
 // MetricsCommand returns a "metrics" subcommand that pretty prints the metrics

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -23,7 +23,7 @@ import (
 	imetrics "github.com/ServiceWeaver/weaver/runtime/prometheus"
 	"github.com/ServiceWeaver/weaver/runtime/protomsg"
 	protos "github.com/ServiceWeaver/weaver/runtime/protos"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 const (

--- a/internal/tool/callgraph/callgraph.go
+++ b/internal/tool/callgraph/callgraph.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/ServiceWeaver/weaver/runtime/bin"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 // Mermaid returns a Mermaid diagram, https://mermaid.js.org/, of the component

--- a/internal/tool/generate/generator.go
+++ b/internal/tool/generate/generator.go
@@ -38,7 +38,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"github.com/ServiceWeaver/weaver/runtime/colors"
 	"github.com/ServiceWeaver/weaver/runtime/version"
-	"golang.org/x/exp/maps"
+	"maps"
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/types/typeutil"
 )

--- a/internal/tool/multi/deployer.go
+++ b/internal/tool/multi/deployer.go
@@ -40,9 +40,9 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/ServiceWeaver/weaver/runtime/traces"
 	"github.com/google/uuid"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
-	"golang.org/x/exp/slog"
+	"maps"
+	"slices"
+	"log/slog"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )

--- a/internal/tool/ssh/deploy.go
+++ b/internal/tool/ssh/deploy.go
@@ -30,7 +30,7 @@ import (
 	"syscall"
 
 	"github.com/google/uuid"
-	"golang.org/x/exp/maps"
+	"maps"
 
 	"github.com/ServiceWeaver/weaver/internal/tool/config"
 	"github.com/ServiceWeaver/weaver/internal/tool/ssh/impl"

--- a/internal/tool/ssh/impl/babysitter.go
+++ b/internal/tool/ssh/impl/babysitter.go
@@ -30,7 +30,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/ServiceWeaver/weaver/runtime/retry"
 	"github.com/google/uuid"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 // babysitter starts and manages weavelets belonging to a single colocation

--- a/internal/tool/ssh/impl/manager.go
+++ b/internal/tool/ssh/impl/manager.go
@@ -34,9 +34,9 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/ServiceWeaver/weaver/runtime/traces"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
-	"golang.org/x/exp/slog"
+	"maps"
+	"slices"
+	"log/slog"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/ServiceWeaver/weaver/internal/proto"

--- a/internal/weaver/remoteweavelet.go
+++ b/internal/weaver/remoteweavelet.go
@@ -38,9 +38,9 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/ServiceWeaver/weaver/runtime/retry"
 	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
-	"golang.org/x/exp/slog"
+	"maps"
+	"slices"
+	"log/slog"
 )
 
 // readyMethodKey holds the key for a method used to check if a backend is ready.

--- a/internal/weaver/singleweavelet.go
+++ b/internal/weaver/singleweavelet.go
@@ -43,7 +43,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/traces"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/exp/slog"
+	"log/slog"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/internal/weaver/types.go
+++ b/internal/weaver/types.go
@@ -18,7 +18,7 @@ import (
 	"net"
 	"reflect"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 var (

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"golang.org/x/exp/maps"
+	"maps"
 	"github.com/ServiceWeaver/weaver/metrics"
 	imetrics "github.com/ServiceWeaver/weaver/runtime/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/protos"

--- a/runtime/logging/logger.go
+++ b/runtime/logging/logger.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/colors"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/google/uuid"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 // Options configures the log entries produced by a logger.

--- a/runtime/logging/logger_test.go
+++ b/runtime/logging/logger_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 func TestTestLogger(t *testing.T) {

--- a/runtime/metrics/io.go
+++ b/runtime/metrics/io.go
@@ -19,7 +19,7 @@ import (
 	"math"
 
 	"github.com/ServiceWeaver/weaver/runtime/protos"
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 // An Exporter produces MetricUpdates summarizing the change in metrics over

--- a/runtime/metrics/metrics.go
+++ b/runtime/metrics/metrics.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/google/uuid"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
+	"maps"
+	"slices"
 )
 
 var (

--- a/runtime/prometheus/prometheus.go
+++ b/runtime/prometheus/prometheus.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 // escaper is used to format the labels according to [1]. Prometheus labels can

--- a/runtime/protomsg/handler.go
+++ b/runtime/protomsg/handler.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/ServiceWeaver/weaver/metrics"
-	"golang.org/x/exp/slog"
+	"log/slog"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/runtime/protomsg/handler_test.go
+++ b/runtime/protomsg/handler_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 func TestPanicHandler(t *testing.T) {

--- a/weaver.go
+++ b/weaver.go
@@ -38,7 +38,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 //go:generate ./dev/protoc.sh internal/status/status.proto

--- a/weavertest/deployer.go
+++ b/weavertest/deployer.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/envelope"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 	"github.com/google/uuid"
-	"golang.org/x/exp/maps"
+	"maps"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/weavertest/init.go
+++ b/weavertest/init.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ServiceWeaver/weaver/internal/weaver"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // Runner runs user-supplied testing code as a weaver application.


### PR DESCRIPTION
Go 1.21 was just released. This PR replaces our use of exp/slog, exp/slices, and exp/maps with the new log/slog, slices, and maps packages in the standard library.