### PR TITLE
Don't allocate slice to pick candidate steps.

### DIFF
--- a/internal/sim/api.go
+++ b/internal/sim/api.go
@@ -129,7 +129,7 @@ type Options struct {
 // A Simulator deterministically simulates a Service Weaver application. See
 // the package documentation for instructions on how to use a Simulator.
 type Simulator struct {
-	t          *testing.T                             // underlying test
+	t          testing.TB                             // underlying test
 	w          reflect.Type                           // workload type
 	regsByIntf map[reflect.Type]*codegen.Registration // components, by interface
 	config     *protos.AppConfig                      // application config
@@ -223,7 +223,7 @@ type Results struct {
 }
 
 // New returns a new Simulator that simulates the provided workload.
-func New(t *testing.T, x Workload, opts Options) *Simulator {
+func New(t testing.TB, x Workload, opts Options) *Simulator {
 	// Note that because the Init method on a workload struct T often has a
 	// pointer receiver *T, it is the pointer *T (rather than T itself) that
 	// implements the Workload interface.
@@ -443,7 +443,7 @@ func (s *Simulator) runOne(ctx context.Context, opts options) (Results, error) {
 
 // registrar validates and collects registered fakes and components.
 type registrar struct {
-	t          *testing.T                             // underlying test
+	t          testing.TB                             // underlying test
 	w          reflect.Type                           // workload type
 	regsByIntf map[reflect.Type]*codegen.Registration // registered components, by interface
 	fakes      map[reflect.Type]any                   // fakes, by component interface


### PR DESCRIPTION
This PR slightly optimizes how a simulator picks the next action to take. Before, the simulator allocated a slice of candidate steps. With this PR, we avoid allocating the slice.

```
$ go test -run=$^ -bench=. -count=5 | tee /tmp/baseline.txt
$ go test -run=$^ -bench=. -count=5 | tee /tmp/experiment.txt
$ benchstat /tmp/{baseline,experiment}.txt
name                        old time/op    new time/op    delta
Workloads/NoCallsNoGen-128    6.30ms ± 1%    6.39ms ± 2%    ~     (p=0.310 n=5+5)
Workloads/NoCalls-128         7.77ms ± 1%    7.79ms ± 2%    ~     (p=0.841 n=5+5)
Workloads/OneCall-128         17.1ms ± 3%    16.7ms ± 3%    ~     (p=0.222 n=5+5)

name                        old alloc/op   new alloc/op   delta
Workloads/NoCallsNoGen-128     513kB ± 0%     513kB ± 0%    ~     (p=0.968 n=5+5)
Workloads/NoCalls-128          622kB ± 0%     622kB ± 0%    ~     (p=1.000 n=5+5)
Workloads/OneCall-128         2.24MB ± 0%    2.22MB ± 0%  -0.73%  (p=0.008 n=5+5)

name                        old allocs/op  new allocs/op  delta
Workloads/NoCallsNoGen-128     10.1k ± 0%     10.1k ± 0%    ~     (all equal)
Workloads/NoCalls-128          14.1k ± 0%     14.1k ± 0%    ~     (all equal)
Workloads/OneCall-128          47.4k ± 0%     45.4k ± 0%  -4.22%  (p=0.008 n=5+5)
```