### PR TITLE
Sped up simulator using wyrand PRNG.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -284,6 +284,7 @@ github.com/ServiceWeaver/weaver/internal/sim
     golang.org/x/exp/maps
     golang.org/x/sync/errgroup
     log/slog
+    math/bits
     math/rand
     net
     os

--- a/internal/sim/rand_test.go
+++ b/internal/sim/rand_test.go
@@ -111,3 +111,20 @@ func TestIntsDuplicateRemove(t *testing.T) {
 		t.Error("14 spuriously present")
 	}
 }
+
+func TestWyRandDeterministic(t *testing.T) {
+	for seed := uint64(0); seed < 100; seed++ {
+		a := &wyrand{seed}
+		b := &wyrand{seed}
+		for i := 0; i < 100; i++ {
+			w, x := a.Int63(), b.Int63()
+			if w != x {
+				t.Fatalf("seed %d Int63: %d != %d", seed, w, x)
+			}
+			y, z := a.Uint64(), b.Uint64()
+			if y != z {
+				t.Fatalf("seed %d Uint64: %d != %d", seed, y, z)
+			}
+		}
+	}
+}

--- a/internal/sim/sim.go
+++ b/internal/sim/sim.go
@@ -193,7 +193,11 @@ func (s *simulator) reset(workload any, fakes map[reflect.Type]any, ops []*op, o
 	s.workload = reflect.ValueOf(workload)
 	s.opts = opts
 	s.ops = ops
-	s.rand = rand.New(rand.NewSource(opts.Seed))
+	if s.rand == nil {
+		s.rand = rand.New(&wyrand{uint64(opts.Seed)})
+	} else {
+		s.rand.Seed(opts.Seed)
+	}
 	s.current = 1
 	s.numStarted = 0
 	s.notFinished.reset(1, 1+opts.NumOps)


### PR DESCRIPTION
Recall that every simulation is assigned a seed and uses a pseudorandom number generator initialized with this seed as its only source of randomness. This allows simulations to be "random" but also replayable.

Before this PR, we were using go's builtin `rand.Source`. Peeking [under the covers][1], we see that go uses a [lagged fibonacci generator][2]. This generator maintains an array of ~600 ints. The seeding process is very slow, as every one of these ints has to be initialized. Through profiling, I found that generating `rand.Source`s was a big bottleneck, even with parallelization.

This PR replaces the builtin generator with [wyrand][3]. Unlike go's builtin generator, wyrand's state is a single uint64, making seeding trivial. I don't understand the differences between a lagged fibonacci generator and wyrand in terms of the quality of randomness they produce, but wyrand is a reputable algorithm, even [used internally by go][4].

As you can see below, switching to wyrand leads to a massive performance improvement.

```
$ go test -run=$^ -bench=. -count=5 | tee /tmp/baseline.txt
$ go test -run=$^ -bench=. -count=5 | tee /tmp/experiment.txt
$ benchstat /tmp/{baseline,experiment}.txt
name                           old time/op    new time/op    delta
NewWorkload/NoCallsNoGen-128      481ns ± 0%     482ns ± 1%     ~     (p=0.310 n=5+5)
NewWorkload/NoCalls-128          1.66µs ± 2%    1.68µs ± 1%     ~     (p=0.548 n=5+5)
NewWorkload/OneCall-128          1.75µs ± 0%    1.75µs ± 3%     ~     (p=0.595 n=5+5)
NewSimulator/NoCallsNoGen-128    22.1µs ± 1%     3.9µs ± 1%  -82.59%  (p=0.008 n=5+5)
NewSimulator/NoCalls-128         23.4µs ± 2%     5.2µs ± 2%  -77.79%  (p=0.008 n=5+5)
NewSimulator/OneCall-128         23.8µs ± 1%     5.5µs ± 1%  -76.96%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128       31.8µs ± 2%    12.3µs ± 2%  -61.21%  (p=0.008 n=5+5)
Workloads/NoCalls-128            34.3µs ± 2%    14.7µs ± 2%  -56.99%  (p=0.008 n=5+5)
Workloads/OneCall-128            47.7µs ± 1%    28.2µs ± 1%  -40.79%  (p=0.008 n=5+5)

name                           old alloc/op   new alloc/op   delta
NewWorkload/NoCallsNoGen-128      0.00B          0.00B          ~     (all equal)
NewWorkload/NoCalls-128            264B ± 0%      264B ± 0%     ~     (all equal)
NewWorkload/OneCall-128            280B ± 0%      280B ± 0%     ~     (all equal)
NewSimulator/NoCallsNoGen-128    6.00kB ± 0%    0.58kB ± 0%  -90.40%  (p=0.008 n=5+5)
NewSimulator/NoCalls-128         6.26kB ± 0%    0.84kB ± 0%  -86.59%  (p=0.008 n=5+5)
NewSimulator/OneCall-128         6.33kB ± 0%    0.90kB ± 0%  -85.71%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128       6.52kB ± 0%    1.10kB ± 0%     ~     (p=0.079 n=4+5)
Workloads/NoCalls-128            6.93kB ± 0%    1.47kB ± 0%  -78.74%  (p=0.008 n=5+5)
Workloads/OneCall-128            8.28kB ± 0%    2.82kB ± 0%  -65.94%  (p=0.008 n=5+5)

name                           old allocs/op  new allocs/op  delta
NewWorkload/NoCallsNoGen-128       0.00           0.00          ~     (all equal)
NewWorkload/NoCalls-128            6.00 ± 0%      6.00 ± 0%     ~     (all equal)
NewWorkload/OneCall-128            7.00 ± 0%      7.00 ± 0%     ~     (all equal)
NewSimulator/NoCallsNoGen-128      21.0 ± 0%      19.0 ± 0%   -9.52%  (p=0.008 n=5+5)
NewSimulator/NoCalls-128           27.0 ± 0%      25.0 ± 0%   -7.41%  (p=0.008 n=5+5)
NewSimulator/OneCall-128           29.0 ± 0%      27.0 ± 0%   -6.90%  (p=0.008 n=5+5)
Workloads/NoCallsNoGen-128         36.0 ± 0%      34.0 ± 0%   -5.56%  (p=0.008 n=5+5)
Workloads/NoCalls-128              46.0 ± 0%      44.0 ± 0%   -4.35%  (p=0.008 n=5+5)
Workloads/OneCall-128              80.0 ± 0%      78.0 ± 0%   -2.50%  (p=0.008 n=5+5)
```

[1]: https://cs.opensource.google/go/go/+/refs/tags/go1.21.1:src/math/rand/rng.go
[2]: https://en.wikipedia.org/wiki/Lagged_Fibonacci_generator
[3]: https://github.com/wangyi-fudan/wyhash
[4]: https://cs.opensource.google/go/go/+/master:src/runtime/hash64.go;l=6;drc=0811559dddd89d90275ebae363c5166d3c29c29d