### PR TITLE
Typo: the file is named main.go

### DIFF
--- a/website/docs.md
+++ b/website/docs.md
@@ -103,7 +103,7 @@ $ cd hello/
 $ go mod init hello
 ```
 
-Then, create a file called `hello.go` with the following contents:
+Then, create a file called `main.go` with the following contents:
 
 ```go
 package main


### PR DESCRIPTION
The file in the repo is `main.go`, and it is later refered to as `main.go`.