### PR TITLE
Fixed flaky tests?

### DIFF
--- a/internal/envelope/conn/conn_test.go
+++ b/internal/envelope/conn/conn_test.go
@@ -145,7 +145,7 @@ func makeConnections(t *testing.T, handler conn.EnvelopeHandler) (*conn.Envelope
 			t.Fatal(err)
 		}
 		err = <-weaveletDone
-		if err != nil && !errors.Is(err, io.EOF) && !strings.Contains(err.Error(), "file already closed") {
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) && !strings.Contains(err.Error(), "file already closed") {
 			t.Fatal("weavelet failed", err)
 		}
 	})

--- a/internal/testdeployer/remoteweavelet_test.go
+++ b/internal/testdeployer/remoteweavelet_test.go
@@ -714,6 +714,21 @@ func TestFailReplica(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Update routing info to exclude replica 3.
+	for _, wlet := range []string{"1", "2"} {
+		for _, component := range []string{componentb, componentc} {
+			routing := &protos.UpdateRoutingInfoRequest{
+				RoutingInfo: &protos.RoutingInfo{
+					Component: component,
+					Replicas:  []string{d.weavelets["2"].env.WeaveletInfo().DialAddr},
+				},
+			}
+			if _, err := d.weavelets[wlet].wlet.UpdateRoutingInfo(routing); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
 	testComponents(d)
 }
 


### PR DESCRIPTION
On GitHub Actions, I saw TestFailReplica and TestMetricPropagation flaking. I can't reproduce the failure locally, but this PR is an attempt at fixing the bugs.