### PR TITLE
Enabled more lint checks.

### DIFF
--- a/runtime/codegen/decoder.go
+++ b/runtime/codegen/decoder.go
@@ -68,7 +68,7 @@ func (d *Decoder) DecodeProto(value proto.Message) {
 	}
 }
 
-// DecodeBinaryMarshaler deserializes the value from a byte slice using
+// DecodeBinaryUnmarshaler deserializes the value from a byte slice using
 // UnmarshalBinary.
 func (d *Decoder) DecodeBinaryUnmarshaler(value encoding.BinaryUnmarshaler) {
 	if err := value.UnmarshalBinary(d.Bytes()); err != nil {

--- a/runtime/metrics/metrics.go
+++ b/runtime/metrics/metrics.go
@@ -111,7 +111,7 @@ func (m *MetricSnapshot) MetricValue() *protos.MetricValue {
 	}
 }
 
-// MetricSnapshot converts a MetricSnapshot to its proto equivalent.
+// ToProto converts a MetricSnapshot to its proto equivalent.
 func (m *MetricSnapshot) ToProto() *protos.MetricSnapshot {
 	return &protos.MetricSnapshot{
 		Id:     m.Id,

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -14,4 +14,4 @@
 #
 # TODO(mwhittaker): Think about enabling some of these checks and updating our
 # code accordingly.
-checks = ["all", "-ST1000", "-ST1003", "-ST1005", "-ST1012", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+checks = ["all", "-ST1000", "-ST1003", "-ST1005", "-ST1012", "-ST1021"]

--- a/weavertest/deployer.go
+++ b/weavertest/deployer.go
@@ -31,7 +31,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// The default number of times a component is replicated.
+// DefaultReplication is the default number of times a component is replicated.
 //
 // TODO(mwhittaker): Include this in the Options struct?
 const DefaultReplication = 2


### PR DESCRIPTION
This PR enables some of the previously disabled linter checks:

- ST1016: This checks that method reciever names are consistent. The code already satisfied this check.
- ST1020: This checks that exported functions are documented with a comment that begins with the function's name. Enabling this check caught a couple of typos in the code.
- ST1022: This checks that exported variables are documented with a comment that begins with the variable's name. Enabling this check caught one bad comment.

I also considered enabling the other default checks, but wasn't sure if it was worth it:

- ST1000: This checks that every package has a package comment. For some internal packages, like those in weavertest/internal, this check felt unnecessary.
- ST1003: This checks for bad variable names. The vast majority of flagged variable names involved the capitalization of "ID". We often use variables like "DeploymentId", but the linter wants "DeploymentID". I couldn't find any official guidance on this kind of capitalization, so I left the check disabled.
- ST1021: This checks that exported types are documented with a comment that begins with the type's name. I want to enable this check, but it doesn't handle generic types. For example, the comment above RoutedBy begins `// RoutedBy[T] ...`, but the check wants `// RoutedBy ...`