### PR TITLE
Optimized simulator trace contexts.

### DIFF
--- a/internal/sim/api.go
+++ b/internal/sim/api.go
@@ -129,7 +129,7 @@ type Options struct {
 // A Simulator deterministically simulates a Service Weaver application. See
 // the package documentation for instructions on how to use a Simulator.
 type Simulator struct {
-	t          *testing.T                             // underlying test
+	t          testing.TB                             // underlying test
 	w          reflect.Type                           // workload type
 	regsByIntf map[reflect.Type]*codegen.Registration // components, by interface
 	config     *protos.AppConfig                      // application config
@@ -223,7 +223,7 @@ type Results struct {
 }
 
 // New returns a new Simulator that simulates the provided workload.
-func New(t *testing.T, x Workload, opts Options) *Simulator {
+func New(t testing.TB, x Workload, opts Options) *Simulator {
 	// Note that because the Init method on a workload struct T often has a
 	// pointer receiver *T, it is the pointer *T (rather than T itself) that
 	// implements the Workload interface.
@@ -443,7 +443,7 @@ func (s *Simulator) runOne(ctx context.Context, opts options) (Results, error) {
 
 // registrar validates and collects registered fakes and components.
 type registrar struct {
-	t          *testing.T                             // underlying test
+	t          testing.TB                             // underlying test
 	w          reflect.Type                           // workload type
 	regsByIntf map[reflect.Type]*codegen.Registration // registered components, by interface
 	fakes      map[reflect.Type]any                   // fakes, by component interface


### PR DESCRIPTION
This PR optimizes how the simulator stores trace and span ids in contexts. Previously, we called `Context.WithValue` twice, once to embed a trace id and once to embed a span id. I believe that every call to `Context.WithValue` leads to an allocation, so this was redundant. I also changed the context key to a pointer, rather than allocating a new key every time.

This PR also adds some benchmarks to evaluate the effects of this (and future) optimizations. Here are the results. You can see that we decrease both the number of allocations and the amount of allocated memory. All workloads speed up, though only the simple workload has a significant speedup.

```
$ go test -run=$^ -bench=. -count=5 | tee /tmp/baseline.txt
$ go test -run=$^ -bench=. -count=5 | tee /tmp/experiment.txt
$ benchstat /tmp/{baseline,experiment}.txt
name                        old time/op    new time/op    delta
Workloads/NoCallsNoGen-128    6.49ms ± 2%    6.34ms ± 1%   -2.40%  (p=0.016 n=5+5)
Workloads/NoCalls-128         7.88ms ± 2%    7.79ms ± 2%     ~     (p=0.310 n=5+5)
Workloads/OneCall-128         17.5ms ± 2%    17.1ms ± 2%     ~     (p=0.056 n=5+5)

name                        old alloc/op   new alloc/op   delta
Workloads/NoCallsNoGen-128     557kB ± 0%     513kB ± 0%   -7.89%  (p=0.008 n=5+5)
Workloads/NoCalls-128          666kB ± 0%     622kB ± 0%   -6.63%  (p=0.008 n=5+5)
Workloads/OneCall-128         2.28MB ± 0%    2.24MB ± 0%   -1.96%  (p=0.008 n=5+5)

name                        old allocs/op  new allocs/op  delta
Workloads/NoCallsNoGen-128     11.6k ± 0%     10.1k ± 0%  -12.86%  (p=0.008 n=5+5)
Workloads/NoCalls-128          15.6k ± 0%     14.1k ± 0%   -9.55%  (p=0.008 n=5+5)
Workloads/OneCall-128          49.0k ± 0%     47.4k ± 0%   -3.28%  (p=0.008 n=5+5)
```