### PR TITLE
internal/net/call now supports optional retries.

### DIFF
--- a/internal/net/call/options.go
+++ b/internal/net/call/options.go
@@ -59,6 +59,10 @@ type ServerOptions struct {
 
 // CallOptions are call-specific options.
 type CallOptions struct {
+	// Retry indicates whether or not calls that failed due to communication
+	// errors should be retried.
+	Retry bool
+
 	// ShardKey, if not 0, is the shard key that a Balancer can use to route a
 	// call. A Balancer can always choose to ignore the ShardKey.
 	//


### PR DESCRIPTION
Added call.CallOptions.Retry, which causes calls to be retried after a communication or unreachable error. Subsequent changes will make ServiceWeaver methods use this functionality when appropriate.