### PR TITLE
Sped up bin_test.go using t.Parallel().

### DIFF
--- a/runtime/bin/bin_test.go
+++ b/runtime/bin/bin_test.go
@@ -27,12 +27,17 @@ import (
 )
 
 func TestReadComponentGraph(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct{ os, arch string }{
 		{"linux", "amd64"},
 		{"windows", "amd64"},
 		{"darwin", "arm64"},
 	} {
+		test := test
 		t.Run(fmt.Sprintf("%s/%s", test.os, test.arch), func(t *testing.T) {
+			t.Parallel()
+
 			// Build the binary for os/arch.
 			d := t.TempDir()
 			binary := filepath.Join(d, "bin")
@@ -81,12 +86,17 @@ func TestReadComponentGraph(t *testing.T) {
 }
 
 func TestReadListeners(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct{ os, arch string }{
 		{"linux", "amd64"},
 		{"windows", "amd64"},
 		{"darwin", "arm64"},
 	} {
+		test := test
 		t.Run(fmt.Sprintf("%s/%s", test.os, test.arch), func(t *testing.T) {
+			t.Parallel()
+
 			// Build the binary for os/arch.
 			d := t.TempDir()
 			binary := filepath.Join(d, "bin")
@@ -152,12 +162,17 @@ func TestExtractVersion(t *testing.T) {
 }
 
 func TestReadVersion(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct{ os, arch string }{
 		{"linux", "amd64"},
 		{"windows", "amd64"},
 		{"darwin", "arm64"},
 	} {
+		test := test
 		t.Run(fmt.Sprintf("%s/%s", test.os, test.arch), func(t *testing.T) {
+			t.Parallel()
+
 			// Build the binary for os/arch.
 			d := t.TempDir()
 			binary := filepath.Join(d, "bin")


### PR DESCRIPTION
I noticed on GitHub Actions that bin_test was taking up to two minutes to execute [1]. This PR speeds things up by running things in parallel. The test also redundantly builds the same binary again and again. We could speed up the tests even further by not rebuilding things, but I'll leave that for another PR as it introduces a bit of complexity.

[1]: https://github.com/ServiceWeaver/weaver/actions/runs/5954182034/job/16150143324