### PR TITLE
Replaced os.Exit with RemoteWeavelet Wait method.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -561,6 +561,7 @@ github.com/ServiceWeaver/weaver/internal/weaver
     go.opentelemetry.io/otel/semconv/v1.4.0
     go.opentelemetry.io/otel/trace
     golang.org/x/exp/maps
+    golang.org/x/sync/errgroup
     google.golang.org/protobuf/types/known/timestamppb
     log/slog
     math

--- a/internal/envelope/conn/conn_test.go
+++ b/internal/envelope/conn/conn_test.go
@@ -121,7 +121,7 @@ func makeConnections(t *testing.T, handler conn.EnvelopeHandler) (*conn.Envelope
 			panic(err)
 		}
 		created <- struct{}{}
-		err = w.Serve(nil)
+		err = w.Serve(ctx, nil)
 		weaveletDone <- err
 	}()
 

--- a/runtime/envelope/envelope_test.go
+++ b/runtime/envelope/envelope_test.go
@@ -86,7 +86,7 @@ func TestMain(m *testing.M) {
 				return nil
 			},
 			"writetraces": func() error { return writeTraces(conn) },
-			"serve_conn":  func() error { return conn.Serve(nil) },
+			"serve_conn":  func() error { return conn.Serve(context.Background(), nil) },
 		}
 		fn, ok := cmds[cmd]
 		if !ok {
@@ -99,7 +99,7 @@ func TestMain(m *testing.M) {
 			fmt.Fprintf(os.Stderr, "subprocess: %v\n", err)
 			os.Exit(1)
 		}
-		conn.Serve(nil)
+		conn.Serve(context.Background(), nil)
 	}
 
 	var err error

--- a/weaver.go
+++ b/weaver.go
@@ -198,9 +198,7 @@ func runRemote[T any, _ PointerToMain[T]](ctx context.Context, app func(context.
 		}
 		return app(ctx, main.(*T))
 	}
-
-	<-ctx.Done()
-	return ctx.Err()
+	return runner.Wait()
 }
 
 // Implements[T] is a type that is be embedded inside a component

--- a/weavertest/multi.go
+++ b/weavertest/multi.go
@@ -60,12 +60,11 @@ func initMultiProcess(ctx context.Context, t testing.TB, isBench bool, runner Ru
 		}()
 
 		opts := weaver.RemoteWeaveletOptions{}
-		_, err := weaver.NewRemoteWeavelet(ctx, codegen.Registered(), bootstrap, opts)
+		wlet, err := weaver.NewRemoteWeavelet(ctx, codegen.Registered(), bootstrap, opts)
 		if err != nil {
 			panic(err)
 		}
-		<-ctx.Done() // Wait for parent process
-		return runtime.Bootstrap{}, nil, ctx.Err()
+		return runtime.Bootstrap{}, nil, wlet.Wait()
 	}
 
 	// Construct AppConfig and EnvelopeInfo.


### PR DESCRIPTION
Recall that a RemoteWeavelet maintains (1) an RPC server to serve remote component method calls from other weavelets and (2) a connection to the envelope. Before this PR, a RemoteWeavelet would os.Exit if either (1) or (2) went down. This made testing failure scenarios impossible, as the process would simply exit.

This PR removes the calls to os.Exit. Instead, I added a Wait method to the RemoteWeavelet that blocks until the weavelet has shut down and returns any errors encountered during shutdown. With this new Wait method, I was able to add a unit test to test the behavior of a weavelet when its connection to the envelope breaks.