### PR TITLE
More logging prettifications.

### DIFF
--- a/runtime/logging/pretty.go
+++ b/runtime/logging/pretty.go
@@ -23,15 +23,12 @@ import (
 	"time"
 
 	"github.com/ServiceWeaver/weaver/runtime/colors"
-	"github.com/ServiceWeaver/weaver/runtime/protomsg"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
 )
 
 var (
-	dimColor       = colors.Color256(245) // dimmed text color (a light gray)
-	errorColor     = colors.Color256(9)   // error color (a light red)
-	attrNameColor  = colors.Color256(245) // attribute name color (a light gray)
-	attrValueColor = colors.Color256(245) // attribute name color (a light gray)
+	dimColor   = colors.Color256(245) // dimmed text color (a light gray)
+	errorColor = colors.Color256(9)   // error color (a light red)
 )
 
 // PrettyPrinter pretty prints log entries. You can safely use a PrettyPrinter
@@ -39,11 +36,12 @@ var (
 type PrettyPrinter struct {
 	colorize func(colors.Code, string) string // colors the provided string
 
-	mu               sync.Mutex       // guards the following fields
-	b                strings.Builder  // used to format entries
-	prev             *protos.LogEntry // previously printed entry
-	componentPadding int              // component padding
-	sourcePadding    int              // file:line padding
+	mu               sync.Mutex      // guards the following fields
+	b                strings.Builder // used to format entries
+	prevTime         time.Time       // Last line timestamp
+	componentPadding int             // component padding
+	sourcePadding    int             // file:line padding
+	attrs            [][2]string     // Temporary storage
 }
 
 // NewPrettyPrinter returns a new PrettyPrinter. If color is true, the pretty
@@ -51,8 +49,8 @@ type PrettyPrinter struct {
 func NewPrettyPrinter(color bool) *PrettyPrinter {
 	pp := &PrettyPrinter{
 		colorize:         func(_ colors.Code, s string) string { return s },
-		componentPadding: 7,
-		sourcePadding:    10,
+		componentPadding: 20,
+		sourcePadding:    20,
 	}
 	if color {
 		pp.colorize = func(code colors.Code, s string) string {
@@ -81,13 +79,6 @@ func (pp *PrettyPrinter) Format(e *protos.LogEntry) string {
 	defer pp.mu.Unlock()
 	pp.b.Reset()
 
-	// Compute some diffs for dimming.
-	sameComponent := pp.prev != nil && e.Component == pp.prev.Component
-	sameNode := pp.prev != nil && e.Node == pp.prev.Node
-	sameLevel := pp.prev != nil && e.Level == pp.prev.Level
-	sameFile := pp.prev != nil && e.File == pp.prev.File
-	sameLine := pp.prev != nil && e.Line == pp.prev.Line
-
 	// Write the abbreviated level and time. If the level is "error", we color
 	// the level and time. Otherwise, we don't.
 	level := " "
@@ -98,38 +89,14 @@ func (pp *PrettyPrinter) Format(e *protos.LogEntry) string {
 	if strings.ToLower(e.Level) == "error" {
 		levelColor = errorColor
 	}
+	pp.b.WriteString(pp.colorize(levelColor, level))
 
 	cur := time.UnixMicro(e.TimeMicros)
-	if !sameComponent || !sameNode || !sameLevel || pp.prev == nil {
-		// If we have a different component, node, or level, we don't dim the
-		// level and time. If we did, then things like the day and year would
-		// almost always be dimmed.
-		pp.b.WriteString(pp.colorize(levelColor, level))
+	if cur.Unix() != pp.prevTime.Unix() {
 		pp.b.WriteString(pp.colorize(levelColor, cur.Format("0102 15:04:05.000000")))
 	} else {
-		pp.b.WriteString(pp.colorize(dimColor, level))
-		prevTime := time.UnixMicro(pp.prev.TimeMicros)
-		switch {
-		case cur.Month() != prevTime.Month():
-			pp.b.WriteString(pp.colorize(levelColor, cur.Format("0102 15:04:05.000000")))
-		case cur.Day() != prevTime.Day():
-			pp.b.WriteString(pp.colorize(dimColor, cur.Format("01")))
-			pp.b.WriteString(pp.colorize(levelColor, cur.Format("02 15:04:05.000000")))
-		case cur.Hour() != prevTime.Hour():
-			pp.b.WriteString(pp.colorize(dimColor, cur.Format("0102")))
-			pp.b.WriteString(pp.colorize(levelColor, cur.Format("15:04:05.000000")))
-		case cur.Minute() != prevTime.Minute():
-			pp.b.WriteString(pp.colorize(dimColor, cur.Format("0102 15:")))
-			pp.b.WriteString(pp.colorize(levelColor, cur.Format("04:05.000000")))
-		case cur.Second() != prevTime.Second():
-			pp.b.WriteString(pp.colorize(dimColor, cur.Format("0102 15:04:")))
-			pp.b.WriteString(pp.colorize(levelColor, cur.Format("05.000000")))
-		case cur.Nanosecond()/1000 != prevTime.Nanosecond()/1000:
-			pp.b.WriteString(pp.colorize(dimColor, cur.Format("0102 15:04:05.")))
-			pp.b.WriteString(pp.colorize(levelColor, fmt.Sprintf("%06d", cur.Nanosecond()/1000)))
-		default:
-			pp.b.WriteString(pp.colorize(dimColor, cur.Format("0102 15:04:05.000000")))
-		}
+		pp.b.WriteString(pp.colorize(dimColor, cur.Format("0102 15:04:05.")))
+		pp.b.WriteString(pp.colorize(levelColor, fmt.Sprintf("%06d", cur.Nanosecond()/1000)))
 	}
 	pp.b.WriteByte(' ')
 
@@ -143,11 +110,7 @@ func (pp *PrettyPrinter) Format(e *protos.LogEntry) string {
 	// Write the node.
 	if len(e.Node) > 0 {
 		pp.b.WriteByte(' ')
-		if sameNode {
-			pp.b.WriteString(pp.colorize(dimColor, Shorten(e.Node)))
-		} else {
-			pp.b.WriteString(pp.colorize(colors.ColorHash(e.Node), Shorten(e.Node)))
-		}
+		pp.b.WriteString(pp.colorize(colors.ColorHash(e.Node), Shorten(e.Node)))
 	}
 
 	// Write the file and line, if present.
@@ -159,49 +122,56 @@ func (pp *PrettyPrinter) Format(e *protos.LogEntry) string {
 			pp.sourcePadding = len(s)
 		}
 
-		if sameFile && sameLine {
-			s := fmt.Sprintf("%s:%s", file, line)
-			pp.b.WriteString(pp.colorize(dimColor, fmt.Sprintf("%*s", -pp.sourcePadding, s)))
-		} else if sameFile && !sameLine {
-			s := pp.colorize(dimColor, fmt.Sprintf("%s:", file)) + line
-			fmt.Fprintf(&pp.b, "%*s", -pp.sourcePadding-len(dimColor)-len(colors.Reset), s)
-		} else {
-			s := fmt.Sprintf("%s:%s", file, line)
-			fmt.Fprintf(&pp.b, "%*s", -pp.sourcePadding, s)
-		}
+		s := fmt.Sprintf("%s:%s", file, line)
+		color := colors.ColorHash(file)
+		pp.b.WriteString(fmt.Sprintf("%*s", -pp.sourcePadding-len(color)-len(colors.Reset), pp.colorize(color, s)))
 	} else {
 		fmt.Fprintf(&pp.b, "%*s", -pp.sourcePadding, "")
 	}
 
 	// Write the message.
-	pp.b.WriteString("] ")
-	pp.b.WriteString(pp.colorize(colors.ColorHash(c), e.Msg))
+	pp.b.WriteString(pp.colorize(dimColor, " │ "))
+	pp.b.WriteString(e.Msg)
 
 	// Write the attributes, if present.
-	if len(e.Attrs) > 0 {
-		// Sort the attributes.
-		type attr struct{ name, value string }
-		attrs := make([]attr, 0, len(e.Attrs)/2)
-		for i := 0; i+1 < len(e.Attrs); i += 2 {
-			name, value := e.Attrs[i], e.Attrs[i+1]
-			if name == "serviceweaver/system" {
-				continue // Aleady implied by component name
-			}
-			attrs = append(attrs, attr{name, value})
+	for _, attr := range pp.sortedAttributes(e) {
+		// Pick attribute color
+		var color colors.Code
+		if attr[0] == "component" {
+			// Stay consistent with color used in component column.
+			color = colors.ColorHash(attr[1])
+		} else if attr[0] == "err" {
+			color = errorColor // Errors have a fixed color
+		} else {
+			// Assign same color to everything with the same key
+			color = colors.ColorHash(attr[0])
 		}
-		sort.Slice(attrs, func(i, j int) bool {
-			return attrs[i].name < attrs[j].name
-		})
-
-		for _, attr := range attrs {
-			pp.b.WriteString(" ")
-			pp.b.WriteString(pp.colorize(attrNameColor, attr.name+"="))
-			pp.b.WriteString(pp.colorize(attrValueColor, fmt.Sprintf("%q", attr.value)))
-		}
+		pp.b.WriteString(" ")
+		pp.b.WriteString(pp.colorize(dimColor, attr[0]+"="))
+		pp.b.WriteString(pp.colorize(color, fmt.Sprintf("%q", attr[1])))
 	}
 
-	pp.prev = protomsg.Clone(e)
+	pp.prevTime = cur
 	return pp.b.String()
+}
+
+func (pp *PrettyPrinter) sortedAttributes(e *protos.LogEntry) [][2]string {
+	attrs := pp.attrs[:0]
+
+	// Get attributes and sort.
+	for i := 0; i+1 < len(e.Attrs); i += 2 {
+		name, value := e.Attrs[i], e.Attrs[i+1]
+		if name == "serviceweaver/system" {
+			continue // Aleady implied by component name
+		}
+		attrs = append(attrs, [2]string{name, value})
+	}
+	sort.Slice(attrs, func(i, j int) bool {
+		return attrs[i][0] < attrs[j][0]
+	})
+
+	pp.attrs = attrs // So we reuse allocated space next time
+	return attrs
 }
 
 // Shorten returns a short prefix of the provided string.

--- a/website/docs.md
+++ b/website/docs.md
@@ -917,9 +917,9 @@ func (a *adder) Add(ctx context.Context, x, y int) (int, error) {
 Logs look like this:
 
 ```console
-D1103 08:55:15.650138 main.Adder 73ddcd04 adder.go:12] A debug log.
-I1103 08:55:15.650149 main.Adder 73ddcd04 adder.go:13] An info log.
-E1103 08:55:15.650158 main.Adder 73ddcd04 adder.go:14] An error log. err="an error"
+D1103 08:55:15.650138 main.Adder 73ddcd04 adder.go:12 │ A debug log.
+I1103 08:55:15.650149 main.Adder 73ddcd04 adder.go:13 │ An info log.
+E1103 08:55:15.650158 main.Adder 73ddcd04 adder.go:14 │ An error log. err="an error"
 ```
 
 The first character of a log line indicates whether the log is a [D]ebug,


### PR DESCRIPTION
* remoteweavelet no longer merges dynamic values into the initial log string.
* Explicitly save the values we need for log line comparisons instead of cloning the entire LogEntry.
* Logging level is never dimmed.
* Timestamp prefix is always dimmed if same as in previous entry.
* Change initial padding for component and node columns.
* File name and line are now always colored by hashing the file name.
* Change separator between log line header and log line contents.
* Log message is not colored.
* Attribute keys are now always dimmed.
* Attribute values are now colored (by hashing the key so that all attribute values for the same key can be spotted at a glance). As an exception, error values are always red, and component values are always colored by hashing the component name.