### PR TITLE
Fixed RemoteWeavelet UpdateRoutingInfo bugs.

### DIFF
--- a/internal/testdeployer/remoteweavelet_test.go
+++ b/internal/testdeployer/remoteweavelet_test.go
@@ -516,8 +516,6 @@ func TestUpdateExistingComponents(t *testing.T) {
 }
 
 func TestUpdateNilRoutingInfo(t *testing.T) {
-	t.Skip("TODO(mwhittaker): Make this test pass.")
-
 	ctx := context.Background()
 	d := deploy(t, ctx)
 	go d.env.Serve(d)
@@ -571,8 +569,6 @@ func TestUpdateRoutingInfoNotStartedComponent(t *testing.T) {
 }
 
 func TestUpdateLocalRoutingInfoWithNonLocal(t *testing.T) {
-	t.Skip("TODO(mwhittaker): Make this test pass.")
-
 	ctx := context.Background()
 	d := deploy(t, ctx)
 	go d.env.Serve(d)


### PR DESCRIPTION
This PR fixes four bugs in RemoteWeavelet's UpdateRoutingInfo.

1. Before this PR, UpdateRoutingInfo would panic if you passed it a nil RoutingInfo. This PR fixes UpdateRoutingInfo to instead return an error.
2. Recall that a component is either always local or always remote. We don't currently allow a component to switch between the two. This PR adds code to UpdateRoutingInfo to check this.
3. Before this PR, we were using the assignment from one component as the assignment for all components' load collectors.
4. UpdateRoutingInfo updates a resolver, balancer, and load collector. Before this PR, it was possible to update the load collector but not the resolver or balancer. This PR reorders things so either all are updated or none of them are. The update is still not transactional, as concurrent calls to UpdateRoutingInfo can interleave. We should consider fixing that in a future PR.