### PR TITLE
Optimized sim config filling; avoid reflection.

### DIFF
--- a/fill.go
+++ b/fill.go
@@ -29,6 +29,7 @@ func init() {
 	weaver.SetLogger = setLogger
 	weaver.FillRefs = fillRefs
 	weaver.FillListeners = fillListeners
+	weaver.GetConfig = getConfig
 }
 
 // See internal/weaver/types.go.
@@ -118,6 +119,14 @@ func fillListeners(impl any, get func(name string) (net.Listener, string, error)
 		l := (*Listener)(f.Addr().UnsafePointer())
 		l.Listener = lis
 		l.proxyAddr = proxyAddr
+	}
+	return nil
+}
+
+// See internal/weaver/types.go.
+func getConfig(impl any) any {
+	if c, ok := impl.(interface{ getConfig() any }); ok {
+		return c.getConfig()
 	}
 	return nil
 }

--- a/godeps.txt
+++ b/godeps.txt
@@ -273,7 +273,6 @@ github.com/ServiceWeaver/weaver/internal/sim
     errors
     fmt
     github.com/ServiceWeaver/weaver
-    github.com/ServiceWeaver/weaver/internal/config
     github.com/ServiceWeaver/weaver/internal/reflection
     github.com/ServiceWeaver/weaver/internal/weaver
     github.com/ServiceWeaver/weaver/runtime

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,9 @@ import (
 //
 // Config panics if the provided value is not a pointer to a struct.
 func Config(v reflect.Value) any {
+	// TODO(mwhittaker): Delete this function and use weaver.GetConfig instead.
+	// Right now, there are some cyclic dependencies preventing us from doing
+	// this.
 	if v.Kind() != reflect.Pointer || v.Elem().Kind() != reflect.Struct {
 		panic(fmt.Errorf("invalid non pointer to struct value: %v", v))
 	}

--- a/internal/sim/sim.go
+++ b/internal/sim/sim.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 
 	core "github.com/ServiceWeaver/weaver"
-	"github.com/ServiceWeaver/weaver/internal/config"
 	"github.com/ServiceWeaver/weaver/internal/weaver"
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
@@ -209,7 +208,7 @@ func newSimulator(name string, workload any, regsByIntf map[reflect.Type]*codege
 			obj := v.Interface()
 
 			// Fill config.
-			if cfg := config.Config(v); cfg != nil {
+			if cfg := weaver.GetConfig(obj); cfg != nil {
 				if err := runtime.ParseConfigSection(reg.Name, "", app.Sections, cfg); err != nil {
 					return nil, err
 				}

--- a/internal/weaver/types.go
+++ b/internal/weaver/types.go
@@ -40,4 +40,8 @@ var (
 	//   - get should be a function that returns the required Listener values,
 	//     namely the network listener and the proxy address.
 	FillListeners func(impl any, get func(string) (net.Listener, string, error)) error
+
+	// GetConfig returns the config stored in the provided component
+	// implementation, or returns nil if there is no config.
+	GetConfig func(impl any) any
 )

--- a/weaver.go
+++ b/weaver.go
@@ -409,6 +409,11 @@ func (wc *WithConfig[T]) Config() *T {
 	return &wc.config
 }
 
+// getConfig returns the underlying config.
+func (wc *WithConfig[T]) getConfig() any {
+	return &wc.config
+}
+
 // WithRouter[T] is a type that can be embedded inside a component
 // implementation struct to indicate that calls to a method M on the component
 // must be routed according to the the value returned by T.M().


### PR DESCRIPTION
Recall that a simulator has to initialize a set of components. Part of this initialization involves filling in any `weaver.WithConfig`s. Previously, we used the `config.Config` function to do this, but `config.Config` is slow and allocates a lot because it heavily uses reflection. This PR replaces `config.Config` with a more optimized approach that doesn't use any reflection.

```
$ go test -run=$^ -bench=. -count=5 | tee /tmp/baseline.txt
$ go test -run=$^ -bench=. -count=5 | tee /tmp/experiment.txt
$ benchstat /tmp/{baseline,experiment}.txt
name                        old time/op    new time/op    delta
NewWorkload-128               1.30µs ± 1%    1.30µs ± 1%     ~     (p=0.690 n=5+5)
NewSimulator-128              31.6µs ± 2%    26.6µs ± 2%  -15.63%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128    40.6µs ± 4%    38.4µs ± 2%   -5.35%  (p=0.008 n=5+5)
Workloads/NoCalls-128         44.8µs ± 1%    40.7µs ± 2%   -9.11%  (p=0.008 n=5+5)
Workloads/OneCall-128         60.0µs ± 2%    56.6µs ± 1%   -5.59%  (p=0.008 n=5+5)

name                        old alloc/op   new alloc/op   delta
NewWorkload-128                 464B ± 0%      464B ± 0%     ~     (all equal)
NewSimulator-128              7.95kB ± 0%    7.61kB ± 0%   -4.33%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128    8.53kB ± 0%    8.19kB ± 0%   -4.03%  (p=0.008 n=5+5)
Workloads/NoCalls-128         9.08kB ± 0%    8.70kB ± 0%   -4.18%  (p=0.008 n=5+5)
Workloads/OneCall-128         11.0kB ± 0%    10.6kB ± 0%   -3.44%  (p=0.008 n=5+5)

name                        old allocs/op  new allocs/op  delta
NewWorkload-128                 3.00 ± 0%      3.00 ± 0%     ~     (all equal)
NewSimulator-128                70.0 ± 0%      53.0 ± 0%  -24.29%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128      85.0 ± 0%      68.0 ± 0%  -20.00%  (p=0.008 n=5+5)
Workloads/NoCalls-128           99.0 ± 0%      82.0 ± 0%  -17.17%  (p=0.008 n=5+5)
Workloads/OneCall-128            138 ± 0%       121 ± 0%  -12.32%  (p=0.008 n=5+5)
```