### PR TITLE
Added hyperparameter for simulator failure rate.

### DIFF
--- a/internal/sim/graveyard.go
+++ b/internal/sim/graveyard.go
@@ -88,10 +88,11 @@ const version = 1
 
 // GraveyardEntry is a set of failing inputs persisted for later execution.
 type GraveyardEntry struct {
-	Version     int   `json:"version"`
-	Seed        int64 `json:"seed"`
-	NumReplicas int   `json:"num_replicas"`
-	NumOps      int   `json:"num_ops"`
+	Version     int     `json:"version"`
+	Seed        int64   `json:"seed"`
+	NumReplicas int     `json:"num_replicas"`
+	NumOps      int     `json:"num_ops"`
+	FailureRate float64 `json:"failure_rate"`
 }
 
 // readGraveyard reads all the graveyard entries stored in the provided directory.

--- a/internal/sim/rand.go
+++ b/internal/sim/rand.go
@@ -63,3 +63,13 @@ func pickValue[K constraints.Ordered, V any](r *rand.Rand, kvs map[K]V) V {
 	}
 	return kvs[pickKey(r, kvs)]
 }
+
+// flip returns true with probability p. For example, flip(0) always returns
+// false, flip(1) always returns true, and flip(0.5) returns true half the
+// time. flip panics if p is not in the range [0, 1].
+func flip(r *rand.Rand, p float64) bool {
+	if p < 0 || p > 1 {
+		panic(fmt.Errorf("flip: probability %f not in range [0, 1.0]", p))
+	}
+	return r.Float64() <= p
+}

