### PR TITLE
Make sure the callgraph always includes a node for weaver.Main.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -351,6 +351,7 @@ github.com/ServiceWeaver/weaver/internal/tool
     runtime
 github.com/ServiceWeaver/weaver/internal/tool/callgraph
     fmt
+    github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/bin
     github.com/ServiceWeaver/weaver/runtime/logging
     golang.org/x/exp/maps

--- a/internal/tool/callgraph/callgraph.go
+++ b/internal/tool/callgraph/callgraph.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/bin"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	"golang.org/x/exp/maps"
@@ -67,6 +68,10 @@ func (g *graph) nodes() []string {
 		components[edge.src] = struct{}{}
 		components[edge.dst] = struct{}{}
 	}
+
+	// Ensure we have a node for the main component.
+	components[runtime.Main] = struct{}{}
+
 	keys := maps.Keys(components)
 	sort.Strings(keys)
 	return keys


### PR DESCRIPTION
This node can be missed if, e.g., the binary only contains weaver.Main and no other components.