### PR TITLE
Re-run graveyard entries in the simulator.

### DIFF
--- a/internal/sim/api.go
+++ b/internal/sim/api.go
@@ -129,7 +129,7 @@ type Options struct {
 // A Simulator deterministically simulates a Service Weaver application. See
 // the package documentation for instructions on how to use a Simulator.
 type Simulator struct {
-	t          *testing.T                             // underlying test
+	t          testing.TB                             // underlying test
 	w          reflect.Type                           // workload type
 	regsByIntf map[reflect.Type]*codegen.Registration // components, by interface
 	config     *protos.AppConfig                      // application config
@@ -223,7 +223,7 @@ type Results struct {
 }
 
 // New returns a new Simulator that simulates the provided workload.
-func New(t *testing.T, x Workload, opts Options) *Simulator {
+func New(t testing.TB, x Workload, opts Options) *Simulator {
 	// Note that because the Init method on a workload struct T often has a
 	// pointer receiver *T, it is the pointer *T (rather than T itself) that
 	// implements the Workload interface.
@@ -443,7 +443,7 @@ func (s *Simulator) runOne(ctx context.Context, opts options) (Results, error) {
 
 // registrar validates and collects registered fakes and components.
 type registrar struct {
-	t          *testing.T                             // underlying test
+	t          testing.TB                             // underlying test
 	w          reflect.Type                           // workload type
 	regsByIntf map[reflect.Type]*codegen.Registration // registered components, by interface
 	fakes      map[reflect.Type]any                   // fakes, by component interface

--- a/internal/sim/graveyard.go
+++ b/internal/sim/graveyard.go
@@ -97,8 +97,6 @@ type graveyardEntry struct {
 }
 
 // readGraveyard reads all the graveyard entries stored in the provided directory.
-//
-//lint:ignore U1000 This function will be used in the future.
 func readGraveyard(dir string) ([]graveyardEntry, error) {
 	// This code borrows from https://cs.opensource.google/go/go/+/master:src/internal/fuzz/fuzz.go;drc=14ab998f95b53baa6e336c598b0f34e319cc9717.
 	files, err := os.ReadDir(dir)


### PR DESCRIPTION
Recall that when a simulator encounters a failing execution, it persists the execution's hyperparameters to a file on disk. The collection of these files is called a graveyard. This PR updates the simulator to re-run the failing executions stored in the graveyard.