--- a/internal/sim/sim.go
+++ b/internal/sim/sim.go
@@ -194,9 +194,19 @@ type op struct {
 type fate int
 
 const (
-	dontFail           fate = iota // dont fail a call
-	failBeforeDelivery             // fail a call before it is delivered
-	failAfterDelivery              // fail a call after it is delivered
+	// Don't fail the call.
+	dontFail fate = iota
+
+	// Fail the call before it is delivered to a component replica. In this
+	// case, the method call does not execute at all.
+	failBeforeDelivery
+
+	// Fail the call after it has been delivered to a component replica. In
+	// this case, the method call will fail after fully executing.
+	//
+	// TODO(mwhittaker): Deliver a method call, and then fail it while it is
+	// still executing.
+	failAfterDelivery
 )
 
 // call is a pending method call.

--- a/internal/sim/sim.go
+++ b/internal/sim/sim.go
@@ -70,6 +70,7 @@ type Options struct {
 	Seed           int64                // the simulator's seed
 	NumReplicas    int                  // the number of replicas of every component
 	NumOps         int                  // the number of ops to run
+	FailureRate    float64              // the fraction of calls to artificially fail
 	ConfigFilename string               // TOML config filename
 	Config         string               // TOML config contents
 	Fakes          map[reflect.Type]any // fake component implementations
@@ -189,10 +190,20 @@ type op struct {
 	components []reflect.Type // Op.Func component argument types
 }
 
+// fate dictates if and how a call should fail.
+type fate int
+
+const (
+	dontFail           fate = iota // dont fail a call
+	failBeforeDelivery             // fail a call before it is delivered
+	failAfterDelivery              // fail a call after it is delivered
+)
+
 // call is a pending method call.
 type call struct {
 	traceID   int
 	spanID    int
+	fate      fate            // whether to fail the operation
 	component reflect.Type    // the component being called
 	method    string          // the method being called
 	args      []reflect.Value // the call's arguments
@@ -362,9 +373,23 @@ func (s *Simulator) call(caller string, replica int, reg *codegen.Registration, 
 	spanID := s.nextSpanID
 	s.nextSpanID++
 
+	// Determine the fate of the call.
+	fate := dontFail
+	if flip(s.rand, s.opts.FailureRate) {
+		// TODO(mwhittaker): Have two parameters to control the rate of failing
+		// before and after delivery? This level of control might be
+		// unnecessary. For now, we pick between them equiprobably.
+		if flip(s.rand, 0.5) {
+			fate = failBeforeDelivery
+		} else {
+			fate = failAfterDelivery
+		}
+	}
+
 	s.calls = append(s.calls, &call{
 		traceID:   traceID,
 		spanID:    spanID,
+		fate:      fate,
 		component: reg.Iface,
 		method:    method,
 		args:      in,
@@ -485,6 +510,7 @@ func (s *Simulator) Simulate(ctx context.Context) (*Results, error) {
 			Seed:        s.opts.Seed,
 			NumReplicas: s.opts.NumReplicas,
 			NumOps:      s.opts.NumOps,
+			FailureRate: s.opts.FailureRate,
 		}
 		// TODO(mwhittaker): Escape names.
 		dir := filepath.Join("testdata", "sim", s.name)
@@ -508,18 +534,16 @@ func (s *Simulator) step() {
 		runOp = iota
 		deliverCall
 		deliverReply
-		deliverCallError
-		deliverReplyError
 	)
 	var candidates []int
 	if s.numOps < s.opts.NumOps {
 		candidates = append(candidates, runOp)
 	}
 	if len(s.calls) > 0 {
-		candidates = append(candidates, deliverCall, deliverCallError)
+		candidates = append(candidates, deliverCall)
 	}
 	if len(s.replies) > 0 {
-		candidates = append(candidates, deliverReply, deliverReplyError)
+		candidates = append(candidates, deliverReply)
 	}
 	if len(candidates) == 0 {
 		return
@@ -539,6 +563,22 @@ func (s *Simulator) step() {
 	case deliverCall:
 		var call *call
 		call, s.calls = pop(s.rand, s.calls)
+
+		if call.fate == failBeforeDelivery {
+			// Fail the call before delivering it.
+			s.history = append(s.history, DeliverError{
+				TraceID: call.traceID,
+				SpanID:  call.spanID,
+			})
+			call.reply <- &reply{
+				call:    call,
+				returns: returnError(call.component, call.method, core.RemoteCallError),
+			}
+			close(call.reply)
+			return
+		}
+
+		// Deliver the call.
 		s.group.Go(func() error {
 			s.deliverCall(call)
 			return nil
@@ -547,38 +587,24 @@ func (s *Simulator) step() {
 	case deliverReply:
 		var reply *reply
 		reply, s.replies = pop(s.rand, s.replies)
+
+		if reply.call.fate == failAfterDelivery {
+			// Fail the call after delivering it.
+			s.history = append(s.history, DeliverError{
+				TraceID: reply.call.traceID,
+				SpanID:  reply.call.spanID,
+			})
+			reply.returns = returnError(reply.call.component, reply.call.method, core.RemoteCallError)
+			reply.call.reply <- reply
+			close(reply.call.reply)
+			return
+		}
+
+		// Return successfully.
 		s.history = append(s.history, DeliverReturn{
 			TraceID: reply.call.traceID,
 			SpanID:  reply.call.spanID,
 		})
-		reply.call.reply <- reply
-		close(reply.call.reply)
-
-	case deliverCallError:
-		// TODO(mwhittaker): Implement co-location. Don't return
-		// RemoteCallErrors between co-located components.
-		var call *call
-		call, s.calls = pop(s.rand, s.calls)
-		s.history = append(s.history, DeliverError{
-			TraceID: call.traceID,
-			SpanID:  call.spanID,
-		})
-		call.reply <- &reply{
-			call:    call,
-			returns: returnError(call.component, call.method, core.RemoteCallError),
-		}
-		close(call.reply)
-
-	case deliverReplyError:
-		// TODO(mwhittaker): Implement co-location. Don't return
-		// RemoteCallErrors between co-located components.
-		var reply *reply
-		reply, s.replies = pop(s.rand, s.replies)
-		s.history = append(s.history, DeliverError{
-			TraceID: reply.call.traceID,
-			SpanID:  reply.call.spanID,
-		})
-		reply.returns = returnError(reply.call.component, reply.call.method, core.RemoteCallError)
 		reply.call.reply <- reply
 		close(reply.call.reply)
 


### PR DESCRIPTION
Recall that the simulator can arbitrarily choose to fail a component method call, either before or after delivering the call. Before this PR, the simulator had an incredibly naive algorithm for deciding when to fail calls. This naive approach failed a lot of calls.

This PR introduces a hyperparameter `FailureRate` to configure how often the simulator fails calls. When FailureRate is 0, the simulator never fails a call, and when FailureRate is 1, the simulator fails every call.