### PR TITLE
Log printing improvements.

### DIFF
--- a/internal/weaver/remoteweavelet.go
+++ b/internal/weaver/remoteweavelet.go
@@ -138,7 +138,7 @@ func NewRemoteWeavelet(ctx context.Context, regs []*codegen.Registration, bootst
 	info := w.conn.EnvelopeInfo()
 
 	// Set up logging.
-	w.syslogger = w.logger(fmt.Sprintf("weavelet-%s", logging.Shorten(info.Id)), "serviceweaver/system", "")
+	w.syslogger = w.logger("weavelet", "serviceweaver/system", "")
 
 	// Set up tracing.
 	exporter := traceio.NewWriter(w.conn.SendTraceSpans)

--- a/runtime/logging/pretty.go
+++ b/runtime/logging/pretty.go
@@ -184,6 +184,9 @@ func (pp *PrettyPrinter) Format(e *protos.LogEntry) string {
 		attrs := make([]attr, 0, len(e.Attrs)/2)
 		for i := 0; i+1 < len(e.Attrs); i += 2 {
 			name, value := e.Attrs[i], e.Attrs[i+1]
+			if name == "serviceweaver/system" {
+				continue // Aleady implied by component name
+			}
 			attrs = append(attrs, attr{name, value})
 		}
 		sort.Slice(attrs, func(i, j int) bool {

--- a/weavertest/internal/simple/simple.go
+++ b/weavertest/internal/simple/simple.go
@@ -72,12 +72,18 @@ type destination struct {
 
 var pid = os.Getpid()
 
+func (d *destination) Init(ctx context.Context) error {
+	d.Logger(ctx).Info("init")
+	return nil
+}
+
 func (d *destination) Getpid(_ context.Context) (int, error) {
 	return pid, nil
 }
 
 // Record adds a message.
-func (d *destination) Record(_ context.Context, file, msg string) error {
+func (d *destination) Record(ctx context.Context, file, msg string) error {
+	d.Logger(ctx).Info("record", "msg", msg)
 	d.mu.Lock()
 	defer d.mu.Unlock()
 


### PR DESCRIPTION
Change weavelet generated log entry component name from a string of the form "weavelet-9f9aa218" to "weavelet". The extra ID information is already available in the node name.

Elide "serviceweaver/system" attribute. The component name already implies it (by being a special string instead of a user component).