### PR TITLE
Removed phantom "main" from weaver single status.

### DIFF
--- a/internal/weaver/singleweavelet.go
+++ b/internal/weaver/singleweavelet.go
@@ -409,11 +409,9 @@ func (w *SingleWeavelet) Status(context.Context) (*status.Status, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	// TODO(mwhittaker): The main process should probably be registered like
-	// any other process?
 	pid := int64(os.Getpid())
 	stats := w.stats.GetStatsStatusz()
-	components := []*status.Component{{Name: "main", Pids: []int64{pid}}}
+	var components []*status.Component
 	for component := range w.components {
 		c := &status.Component{
 			Name: component,


### PR DESCRIPTION
This PR fixes a bug where `weaver single status` was erroneously reporting a phantom `main` component in addition to the expected `weaver.Main` component. Here's the output of `weaver single status` on the collatz app before and after this change:

```diff
 ╭──────────────────────────────────────────────────────╮
 │ DEPLOYMENTS                                          │
 ├─────────┬──────────────────────────────────────┬─────┤
 │ APP     │ DEPLOYMENT                           │ AGE │
 ├─────────┼──────────────────────────────────────┼─────┤
 │ collatz │ b025a10f-0d71-48af-9f1d-a53a46f81e31 │ 3s  │
 ╰─────────┴──────────────────────────────────────┴─────╯
 ╭────────────────────────────────────────────────────╮
 │ COMPONENTS                                         │
 ├─────────┬────────────┬──────────────┬──────────────┤
 │ APP     │ DEPLOYMENT │ COMPONENT    │ REPLICA PIDS │
 ├─────────┼────────────┼──────────────┼──────────────┤
 │ collatz │ b025a10f   │ weaver.Main  │ 55837        │
 │ collatz │ b025a10f   │ collatz.Even │ 55837        │
 │ collatz │ b025a10f   │ collatz.Odd  │ 55837        │
-│ collatz │ b025a10f   │ main         │ 55837        │
 ╰─────────┴────────────┴──────────────┴──────────────╯
 ╭──────────────────────────────────────────────────╮
 │ LISTENERS                                        │
 ├─────────┬────────────┬──────────┬────────────────┤
 │ APP     │ DEPLOYMENT │ LISTENER │ ADDRESS        │
 ├─────────┼────────────┼──────────┼────────────────┤
 │ collatz │ b025a10f   │ collatz  │ 127.0.0.1:9000 │
 ╰─────────┴────────────┴──────────┴────────────────╯
```