### PR TITLE
Re-use simulator memory to avoid allocations.

### DIFF
--- a/internal/sim/api.go
+++ b/internal/sim/api.go
@@ -283,14 +283,15 @@ func New(t testing.TB, x Workload, opts Options) *Simulator {
 	}
 
 	// Call Init and validate the registered fakes and generators.
-	r := &registrar{t: t, w: w, methods: methods, regsByIntf: regsByIntf}
+	s := &Simulator{t, w, methods, regsByIntf, app}
+	r := s.newRegistrar()
 	if err := x.Init(r); err != nil {
 		t.Fatalf("sim.New: %v", err)
 	}
 	if err := r.finalize(); err != nil {
 		t.Fatalf("sim.New: %v", err)
 	}
-	return &Simulator{t, w, methods, regsByIntf, app}
+	return s
 }
 
 // validateWorkload validates a workload struct of the provided type.
@@ -359,13 +360,15 @@ func (s *Simulator) Run(duration time.Duration) Results {
 	for i := 0; i < n; i++ {
 		go func() {
 			defer done.Done()
+			r := s.newRegistrar()
+			sim := s.newSimulator()
 			for {
 				select {
 				case <-ctx.Done():
 					return
 				case o := <-opts:
 					atomic.AddInt64(&numSimulations, 1)
-					switch r, err := s.runOne(ctx, o); {
+					switch r, err := s.simulateOne(ctx, r, sim, o); {
 					case err != nil && err == ctx.Err():
 						// The simulation was cancelled because the deadline
 						// was met. Stop executing simulations.
@@ -456,30 +459,39 @@ func (s *Simulator) Run(duration time.Duration) Results {
 	}
 }
 
+// newRegistar returns a new registrar.
+func (s *Simulator) newRegistrar() *registrar {
+	return newRegistrar(s.t, s.w, s.methods, s.regsByIntf)
+}
+
 // newWorkload returns a new, fully validated workload instance.
-func (s *Simulator) newWorkload(ctx context.Context) (Workload, *registrar, error) {
+func (s *Simulator) newWorkload(ctx context.Context, r *registrar) (Workload, error) {
 	// Construct an instance of the workload struct.
 	workload := reflect.New(s.w.Elem()).Interface().(Workload)
 
 	// Call the struct's Init method.
-	r := &registrar{t: s.t, w: s.w, methods: s.methods, regsByIntf: s.regsByIntf}
+	r.reset()
 	if err := workload.Init(r); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if err := r.finalize(); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return workload, r, nil
+	return workload, nil
 }
 
-// runOne runs a single simulation.
-func (s *Simulator) runOne(ctx context.Context, opts options) (Results, error) {
-	workload, r, err := s.newWorkload(ctx)
+// newSimulator returns a new simulator.
+func (s *Simulator) newSimulator() *simulator {
+	return newSimulator(s.t.Name(), s.regsByIntf, s.config)
+}
+
+// simulateOne runs a single simulation.
+func (s *Simulator) simulateOne(ctx context.Context, r *registrar, sim *simulator, opts options) (Results, error) {
+	workload, err := s.newWorkload(ctx, r)
 	if err != nil {
 		return Results{}, err
 	}
-	sim, err := newSimulator(s.t.Name(), workload, s.regsByIntf, s.config, r.fakes, r.ops(), opts)
-	if err != nil {
+	if err := sim.reset(workload, r.fakes, r.ops, opts); err != nil {
 		return Results{}, err
 	}
 	return sim.Simulate(ctx)
@@ -492,7 +504,44 @@ type registrar struct {
 	methods    map[string]reflect.Method              // non-Init exported methods, by name
 	regsByIntf map[reflect.Type]*codegen.Registration // registered components, by interface
 	fakes      map[reflect.Type]any                   // fakes, by component interface
-	generators map[string][]generator                 // generators, by method name
+	ops        []*op                                  // operations
+	opsByName  map[string]int                         // index into ops, by name
+}
+
+// newRegistrar returns a new registrar.
+func newRegistrar(t testing.TB, w reflect.Type, methods map[string]reflect.Method, regsByIntf map[reflect.Type]*codegen.Registration) *registrar {
+	ops := make([]*op, 0, len(methods))
+	opsByName := make(map[string]int, len(methods))
+	i := 0
+	for _, m := range methods {
+		ops = append(ops, &op{
+			name:       m.Name,
+			arity:      m.Type.NumIn() - 2,
+			generators: []generator{},
+			f:          m.Func,
+		})
+		opsByName[m.Name] = i
+		i++
+	}
+	return &registrar{
+		t:          t,
+		w:          w,
+		methods:    methods,
+		regsByIntf: regsByIntf,
+		fakes:      map[reflect.Type]any{},
+		ops:        ops,
+		opsByName:  opsByName,
+	}
+}
+
+// reset resets a registrar.
+func (r *registrar) reset() {
+	for k := range r.fakes {
+		delete(r.fakes, k)
+	}
+	for _, op := range r.ops {
+		op.generators = op.generators[:0]
+	}
 }
 
 // RegisterFake implements the Registrar interface.
@@ -519,28 +568,25 @@ func (r *registrar) registerFakes(fake FakeComponent) error {
 	if _, ok := r.regsByIntf[fake.intf]; !ok {
 		return fmt.Errorf("component %v not found", fake.intf)
 	}
-	if r.fakes == nil {
-		r.fakes = map[reflect.Type]any{}
-	}
 	r.fakes[fake.intf] = fake.impl
 	return nil
 }
 
 // registerGenerators implements RegisterGenerators.
 func (r *registrar) registerGenerators(method string, generators ...any) error {
-	if _, ok := r.generators[method]; ok {
-		return fmt.Errorf("method %q generators already registered", method)
-	}
 	m, ok := r.methods[method]
 	if !ok {
 		return fmt.Errorf("method %q not found", method)
 	}
-	if got, want := len(generators), m.Type.NumIn()-2; got != want {
+	op := r.ops[r.opsByName[method]]
+	if len(op.generators) > 0 {
+		return fmt.Errorf("method %q generators already registered", method)
+	}
+	if got, want := len(generators), op.arity; got != want {
 		return fmt.Errorf("method %v: want %d generators, got %d", method, want, got)
 	}
 
 	var errs []error
-	var gens []generator
 	for i, generator := range generators {
 		// TODO(mwhittaker): Handle the case where a generator's Generate
 		// method receives by pointer, but the user passed by value.
@@ -577,43 +623,23 @@ func (r *registrar) registerGenerators(method string, generators ...any) error {
 		}
 
 		generator := generator
-		gens = append(gens, func(r *rand.Rand) reflect.Value {
+		op.generators = append(op.generators, func(r *rand.Rand) reflect.Value {
 			in := []reflect.Value{reflect.ValueOf(generator), reflect.ValueOf(r)}
 			return generate.Func.Call(in)[0]
 		})
 	}
-	if err := errors.Join(errs...); err != nil {
-		return err
-	}
-	if r.generators == nil {
-		r.generators = map[string][]generator{}
-	}
-	r.generators[method] = gens
-	return nil
+	return errors.Join(errs...)
 }
 
 // finalize finalizes registration.
 func (r *registrar) finalize() error {
 	var errs []error
-	for _, m := range r.methods {
-		if _, ok := r.generators[m.Name]; !ok {
-			errs = append(errs, fmt.Errorf("no generators registered for method %s", m.Name))
+	for _, op := range r.ops {
+		if len(op.generators) != op.arity {
+			errs = append(errs, fmt.Errorf("no generators registered for method %s", op.name))
 		}
 	}
 	return errors.Join(errs...)
-}
-
-// ops returns the ops of a workload.
-func (r *registrar) ops() []op {
-	ops := make([]op, 0, len(r.methods))
-	for _, m := range r.methods {
-		ops = append(ops, op{
-			name:       m.Name,
-			generators: r.generators[m.Name],
-			f:          m.Func,
-		})
-	}
-	return ops
 }
 
 // Summary returns a human readable summary of the results.

--- a/internal/sim/rand.go
+++ b/internal/sim/rand.go
@@ -61,21 +61,29 @@ type ints struct {
 	indices []int
 }
 
-// newInts returns a new set of integers in the range [low, high).
-// newInts panics if low >= high.
-func newInts(low, high int) *ints {
+// reset resets a set of integers to the range [low, high).
+// reset panics if low >= high.
+func (i *ints) reset(low, high int) {
 	if low >= high {
 		panic(fmt.Errorf("newInts: low (%d) >= high (%d)", low, high))
 	}
 
+	i.low = low
+	i.high = high
 	n := high - low
-	elements := make([]int, n)
-	indices := make([]int, n)
-	for i := 0; i < n; i++ {
-		elements[i] = low + i
-		indices[i] = i
+	if i.elements == nil {
+		i.elements = make([]int, n)
 	}
-	return &ints{low, high, elements, indices}
+	i.elements = i.elements[:0]
+	if i.indices == nil {
+		i.indices = make([]int, n)
+	}
+	i.indices = i.indices[:0]
+
+	for j := 0; j < n; j++ {
+		i.elements = append(i.elements, low+j)
+		i.indices = append(i.indices, j)
+	}
 }
 
 // has returns whether the provided integer is in the set.

--- a/internal/sim/rand_test.go
+++ b/internal/sim/rand_test.go
@@ -20,6 +20,14 @@ import (
 	"time"
 )
 
+// newInts returns a new set of integers in the range [low, high).
+// newInts panics if low >= high.
+func newInts(low, high int) *ints {
+	i := &ints{}
+	i.reset(low, high)
+	return i
+}
+
 func TestIntsHas(t *testing.T) {
 	const low = 10
 	const high = 100

--- a/internal/sim/sim.go
+++ b/internal/sim/sim.go
@@ -53,7 +53,7 @@ type simulator struct {
 	config     *protos.AppConfig                      // application config
 	opts       options                                // simulator options
 	components map[string][]any                       // component replicas
-	ops        []op                                   // registered ops
+	ops        []*op                                  // registered ops
 
 	ctx   context.Context // simulation context
 	group *errgroup.Group // group with all running goroutines
@@ -62,7 +62,7 @@ type simulator struct {
 	rand        *rand.Rand       // random number generator
 	current     int              // currently running op
 	numStarted  int              // number of started ops
-	notFinished *ints            // not finished op trace ids, optimized for removal and sampling
+	notFinished ints             // not finished op trace ids, optimized for removal and sampling
 	calls       map[int][]*call  // pending calls, by trace id
 	replies     map[int][]*reply // pending replies, by trace id
 	history     []Event          // history of events
@@ -77,6 +77,7 @@ type generator func(*rand.Rand) reflect.Value
 // derived from exported methods on a workload struct.
 type op struct {
 	name       string        // the name of the op
+	arity      int           // arity of op, ignoring context.Context argument
 	generators []generator   // the op's generators
 	f          reflect.Value // the op method itself
 }
@@ -151,57 +152,70 @@ func extractIDs(ctx context.Context) (int, int) {
 	return traceID, spanID
 }
 
-// newSimulator returns a new Simulator.
-func newSimulator(name string, workload any, regsByIntf map[reflect.Type]*codegen.Registration, app *protos.AppConfig, fakes map[reflect.Type]any, ops []op, opts options) (*simulator, error) {
-	// Validate options.
-	if opts.NumReplicas <= 0 {
-		return nil, fmt.Errorf("NumReplicas (%d) <= 0", opts.NumReplicas)
-	}
-	if opts.NumOps <= 0 {
-		return nil, fmt.Errorf("NumOps (%d) <= 0", opts.NumOps)
-	}
-	if opts.FailureRate < 0 || opts.FailureRate > 1 {
-		return nil, fmt.Errorf("FailureRate (%f) out of range [0, 1]", opts.FailureRate)
-	}
-	if opts.YieldRate < 0 || opts.YieldRate > 1 {
-		return nil, fmt.Errorf("YieldRate (%f) out of range [0, 1]", opts.YieldRate)
-	}
-
-	// Create simulator.
-	//
-	// TODO(mwhittaker): Take a *testing.T and use the test name as the name.
+// newSimulator returns a new simulator.
+func newSimulator(name string, regsByIntf map[reflect.Type]*codegen.Registration, app *protos.AppConfig) *simulator {
 	s := &simulator{
 		name:       name,
-		workload:   reflect.ValueOf(workload),
-		opts:       opts,
 		config:     app,
 		regsByIntf: regsByIntf,
-		components: map[string][]any{},
-		ops:        ops,
-		rand:       rand.New(rand.NewSource(opts.Seed)),
-		// Start both trace and span ids at 1 to reserve 0 as an invalid id.
-		current:     1,
-		numStarted:  0,
-		notFinished: newInts(1, 1+opts.NumOps),
-		calls:       map[int][]*call{},
-		replies:     map[int][]*reply{},
-		nextTraceID: 1,
-		nextSpanID:  1,
+		components: make(map[string][]any, len(regsByIntf)),
+		calls:      map[int][]*call{},
+		replies:    map[int][]*reply{},
 	}
+	return s
+}
+
+func (s *simulator) reset(workload any, fakes map[reflect.Type]any, ops []*op, opts options) error {
+	// Validate options.
+	if opts.NumReplicas <= 0 {
+		return fmt.Errorf("NumReplicas (%d) <= 0", opts.NumReplicas)
+	}
+	if opts.NumOps <= 0 {
+		return fmt.Errorf("NumOps (%d) <= 0", opts.NumOps)
+	}
+	if opts.FailureRate < 0 || opts.FailureRate > 1 {
+		return fmt.Errorf("FailureRate (%f) out of range [0, 1]", opts.FailureRate)
+	}
+	if opts.YieldRate < 0 || opts.YieldRate > 1 {
+		return fmt.Errorf("YieldRate (%f) out of range [0, 1]", opts.YieldRate)
+	}
+
+	s.workload = reflect.ValueOf(workload)
+	s.opts = opts
+	s.ops = ops
+	s.rand = rand.New(rand.NewSource(opts.Seed))
+	s.current = 1
+	s.numStarted = 0
+	s.notFinished.reset(1, 1+opts.NumOps)
+	for k, v := range s.calls {
+		s.calls[k] = v[:0]
+	}
+	for k, v := range s.replies {
+		s.replies[k] = v[:0]
+	}
+	s.history = []Event{}
+	s.nextTraceID = 1
+	s.nextSpanID = 1
 
 	// Fill ref fields inside the workload struct.
 	if err := weaver.FillRefs(workload, func(t reflect.Type) (any, error) {
 		return s.getIntf(t, "op", 0)
 	}); err != nil {
-		return nil, err
+		return err
 	}
 
 	// Create component replicas.
-	for _, reg := range regsByIntf {
+	for _, reg := range s.regsByIntf {
+		components := s.components[reg.Name]
+		if components != nil {
+			components = components[:0]
+		}
+
 		if fake, ok := fakes[reg.Iface]; ok {
-			s.components[reg.Name] = []any{fake}
+			s.components[reg.Name] = append(components, fake)
 			continue
 		}
+
 		for i := 0; i < opts.NumReplicas; i++ {
 			// Create the component implementation.
 			v := reflect.New(reg.Impl)
@@ -209,8 +223,8 @@ func newSimulator(name string, workload any, regsByIntf map[reflect.Type]*codege
 
 			// Fill config.
 			if cfg := weaver.GetConfig(obj); cfg != nil {
-				if err := runtime.ParseConfigSection(reg.Name, "", app.Sections, cfg); err != nil {
-					return nil, err
+				if err := runtime.ParseConfigSection(reg.Name, "", s.config.Sections, cfg); err != nil {
+					return err
 				}
 			}
 
@@ -218,14 +232,14 @@ func newSimulator(name string, workload any, regsByIntf map[reflect.Type]*codege
 			//
 			// TODO(mwhittaker): Use custom logger.
 			if err := weaver.SetLogger(obj, slog.Default()); err != nil {
-				return nil, err
+				return err
 			}
 
 			// Fill ref fields.
 			if err := weaver.FillRefs(obj, func(t reflect.Type) (any, error) {
 				return s.getIntf(t, reg.Name, i)
 			}); err != nil {
-				return nil, err
+				return err
 			}
 
 			// Fill listener fields.
@@ -233,22 +247,23 @@ func newSimulator(name string, workload any, regsByIntf map[reflect.Type]*codege
 				lis, err := net.Listen("tcp", ":0")
 				return lis, "", err
 			}); err != nil {
-				return nil, err
+				return err
 			}
 
 			// Call Init if available.
 			if i, ok := obj.(interface{ Init(context.Context) error }); ok {
 				// TODO(mwhittaker): Use better context.
 				if err := i.Init(context.Background()); err != nil {
-					return nil, fmt.Errorf("component %q initialization failed: %w", reg.Name, err)
+					return fmt.Errorf("component %q initialization failed: %w", reg.Name, err)
 				}
 			}
 
-			s.components[reg.Name] = append(s.components[reg.Name], obj)
+			components = append(components, obj)
 		}
+		s.components[reg.Name] = components
 	}
 
-	return s, nil
+	return nil
 }
 
 // getIntf returns a handle to the component of the provided type.
@@ -475,7 +490,7 @@ func (s *simulator) step() {
 }
 
 // runOp runs the provided operation.
-func (s *simulator) runOp(ctx context.Context, o op) error {
+func (s *simulator) runOp(ctx context.Context, o *op) error {
 	s.mu.Lock()
 	traceID, spanID := s.nextTraceID, s.nextSpanID
 	s.nextTraceID++

--- a/internal/sim/sim.go
+++ b/internal/sim/sim.go
@@ -76,6 +76,7 @@ type generator func(*rand.Rand) reflect.Value
 // An op is a randomized operation performed as part of a simulation. ops are
 // derived from exported methods on a workload struct.
 type op struct {
+	t          reflect.Type  // method type
 	name       string        // the name of the op
 	arity      int           // arity of op, ignoring context.Context argument
 	generators []generator   // the op's generators


### PR DESCRIPTION
Recall that a `Simulator` performs a number of simulations. Previously, for every simulation, the `Simulator` created a new `simulator`. This lead to a lot of extra allocations. This PR reduces the number of allocations by re-using a simulator across multiple simulations, re-using memory whenever possible.

The crux of the implementation is the introduction of a `simulator.reset` method that resets a `simulator` for the next simulation.

```
$ go test -run=$^ -bench=. -count=5 | tee /tmp/baseline.txt
$ go test -run=$^ -bench=. -count=5 | tee /tmp/experiment.txt
$ benchstat /tmp/{baseline,experiment}.txt
name                        old time/op    new time/op    delta
NewWorkload-128               1.29µs ± 2%    0.47µs ± 1%   -63.70%  (p=0.008 n=5+5)
NewSimulator-128              24.3µs ± 1%    23.5µs ± 1%    -3.05%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128    37.3µs ± 2%    33.0µs ± 2%   -11.44%  (p=0.008 n=5+5)
Workloads/NoCalls-128         39.6µs ± 4%    36.7µs ± 3%    -7.33%  (p=0.008 n=5+5)
Workloads/OneCall-128         55.8µs ± 3%    50.3µs ± 1%    -9.91%  (p=0.008 n=5+5)

name                        old alloc/op   new alloc/op   delta
NewWorkload-128                 464B ± 0%        0B       -100.00%  (p=0.008 n=5+5)
NewSimulator-128              7.58kB ± 0%    6.14kB ± 0%   -19.01%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128    8.15kB ± 0%    6.66kB ± 0%   -18.35%  (p=0.008 n=5+5)
Workloads/NoCalls-128         8.67kB ± 0%    7.15kB ± 0%   -17.47%  (p=0.008 n=5+5)
Workloads/OneCall-128         10.6kB ± 0%     8.5kB ± 0%   -19.90%  (p=0.008 n=5+5)

name                        old allocs/op  new allocs/op  delta
NewWorkload-128                 3.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
NewSimulator-128                49.0 ± 0%      32.0 ± 0%   -34.69%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128      64.0 ± 0%      47.0 ± 0%   -26.56%  (p=0.008 n=5+5)
Workloads/NoCalls-128           78.0 ± 0%      60.0 ± 0%   -23.08%  (p=0.008 n=5+5)
Workloads/OneCall-128            116 ± 0%        94 ± 0%   -18.97%  (p=0.008 n=5+5)
```