### PR TITLE
Remove sim.WorkloadPointer interface.

### DIFF
--- a/internal/sim/api_test.go
+++ b/internal/sim/api_test.go
@@ -83,9 +83,7 @@ func TestPassingSimulation(t *testing.T) {
 }
 
 // See TestInitByValueSimulation.
-type initByValueWorkload struct {
-	byPointerCalls int
-}
+type initByValueWorkload struct{}
 
 func (initByValueWorkload) Init(r Registrar) error {
 	r.RegisterGenerators("ByValue")

--- a/internal/sim/api_test.go
+++ b/internal/sim/api_test.go
@@ -74,7 +74,7 @@ func (d *divModWorkload) Mod(ctx context.Context, x, y int) error {
 }
 
 func TestPassingSimulation(t *testing.T) {
-	s := New[divModWorkload](t, Options{})
+	s := New(t, &divModWorkload{}, Options{})
 	r := s.Run(2 * time.Second)
 	t.Log(r.Summary())
 	if r.Err != nil {
@@ -87,7 +87,7 @@ type divideByZeroWorkload struct {
 }
 
 func (d *divideByZeroWorkload) Init(r Registrar) error {
-	r.RegisterGenerators("DivMod", intn{0, 1000}, intn{0, 1000})
+	r.RegisterGenerators("DivMod", intn{0, 10}, intn{0, 10})
 	return nil
 }
 
@@ -101,7 +101,7 @@ func (d *divideByZeroWorkload) DivMod(ctx context.Context, x, y int) error {
 }
 
 func TestFailingSimulation(t *testing.T) {
-	s := New[divideByZeroWorkload](t, Options{})
+	s := New(t, &divideByZeroWorkload{}, Options{})
 	r := s.Run(2 * time.Second)
 	t.Log(r.Summary())
 	if r.Err == nil {

--- a/internal/sim/sim.go
+++ b/internal/sim/sim.go
@@ -359,7 +359,7 @@ func (s *simulator) Simulate(ctx context.Context) (Results, error) {
 		dir := filepath.Join("testdata", "sim", s.name)
 		writeGraveyardEntry(dir, entry)
 	}
-	if err == nil || err == ctx.Err() {
+	if err != nil && err == ctx.Err() {
 		return Results{}, err
 	}
 	return Results{Err: err, History: s.history}, nil

--- a/internal/sim/sim_test.go
+++ b/internal/sim/sim_test.go
@@ -59,7 +59,7 @@ func TestSuccessfulSimulation(t *testing.T) {
 		FailureRate: 0.1,
 		YieldRate:   0.5,
 	}
-	s := New[successfulWorkload](t, Options{})
+	s := New(t, &successfulWorkload{}, Options{})
 	results, err := s.runOne(context.Background(), opts)
 	if err != nil {
 		t.Fatal(err)
@@ -93,7 +93,7 @@ func TestUnsuccessfulSimulation(t *testing.T) {
 		FailureRate: 0.1,
 		YieldRate:   0.5,
 	}
-	s := New[unsuccessfulWorkload](t, Options{})
+	s := New(t, &unsuccessfulWorkload{}, Options{})
 	results, err := s.runOne(context.Background(), opts)
 	if err == nil && results.Err == nil {
 		t.Fatal("unexpected success")
@@ -114,7 +114,7 @@ func TestSimulateGraveyardEntries(t *testing.T) {
 			FailureRate: entry.FailureRate,
 			YieldRate:   entry.YieldRate,
 		}
-		s := New[unsuccessfulWorkload](t, Options{})
+		s := New(t, &unsuccessfulWorkload{}, Options{})
 		results, err := s.runOne(context.Background(), opts)
 		if err == nil && results.Err == nil {
 			t.Fatal("unexpected success")
@@ -140,7 +140,7 @@ func (c *cancellableWorkload) Block(ctx context.Context) error {
 func TestCancelledSimulation(t *testing.T) {
 	// Run a blocking simulation and cancel it.
 	opts := options{NumReplicas: 10, NumOps: 1000}
-	s := New[cancellableWorkload](t, Options{})
+	s := New(t, &cancellableWorkload{}, Options{})
 
 	const delay = 100 * time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), delay)
@@ -193,7 +193,7 @@ func TestFailureRateZero(t *testing.T) {
 		FailureRate: 0.0,
 		YieldRate:   0.5,
 	}
-	s := New[noFailureWorkload](t, Options{})
+	s := New(t, &noFailureWorkload{}, Options{})
 	results, err := s.runOne(context.Background(), opts)
 	if err != nil {
 		t.Fatal(err)
@@ -229,7 +229,7 @@ func TestFailureRateOne(t *testing.T) {
 		FailureRate: 1.0,
 		YieldRate:   0.5,
 	}
-	s := New[totalFailureWorkload](t, Options{})
+	s := New(t, &totalFailureWorkload{}, Options{})
 	results, err := s.runOne(context.Background(), opts)
 	if err != nil {
 		t.Fatal(err)
@@ -315,7 +315,7 @@ func TestInjectedErrors(t *testing.T) {
 		FailureRate: 0.5,
 		YieldRate:   0.5,
 	}
-	s := New[injectedErrorWorkload](t, Options{})
+	s := New(t, &injectedErrorWorkload{}, Options{})
 	results, err := s.runOne(context.Background(), opts)
 	if err != nil || results.Err != nil {
 		t.Fatal(err)
@@ -360,7 +360,7 @@ func TestFakes(t *testing.T) {
 		NumOps:      1000,
 		YieldRate:   0.5,
 	}
-	s := New[fakeWorkload](t, Options{})
+	s := New(t, &fakeWorkload{}, Options{})
 	results, err := s.runOne(context.Background(), opts)
 	if err != nil || results.Err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR removes the `WorkloadPointer` interface, as suggested by Srdjan in https://github.com/ServiceWeaver/weaver/pull/588. The `New` function now has the following signature:

```go
func New(t *testing.T, x Workload, opts Options) *Simulator
```

This PR also addresses a subtlety in how Go defines method sets. Consider the following workload:

```go
type myWorkload struct{}
func (myWorkload) Init(sim.Registrar) error { ... }
func (myWorkload) Foo(context.Context) error { ... }
func (*myWorkload) Bar(context.Context) error { ... }
```

`myWorkload` implements the `Workload` interface and is a valid workload. Thus, a simulator should call all of `myWorkload`'s methods. But, which methods are defined on `myWorkload`? The answer might surprise you!

According to [the Go spec][spec], the method set of `myWorkload` includes `Init` and `Foo` but not `Bar` because `Bar` has a pointer receiver. `*myWorkload`, on the other hand, has `Init`, `Foo`, and `Bar` in its method set.

Thus, if we're being careful, we can't just call the methods defined on the workload type. We may have to take a pointer to the type first. This PR implements that.

This PR also tweaks a flaky test.

[spec]: https://go.dev/ref/spec#Method_sets