### PR TITLE
Fixed period (".") app name bug.

### DIFF
--- a/runtime/config.go
+++ b/runtime/config.go
@@ -140,7 +140,7 @@ func extractApp(file string, config *protos.AppConfig) error {
 func canonicalizeConfig(c *protos.AppConfig, dir string) error {
 	// Fill in the application name if necessary.
 	bin := c.GetBinary()
-	if c.Name == "" {
+	if c.Name == "" && bin != "" {
 		c.Name = filepath.Base(bin)
 	}
 


### PR DESCRIPTION
Before this PR, if you go ran a Service Weaver app with a config file that was missing an app name and a binary, the app name would erroneously default to ".".

```
╭──────────────────────────────────────────────────╮
│ DEPLOYMENTS                                      │
├─────┬──────────────────────────────────────┬─────┤
│ APP │ DEPLOYMENT                           │ AGE │
├─────┼──────────────────────────────────────┼─────┤
│ .   │ 10695f3a-0afe-4361-8d9a-033fd6ea81a0 │ 2s  │
╰─────┴──────────────────────────────────────┴─────╯
╭────────────────────────────────────────────────╮
│ COMPONENTS                                     │
├─────┬────────────┬──────────────┬──────────────┤
│ APP │ DEPLOYMENT │ COMPONENT    │ REPLICA PIDS │
├─────┼────────────┼──────────────┼──────────────┤
│ .   │ 10695f3a   │ weaver.Main  │ 2417098      │
│ .   │ 10695f3a   │ collatz.Even │ 2417098      │
│ .   │ 10695f3a   │ collatz.Odd  │ 2417098      │
│ .   │ 10695f3a   │ main         │ 2417098      │
╰─────┴────────────┴──────────────┴──────────────╯
╭──────────────────────────────────────────────╮
│ LISTENERS                                    │
├─────┬────────────┬──────────┬────────────────┤
│ APP │ DEPLOYMENT │ LISTENER │ ADDRESS        │
├─────┼────────────┼──────────┼────────────────┤
│ .   │ 10695f3a   │ collatz  │ 127.0.0.1:9000 │
╰─────┴────────────┴──────────┴────────────────╯
```

To calculate the app name, we called `filepath.Base` on the binary, but if the binary was empty, `filepath.Base` would return `"."`. This PR fixes the bug by only setting the app name if the binary is present.