### PR TITLE
Added basic tracing to the simulator.

### DIFF
--- a/internal/sim/sim_test.go
+++ b/internal/sim/sim_test.go
@@ -319,24 +319,24 @@ func TestValidateOp(t *testing.T) {
 	}
 }
 
-func TestExtractIds(t *testing.T) {
-	const traceId = 42
-	const spanId = 9001
-	ctx := withIds(context.Background(), traceId, spanId)
-	if got, _ := extractIds(ctx); got != traceId {
-		t.Errorf("trace id: got %d, want %d", got, traceId)
+func TestExtractIDs(t *testing.T) {
+	const traceID = 42
+	const spanID = 9001
+	ctx := withIDs(context.Background(), traceID, spanID)
+	if got, _ := extractIDs(ctx); got != traceID {
+		t.Errorf("trace id: got %d, want %d", got, traceID)
 	}
-	if _, got := extractIds(ctx); got != spanId {
-		t.Errorf("span id: got %d, want %d", got, spanId)
+	if _, got := extractIDs(ctx); got != spanID {
+		t.Errorf("span id: got %d, want %d", got, spanID)
 	}
 }
 
-func TestExtractIdsOnInvalidContext(t *testing.T) {
-	traceId, spanId := extractIds(context.Background())
-	if traceId != 0 {
-		t.Errorf("trace id: got %d, want 0", traceId)
+func TestExtractIDsOnInvalidContext(t *testing.T) {
+	traceID, spanID := extractIDs(context.Background())
+	if traceID != 0 {
+		t.Errorf("trace id: got %d, want 0", traceID)
 	}
-	if spanId != 0 {
-		t.Errorf("span id: got %d, want 0", spanId)
+	if spanID != 0 {
+		t.Errorf("span id: got %d, want 0", spanID)
 	}
 }


### PR DESCRIPTION
Recall that a simulation consists of a number of discrete events:

- An op starts.
- An op finishes.
- A method call is made.
- A method call is delivered.
- A method call returns.
- A method return return is delivered.
- An error is injected.

This PR adds basic tracing to the simulator to keep track of these events. When a simulation fails, a history of the events is returned to the user. They can inspect the history to understand why the simulation failed. In a future PR, I'll add a way to visualize a history of events.

In the future, traces could be used for more than just visualization. For example, we may use traces for minimization or for checking that a simulation is deterministic. Thus, I expect the contents of the traces to change over time as we refine the simulator. I went with something simple for now.