### PR TITLE
Verify registered listeners when starting the app.

### DIFF
--- a/dev/build_and_test
+++ b/dev/build_and_test
@@ -54,7 +54,7 @@ function cmd_vet() {
 
 function cmd_lint() {
   if ! exists staticcheck; then
-    printf "staticcheck not found; install via\ngo install honnef.co/go/tools/cmd/staticcheck@0.4.3\n" >&2
+    printf "staticcheck not found; install via\ngo install honnef.co/go/tools/cmd/staticcheck@v0.4.3\n" >&2
     exit 1
   fi
 

--- a/fill.go
+++ b/fill.go
@@ -101,7 +101,7 @@ func fillListeners(impl any, get func(name string) (net.Listener, string, error)
 		// The listener's name is the field name, unless a tag is present.
 		name := t.Name
 		if tag, ok := t.Tag.Lookup("weaver"); ok {
-			if !isValidListenerName(tag) {
+			if !isValidListenerName(name) {
 				return fmt.Errorf("FillListeners: listener tag %s is not a valid Go identifier", tag)
 			}
 			name = tag

--- a/godeps.txt
+++ b/godeps.txt
@@ -10,6 +10,7 @@ github.com/ServiceWeaver/weaver
     github.com/ServiceWeaver/weaver/runtime/codegen
     go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
     go.opentelemetry.io/otel/trace
+    golang.org/x/exp/slices
     log/slog
     math/rand
     net

--- a/internal/tool/generate/generator.go
+++ b/internal/tool/generate/generator.go
@@ -510,6 +510,16 @@ func extractComponent(opt Options, pkg *packages.Package, file *ast.File, tset *
 		return nil, err
 	}
 
+	// Check that listener names are unique.
+	seenLis := map[string]struct{}{}
+	for _, lis := range listeners {
+		if _, ok := seenLis[lis]; ok {
+			return nil, errorf(pkg.Fset, spec.Pos(),
+				"component implementation %s declares multiple listeners with name %s. Please disambiguate.", formatType(pkg, impl), lis)
+		}
+		seenLis[lis] = struct{}{}
+	}
+
 	// Warn the user if the component has a mistyped Init method. Init methods
 	// are supposed to have type "func(context.Context) error", but it's easy
 	// to forget to add a context.Context argument or error return. Without

--- a/internal/tool/generate/testdata/errors/listeners_name_clash.go
+++ b/internal/tool/generate/testdata/errors/listeners_name_clash.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ERROR: multiple listeners with name bar
+
+// Multiple listeners with the same name.
+package foo
+
+import (
+	"github.com/ServiceWeaver/weaver"
+)
+
+type foo interface{}
+
+type impl struct {
+	weaver.Implements[foo]
+	bar weaver.Listener
+	_   weaver.Listener `weaver:"bar"`
+}


### PR DESCRIPTION
This ensures that the application listeners match the information stored in the read-only section of the application binary, and used by various deployers. If there is a mismatch, the user will be prompted to run `weaver generate`.

This fixes one of the common issues that came up in workshops, where people forgot to re-run `weaver generate` after declaring the listener.