### PR TITLE
Allow methods to be marked as non-retriable.

### DIFF
--- a/internal/tool/generate/generator_test.go
+++ b/internal/tool/generate/generator_test.go
@@ -226,11 +226,11 @@ func TestGenerator(t *testing.T) {
 				if strings.Contains(output, expect) {
 					continue
 				}
-				t.Errorf("output does not contain expected string %q", expect)
+				t.Errorf("output does not contain expected string %q in\n%s", expect, output)
 			}
 			for _, unexpect := range unexpected {
 				if strings.Contains(output, unexpect) {
-					t.Errorf("output contains unexpected string %q", unexpect)
+					t.Errorf("output contains unexpected string %q in \n%s", unexpect, output)
 				}
 			}
 		})

--- a/internal/tool/generate/testdata/errors/noretry_not_component.go
+++ b/internal/tool/generate/testdata/errors/noretry_not_component.go
@@ -1,0 +1,28 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ERROR: weaver.NonRetriable
+package foo
+
+import (
+	"context"
+
+	"github.com/ServiceWeaver/weaver"
+)
+
+type Bar interface {
+	A(context.Context) error
+}
+
+var _ weaver.NotRetriable = Bar.A

--- a/internal/tool/generate/testdata/errors/noretry_not_method.go
+++ b/internal/tool/generate/testdata/errors/noretry_not_method.go
@@ -1,0 +1,22 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ERROR: weaver.NonRetriable
+package foo
+
+import (
+	"github.com/ServiceWeaver/weaver"
+)
+
+var _ weaver.NotRetriable = 100

--- a/internal/tool/generate/testdata/errors/noretry_not_named.go
+++ b/internal/tool/generate/testdata/errors/noretry_not_named.go
@@ -1,0 +1,24 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ERROR: weaver.NonRetriable
+package foo
+
+import (
+	"context"
+
+	"github.com/ServiceWeaver/weaver"
+)
+
+var _ weaver.NotRetriable = interface{ A(context.Context) error }.A

--- a/internal/tool/generate/testdata/noretry.go
+++ b/internal/tool/generate/testdata/noretry.go
@@ -1,0 +1,45 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// EXPECTED
+// NoRetry: []int{1, 3}
+
+// Package foo contains some a component with some non-retriable methods.
+package foo
+
+import (
+	"context"
+
+	"github.com/ServiceWeaver/weaver"
+)
+
+type foo interface {
+	A(context.Context) error
+	B(context.Context) error
+	C(context.Context) error
+	D(context.Context) error
+}
+
+type impl struct{ weaver.Implements[foo] }
+
+func (l *impl) A(context.Context) error { return nil }
+func (l *impl) B(context.Context) error { return nil }
+func (l *impl) C(context.Context) error { return nil }
+func (l *impl) D(context.Context) error { return nil }
+
+var _ weaver.NotRetriable = foo.B
+var _ weaver.NotRetriable = foo.D
+
+// Following should be ignored.
+var _ any = foo.A

--- a/internal/tool/generate/types.go
+++ b/internal/tool/generate/types.go
@@ -889,6 +889,10 @@ func isWeaverAutoMarshal(t types.Type) bool {
 	return isWeaverType(t, "AutoMarshal", 0)
 }
 
+func isWeaverNotRetriable(t types.Type) bool {
+	return isWeaverType(t, "NotRetriable", 0)
+}
+
 func isString(t types.Type) bool {
 	b, ok := t.(*types.Basic)
 	return ok && b.Kind() == types.String

--- a/internal/weaver/remoteweavelet.go
+++ b/internal/weaver/remoteweavelet.go
@@ -373,18 +373,10 @@ func (w *RemoteWeavelet) makeStub(reg *codegen.Registration, resolver *routingRe
 	}
 	w.syslogger.Debug(fmt.Sprintf("Connected to remote component %q", name))
 
-	// Construct the keys for the methods.
-	n := reg.Iface.NumMethod()
-	methods := make([]call.MethodKey, n)
-	for i := 0; i < n; i++ {
-		mname := reg.Iface.Method(i).Name
-		methods[i] = call.MakeMethodKey(reg.Name, mname)
-	}
-
 	return &stub{
 		component: reg.Name,
 		conn:      conn,
-		methods:   methods,
+		methods:   makeStubMethods(reg),
 		tracer:    w.tracer,
 	}, nil
 }

--- a/runtime/codegen/registry.go
+++ b/runtime/codegen/registry.go
@@ -59,6 +59,7 @@ type Registration struct {
 	Impl      reflect.Type // implementation type (struct)
 	Routed    bool         // True if calls to this component should be routed
 	Listeners []string     // the names of any weaver.Listeners
+	NoRetry   []int        // indices of methods that should not be retried
 
 	// Functions that return different types of stubs.
 	LocalStubFn   func(impl any, caller string, tracer trace.Tracer) any

--- a/weaver.go
+++ b/weaver.go
@@ -535,3 +535,5 @@ type AutoMarshal struct{}
 
 func (AutoMarshal) WeaverMarshal(*codegen.Encoder)   {}
 func (AutoMarshal) WeaverUnmarshal(*codegen.Decoder) {}
+
+type NotRetriable interface{}


### PR DESCRIPTION
A component method can now be marked as non-retriable by adding a blank assignment of the form:

```
var _ weaver.NotRetriable = Component.Method
```

We currently don't auto-retry, so such annotations are no-ops, but will become meaningful after we enable auto-retries.

Refactored some stub creation code out of remoteweavelet.go and made it easier to test.