### PR TITLE
Bump up the module version number.

### DIFF
--- a/examples/chat/weaver_gen.go
+++ b/examples/chat/weaver_gen.go
@@ -720,7 +720,7 @@ func (s sQLStore_client_stub) GetImage(ctx context.Context, a0 string, a1 ImageI
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/examples/collatz/weaver_gen.go
+++ b/examples/collatz/weaver_gen.go
@@ -289,7 +289,7 @@ func (s odd_client_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/examples/factors/weaver_gen.go
+++ b/examples/factors/weaver_gen.go
@@ -183,7 +183,7 @@ var _ weaver.Main = (*main_client_stub)(nil)
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/examples/fakes/weaver_gen.go
+++ b/examples/fakes/weaver_gen.go
@@ -133,7 +133,7 @@ func (s clock_client_stub) UnixMicro(ctx context.Context) (r0 int64, err error) 
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/examples/hello/weaver_gen.go
+++ b/examples/hello/weaver_gen.go
@@ -176,7 +176,7 @@ func (s reverser_client_stub) Reverse(ctx context.Context, a0 string) (r0 string
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/examples/helloworld/weaver_gen.go
+++ b/examples/helloworld/weaver_gen.go
@@ -60,7 +60,7 @@ var _ weaver.Main = (*main_client_stub)(nil)
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/examples/reverser/weaver_gen.go
+++ b/examples/reverser/weaver_gen.go
@@ -176,7 +176,7 @@ func (s reverser_client_stub) Reverse(ctx context.Context, a0 string) (r0 string
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/internal/benchmarks/weaver_gen.go
+++ b/internal/benchmarks/weaver_gen.go
@@ -1920,7 +1920,7 @@ func (s ping9_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/internal/sim/weaver_gen.go
+++ b/internal/sim/weaver_gen.go
@@ -592,7 +592,7 @@ func (s mod_client_stub) Mod(ctx context.Context, a0 int, a1 int) (r0 int, err e
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/internal/testdeployer/weaver_gen.go
+++ b/internal/testdeployer/weaver_gen.go
@@ -369,7 +369,7 @@ func (s c_client_stub) C(ctx context.Context, a0 int) (r0 int, err error) {
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/internal/tool/generate/example/weaver_gen.go
+++ b/internal/tool/generate/example/weaver_gen.go
@@ -439,7 +439,7 @@ func (s b_client_stub) M2(ctx context.Context, a0 int, a1 string, a2 bool, a3 [1
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/internal/tool/generate/generator_test.go
+++ b/internal/tool/generate/generator_test.go
@@ -459,7 +459,7 @@ func TestExampleVersion(t *testing.T) {
 	got := fmt.Sprintf("%x", h.Sum(nil))
 
 	// If weaver_gen.go has changed, the codegen version may need updating.
-	const want = "2f98821d5b425b43781954029cc513cd76362910321b0bf4079a41ea20187bd1"
+	const want = "19b9902b0a2f4909f6cea086e8d6f7bd7f39dad21c2bb0efefa0208d04149086"
 	if got != want {
 		t.Fatalf(`Unexpected SHA-256 hash of examples/weaver_gen.go: got %s, want %s. If this change is meaningful, REMEMBER TO UPDATE THE CODEGEN VERSION in runtime/version/version.go.`, got, want)
 	}

--- a/runtime/bin/bin.go
+++ b/runtime/bin/bin.go
@@ -41,7 +41,7 @@ func init() {
 	// the values of version.ModuleVersion and version.DeployerVersion. If the
 	// string is not a constant---if we try to use fmt.Sprintf, for
 	// example---it will not be embedded in a Service Weaver binary.
-	versionData = "⟦wEaVeRvErSiOn:module=v0.20.0;deployer=v0.20.0⟧"
+	versionData = "⟦wEaVeRvErSiOn:module=v0.21.0;deployer=v0.20.0⟧"
 }
 
 // rodata returns the read-only data section of the provided binary.

--- a/runtime/bin/testprogram/weaver_gen.go
+++ b/runtime/bin/testprogram/weaver_gen.go
@@ -163,7 +163,7 @@ var _ weaver.Main = (*main_client_stub)(nil)
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/runtime/version/version.go
+++ b/runtime/version/version.go
@@ -28,7 +28,7 @@ const (
 	//
 	// [1]: https://go.dev/doc/modules/version-numbers
 	ModuleMajor = 0
-	ModuleMinor = 20
+	ModuleMinor = 21
 	ModulePatch = 0
 
 	// Note that there is currently no way to programmatically get the version

--- a/weavertest/internal/chain/weaver_gen.go
+++ b/weavertest/internal/chain/weaver_gen.go
@@ -365,7 +365,7 @@ func (s c_client_stub) Propagate(ctx context.Context, a0 int) (err error) {
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/weavertest/internal/deploy/weaver_gen.go
+++ b/weavertest/internal/deploy/weaver_gen.go
@@ -253,7 +253,7 @@ func (s widget_client_stub) Use(ctx context.Context, a0 string) (err error) {
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/weavertest/internal/diverge/weaver_gen.go
+++ b/weavertest/internal/diverge/weaver_gen.go
@@ -246,7 +246,7 @@ func (s pointer_client_stub) Get(ctx context.Context) (r0 Pair, err error) {
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/weavertest/internal/generate/weaver_gen.go
+++ b/weavertest/internal/generate/weaver_gen.go
@@ -304,7 +304,7 @@ func (s testApp_client_stub) IncPointer(ctx context.Context, a0 *int) (r0 *int, 
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/weavertest/internal/protos/weaver_gen.go
+++ b/weavertest/internal/protos/weaver_gen.go
@@ -137,7 +137,7 @@ func (s pingPonger_client_stub) Ping(ctx context.Context, a0 *Ping) (r0 *Pong, e
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/weavertest/internal/simple/weaver_gen.go
+++ b/weavertest/internal/simple/weaver_gen.go
@@ -748,7 +748,7 @@ func (s source_client_stub) Emit(ctx context.Context, a0 string, a1 string) (err
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.20.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.21.0 (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.


### PR DESCRIPTION
We've had some backward-incompatible changes (e.g., auto-retries).