### PR TITLE
Enable automatic retrying on a network error.

### DIFF
--- a/examples/chat/sqlstore.go
+++ b/examples/chat/sqlstore.go
@@ -80,6 +80,11 @@ type SQLStore interface {
 	GetImage(ctx context.Context, _ string, image ImageID) ([]byte, error)
 }
 
+var (
+	_ weaver.NotRetriable = SQLStore.CreateThread
+	_ weaver.NotRetriable = SQLStore.CreatePost
+)
+
 type config struct {
 	Driver string `toml:"db_driver"` // Name of the database driver.
 	URI    string `toml:"db_uri"`    // Database server URI.

--- a/examples/chat/weaver_gen.go
+++ b/examples/chat/weaver_gen.go
@@ -70,9 +70,10 @@ func init() {
 		RefData: "⟦7e1a0aa0:wEaVeReDgE:github.com/ServiceWeaver/weaver/Main→github.com/ServiceWeaver/weaver/examples/chat/SQLStore⟧\n⟦ae108c0d:wEaVeReDgE:github.com/ServiceWeaver/weaver/Main→github.com/ServiceWeaver/weaver/examples/chat/ImageScaler⟧\n⟦c86a1d44:wEaVeReDgE:github.com/ServiceWeaver/weaver/Main→github.com/ServiceWeaver/weaver/examples/chat/LocalCache⟧\n⟦7b9a3b0b:wEaVeRlIsTeNeRs:github.com/ServiceWeaver/weaver/Main→chat⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:  "github.com/ServiceWeaver/weaver/examples/chat/SQLStore",
-		Iface: reflect.TypeOf((*SQLStore)(nil)).Elem(),
-		Impl:  reflect.TypeOf(sqlStore{}),
+		Name:    "github.com/ServiceWeaver/weaver/examples/chat/SQLStore",
+		Iface:   reflect.TypeOf((*SQLStore)(nil)).Elem(),
+		Impl:    reflect.TypeOf(sqlStore{}),
+		NoRetry: []int{0, 1},
 		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
 			return sQLStore_local_stub{impl: impl.(SQLStore), tracer: tracer, createPostMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "CreatePost", Remote: false}), createThreadMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "CreateThread", Remote: false}), getFeedMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "GetFeed", Remote: false}), getImageMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/examples/chat/SQLStore", Method: "GetImage", Remote: false})}
 		},

--- a/internal/weaver/remoteweavelet.go
+++ b/internal/weaver/remoteweavelet.go
@@ -47,7 +47,8 @@ var readyMethodKey = call.MakeMethodKey("", "ready")
 
 // RemoteWeaveletOptions configure a RemoteWeavelet.
 type RemoteWeaveletOptions struct {
-	Fakes map[reflect.Type]any // component fakes, by component interface type
+	Fakes         map[reflect.Type]any // component fakes, by component interface type
+	InjectRetries int                  // Number of artificial retries to inject per retriable call
 }
 
 // RemoteWeavelet is a weavelet that runs some components locally, but
@@ -374,10 +375,11 @@ func (w *RemoteWeavelet) makeStub(reg *codegen.Registration, resolver *routingRe
 	w.syslogger.Debug(fmt.Sprintf("Connected to remote component %q", name))
 
 	return &stub{
-		component: reg.Name,
-		conn:      conn,
-		methods:   makeStubMethods(reg),
-		tracer:    w.tracer,
+		component:     reg.Name,
+		conn:          conn,
+		methods:       makeStubMethods(reg),
+		tracer:        w.tracer,
+		injectRetries: w.opts.InjectRetries,
 	}, nil
 }
 

--- a/weavertest/internal/simple/simple.go
+++ b/weavertest/internal/simple/simple.go
@@ -52,6 +52,12 @@ type Destination interface {
 	RoutedRecord(_ context.Context, file, msg string) error
 }
 
+var (
+	_ weaver.NotRetriable = Source.Emit
+	_ weaver.NotRetriable = Destination.Record
+	_ weaver.NotRetriable = Destination.RoutedRecord
+)
+
 type destRouter struct{}
 
 func (r destRouter) RoutedRecord(_ context.Context, file, msg string) string {

--- a/weavertest/internal/simple/weaver_gen.go
+++ b/weavertest/internal/simple/weaver_gen.go
@@ -15,10 +15,11 @@ import (
 
 func init() {
 	codegen.Register(codegen.Registration{
-		Name:   "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination",
-		Iface:  reflect.TypeOf((*Destination)(nil)).Elem(),
-		Impl:   reflect.TypeOf(destination{}),
-		Routed: true,
+		Name:    "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination",
+		Iface:   reflect.TypeOf((*Destination)(nil)).Elem(),
+		Impl:    reflect.TypeOf(destination{}),
+		Routed:  true,
+		NoRetry: []int{2, 3},
 		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
 			return destination_local_stub{impl: impl.(Destination), tracer: tracer, getAllMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "GetAll", Remote: false}), getpidMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Getpid", Remote: false}), recordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Record", Remote: false}), routedRecordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "RoutedRecord", Remote: false})}
 		},
@@ -53,9 +54,10 @@ func init() {
 		RefData: "⟦1e2dce71:wEaVeRlIsTeNeRs:github.com/ServiceWeaver/weaver/weavertest/internal/simple/Server→hello⟧\n",
 	})
 	codegen.Register(codegen.Registration{
-		Name:  "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Source",
-		Iface: reflect.TypeOf((*Source)(nil)).Elem(),
-		Impl:  reflect.TypeOf(source{}),
+		Name:    "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Source",
+		Iface:   reflect.TypeOf((*Source)(nil)).Elem(),
+		Impl:    reflect.TypeOf(source{}),
+		NoRetry: []int{0},
 		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
 			return source_local_stub{impl: impl.(Source), tracer: tracer, emitMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Source", Method: "Emit", Remote: false})}
 		},

--- a/website/blog/corba.md
+++ b/website/blog/corba.md
@@ -139,7 +139,7 @@ freeze until it is repaired.
 While Service Weaver remote method calls *look* like local method calls, they do
 not *act* like them.
 
-- Remote methods return an error on network and participant failures.  The
+- Remote methods may return an error on network and participant failures.  The
   developer is responsible for handling such errors.
 - Every remote method's first argument is a `context.Context`. The
   developer is responsible for setting deadlines on these contexts to detect and


### PR DESCRIPTION
Remote method calls are now automatically retried after network errors. This functionality can be disabled on a method-by-method basis by marking the method as not-retriable:

```go
var _ weaver.NotRetriable = Component.Method
```

weavertest's RPC runner helps to discover methods that should be marked as not-retriable by artificially retrying all unmarked methods an extra time.