### PR TITLE
Skip component init steps when possible.

### DIFF
--- a/internal/weaver/types.go
+++ b/internal/weaver/types.go
@@ -28,11 +28,19 @@ var (
 	// should be a pointer to the implementation struct.
 	SetLogger func(impl any, logger *slog.Logger) error
 
+	// HasRefs returns whether the provided component implementation has
+	// weaver.Refs fields.
+	HasRefs func(impl any) bool
+
 	// FillRefs initializes Ref[T] fields in a component implement struct.
 	//   - impl should be a pointer to the implementation struct
 	//   - get should be a function that returns the component of interface
 	//     type T when passed the reflect.Type for T.
 	FillRefs func(impl any, get func(reflect.Type) (any, error)) error
+
+	// HasListeners returns whether the provided component implementation has
+	// weaver.Listener fields.
+	HasListeners func(impl any) bool
 
 	// FillListeners initializes Listener fields in a component implementation
 	// struct.
@@ -40,6 +48,10 @@ var (
 	//   - get should be a function that returns the required Listener values,
 	//     namely the network listener and the proxy address.
 	FillListeners func(impl any, get func(string) (net.Listener, string, error)) error
+
+	// HasConfig returns whether the provided component implementation has
+	// an embedded weaver.Config field.
+	HasConfig func(impl any) bool
 
 	// GetConfig returns the config stored in the provided component
 	// implementation, or returns nil if there is no config.


### PR DESCRIPTION
Recall that a simulator has to intiialize the components used by the workload. This involves filling its refs, listeners, and configs. Through profiling, I found that this was leading to a lot of allocations.

This PR takes advantage of the fact that most components won't have a listener, and some won't have refs or configs. For every component, we precompute if it has refs, configs, and listeners. Then, when initializing, we skip the work of filling a ref, config, or listener if we've precomputed it to be unnecessary.

```
$ go test -run=$^ -bench=. -count=5 | tee /tmp/baseline.txt
$ go test -run=$^ -bench=. -count=5 | tee /tmp/experiment.txt
$ benchstat /tmp/{baseline,experiment}.txt
name                           old time/op    new time/op    delta
NewWorkload/NoCallsNoGen-128      483ns ± 0%     482ns ± 1%     ~     (p=1.000 n=5+5)
NewWorkload/NoCalls-128          2.23µs ± 3%    2.25µs ± 2%     ~     (p=0.310 n=5+5)
NewWorkload/OneCall-128          2.27µs ± 2%    2.32µs ± 1%   +2.20%  (p=0.032 n=5+5)
NewSimulator/NoCallsNoGen-128    23.1µs ± 5%    22.4µs ± 2%     ~     (p=0.095 n=5+5)
NewSimulator/NoCalls-128         26.0µs ± 2%    25.0µs ± 3%   -3.69%  (p=0.016 n=5+5)
NewSimulator/OneCall-128         26.5µs ± 1%    24.5µs ± 2%   -7.47%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128       32.9µs ± 2%    32.4µs ± 1%     ~     (p=0.151 n=5+5)
Workloads/NoCalls-128            36.8µs ± 2%    35.1µs ± 2%   -4.57%  (p=0.008 n=5+5)
Workloads/OneCall-128            50.6µs ± 2%    49.1µs ± 1%   -2.88%  (p=0.008 n=5+5)

name                           old alloc/op   new alloc/op   delta
NewWorkload/NoCallsNoGen-128      0.00B          0.00B          ~     (all equal)
NewWorkload/NoCalls-128            346B ± 0%      346B ± 0%     ~     (all equal)
NewWorkload/OneCall-128            362B ± 0%      362B ± 0%     ~     (all equal)
NewSimulator/NoCallsNoGen-128    6.14kB ± 0%    6.00kB ± 0%   -2.22%  (p=0.008 n=5+5)
NewSimulator/NoCalls-128         6.53kB ± 0%    6.39kB ± 0%   -2.09%  (p=0.000 n=4+5)
NewSimulator/OneCall-128         6.59kB ± 0%    6.46kB ± 0%   -2.09%  (p=0.029 n=4+4)
Workloads/NoCallsNoGen-128       6.66kB ± 0%    6.52kB ± 0%   -2.04%  (p=0.008 n=5+5)
Workloads/NoCalls-128            7.15kB ± 0%    7.02kB ± 0%   -1.91%  (p=0.008 n=5+5)
Workloads/OneCall-128            8.50kB ± 0%    8.36kB ± 0%   -1.62%  (p=0.008 n=5+5)

name                           old allocs/op  new allocs/op  delta
NewWorkload/NoCallsNoGen-128       0.00           0.00          ~     (all equal)
NewWorkload/NoCalls-128            9.00 ± 0%      9.00 ± 0%     ~     (all equal)
NewWorkload/OneCall-128            10.0 ± 0%      10.0 ± 0%     ~     (all equal)
NewSimulator/NoCallsNoGen-128      32.0 ± 0%      21.0 ± 0%  -34.38%  (p=0.008 n=5+5)
NewSimulator/NoCalls-128           41.0 ± 0%      30.0 ± 0%  -26.83%  (p=0.008 n=5+5)
NewSimulator/OneCall-128           43.0 ± 0%      32.0 ± 0%  -25.58%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128         47.0 ± 0%      36.0 ± 0%  -23.40%  (p=0.008 n=5+5)
Workloads/NoCalls-128              60.0 ± 0%      49.0 ± 0%  -18.33%  (p=0.008 n=5+5)
Workloads/OneCall-128              94.0 ± 0%      83.0 ± 0%  -11.70%  (p=0.008 n=5+5)
```