### PR TITLE
Optimized ref filling.

### DIFF
--- a/weaver.go
+++ b/weaver.go
@@ -286,6 +286,11 @@ func (r Ref[T]) Get() T { return r.value }
 // used internally to check that a value is of type Ref[T].
 func (r Ref[T]) isRef() {}
 
+// setRef sets the underlying value of a Ref.
+func (r *Ref[T]) setRef(value any) {
+	r.value = value.(T)
+}
+
 // Listener is a network listener that can be placed as a field inside a
 // component implementation struct. Once placed, Service Weaver automatically
 // initializes the Listener and makes it suitable for receiving network


### PR DESCRIPTION
This PR speeds up how we fill `weaver.Ref`s by using less reflection.

```
$ go test -run=$^ -bench=. -count=5 | tee /tmp/baseline.txt
$ go test -run=$^ -bench=. -count=5 | tee /tmp/experiment.txt
$ benchstat /tmp/{baseline,experiment}.txt
ok      github.com/ServiceWeaver/weaver/internal/sim    38.134s
name                        old time/op    new time/op    delta
NewWorkload-128               1.30µs ± 1%    1.29µs ± 2%    ~     (p=0.278 n=5+5)
NewSimulator-128              26.6µs ± 2%    24.3µs ± 1%  -8.98%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128    38.4µs ± 2%    37.3µs ± 2%    ~     (p=0.056 n=5+5)
Workloads/NoCalls-128         40.7µs ± 2%    39.6µs ± 4%    ~     (p=0.095 n=5+5)
Workloads/OneCall-128         56.6µs ± 1%    55.8µs ± 3%    ~     (p=0.310 n=5+5)

name                        old alloc/op   new alloc/op   delta
NewWorkload-128                 464B ± 0%      464B ± 0%    ~     (all equal)
NewSimulator-128              7.61kB ± 0%    7.58kB ± 0%  -0.42%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128    8.19kB ± 0%    8.15kB ± 0%  -0.39%  (p=0.008 n=5+5)
Workloads/NoCalls-128         8.70kB ± 0%    8.67kB ± 0%  -0.37%  (p=0.008 n=5+5)
Workloads/OneCall-128         10.6kB ± 0%    10.6kB ± 0%  -0.37%  (p=0.008 n=5+5)

name                        old allocs/op  new allocs/op  delta
NewWorkload-128                 3.00 ± 0%      3.00 ± 0%    ~     (all equal)
NewSimulator-128                53.0 ± 0%      49.0 ± 0%  -7.55%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128      68.0 ± 0%      64.0 ± 0%  -5.88%  (p=0.008 n=5+5)
Workloads/NoCalls-128           82.0 ± 0%      78.0 ± 0%  -4.88%  (p=0.008 n=5+5)
Workloads/OneCall-128            121 ± 0%       116 ± 0%  -4.13%  (p=0.008 n=5+5)
```