### PR TITLE
Fixed bug in examples_test.go

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -34,6 +34,13 @@ type test struct {
 }
 
 func TestExamples(t *testing.T) {
+	// Build the weaver binary.
+	cmd := exec.Command("go", "build")
+	cmd.Dir = "../cmd/weaver"
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+
 	testCases := map[string]test{
 		// TODO(mwhittaker): Add helloworld example.
 		"hello": {


### PR DESCRIPTION
This PR fixes #549. examples_test.go was using the weaver binary but wasn't building it first.