### PR TITLE
Update the [kube] example.

### DIFF
--- a/examples/collatz/weaver.toml
+++ b/examples/collatz/weaver.toml
@@ -18,5 +18,5 @@ listeners.collatz = {public_hostname = "collatz.example.com"}
 
 [kube]
 listeners.collatz = {public = true}
-# To upload the image to another registry, check `weaver kube deploy -h`.
-image = "docker.io/my_docker_hub_username/collatz"
+# To upload the image to another repository, check `weaver kube deploy -h`.
+repo = "docker.io/my_docker_hub_username/"


### PR DESCRIPTION
We no longer use the `image` field - it has been replaced by separate "tag" and "repo" fields.