### PR TITLE
Cache generator types in registrar.

### DIFF
--- a/internal/sim/registrar_test.go
+++ b/internal/sim/registrar_test.go
@@ -108,3 +108,26 @@ func TestMissingRegisterGenerators(t *testing.T) {
 		t.Errorf("Error does not contain %q:\n%s", want, err.Error())
 	}
 }
+
+func TestChangeGeneratorType(t *testing.T) {
+	// Register a generator of type integers. Then, reset the registrar and
+	// register a generator of type positives. This should produce an error
+	// because generator types cannot change across executions.
+	r := newTestRegistrar[*oneCallWorkload](t)
+	if err := r.registerGenerators("Foo", integers{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.finalize(); err != nil {
+		t.Fatal(err)
+	}
+
+	r.reset()
+	err := r.registerGenerators("Foo", positives{})
+	if err == nil {
+		t.Fatal("unexpected success")
+	}
+	const want = "but previously had type sim.integers"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("Error does not contain %q:\n%s", want, err.Error())
+	}
+}


### PR DESCRIPTION
Recall that users call `Registrar.RegisterGenerators` to register the generators for a workload method. For every generator, a registrar has to validate that the registered generators are actually generators. Part of this validation involves calling `MethodByName` to get the generator's `Generate` method.  Through profiling, I found that calling `MethodByName` takes a non-trivial amount of time.

This PR optimizes things by caching the types of all registered generators and their `Generate` methods after the first time they are validated. In subsequent executions, we only have to check that the registered generator has the same type as before. We don't have to call `MethodByName` more than once.

```
$ go test -run=$^ -bench="(NewWorkload|ResetExecutor|Executions)" -count=5 | tee /tmp/baseline.txt
$ go test -run=$^ -bench="(NewWorkload|ResetExecutor|Executions)" -count=5 | tee /tmp/experiment.txt
$ benchstat /tmp/{baseline,experiment}.txt
name                                 old time/op    new time/op    delta
NewWorkload/NoCallsNoGen-128            458ns ± 1%     455ns ± 1%     ~     (p=0.310 n=5+5)
NewWorkload/NoCalls-128                1.68µs ± 1%    0.88µs ± 2%  -47.68%  (p=0.008 n=5+5)
NewWorkload/OneCall-128                1.74µs ± 2%    0.93µs ± 1%  -46.59%  (p=0.008 n=5+5)
ResetExecutor/NoCallsNoGen-128         3.88µs ± 2%    3.88µs ± 1%     ~     (p=0.841 n=5+5)
ResetExecutor/NoCalls-128              5.26µs ± 2%    4.32µs ± 1%  -17.93%  (p=0.008 n=5+5)
ResetExecutor/OneCall-128              5.47µs ± 1%    4.60µs ± 2%  -15.96%  (p=0.008 n=5+5)
Executions/NoCallsNoGen-128            11.8µs ± 2%    11.9µs ± 2%     ~     (p=0.222 n=5+5)
Executions/NoCalls-128                 14.0µs ± 2%    13.0µs ± 2%   -7.57%  (p=0.008 n=5+5)
Executions/OneCall-128                 27.5µs ± 1%    25.9µs ± 2%   -5.68%  (p=0.008 n=5+5)
ParallelExecutions/NoCallsNoGen-128    1.73µs ± 7%    1.70µs ± 6%     ~     (p=0.460 n=5+5)
ParallelExecutions/NoCalls-128         1.88µs ± 1%    1.83µs ± 1%   -2.95%  (p=0.008 n=5+5)
ParallelExecutions/OneCall-128         2.81µs ± 2%    2.67µs ± 1%   -4.97%  (p=0.008 n=5+5)

name                                 old alloc/op   new alloc/op   delta
NewWorkload/NoCallsNoGen-128            0.00B          0.00B          ~     (all equal)
NewWorkload/NoCalls-128                  264B ± 0%      144B ± 0%  -45.45%  (p=0.008 n=5+5)
NewWorkload/OneCall-128                  280B ± 0%      160B ± 0%  -42.86%  (p=0.008 n=5+5)
ResetExecutor/NoCallsNoGen-128           576B ± 0%      576B ± 0%     ~     (all equal)
ResetExecutor/NoCalls-128                840B ± 0%      720B ± 0%  -14.29%  (p=0.008 n=5+5)
ResetExecutor/OneCall-128                904B ± 0%      784B ± 0%  -13.27%  (p=0.008 n=5+5)
Executions/NoCallsNoGen-128            1.05kB ± 0%    1.05kB ± 0%     ~     (all equal)
Executions/NoCalls-128                 1.39kB ± 0%    1.27kB ± 0%   -8.71%  (p=0.000 n=5+4)
Executions/OneCall-128                 2.74kB ± 0%    2.62kB ± 0%   -4.43%  (p=0.000 n=4+5)
ParallelExecutions/NoCallsNoGen-128    1.05kB ± 0%    1.05kB ± 0%     ~     (all equal)
ParallelExecutions/NoCalls-128         1.39kB ± 0%    1.27kB ± 0%   -8.64%  (p=0.008 n=5+5)
ParallelExecutions/OneCall-128         2.73kB ± 0%    2.61kB ± 0%     ~     (p=0.079 n=4+5)

name                                 old allocs/op  new allocs/op  delta
NewWorkload/NoCallsNoGen-128             0.00           0.00          ~     (all equal)
NewWorkload/NoCalls-128                  6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.008 n=5+5)
NewWorkload/OneCall-128                  7.00 ± 0%      3.00 ± 0%  -57.14%  (p=0.008 n=5+5)
ResetExecutor/NoCallsNoGen-128           19.0 ± 0%      19.0 ± 0%     ~     (all equal)
ResetExecutor/NoCalls-128                25.0 ± 0%      21.0 ± 0%  -16.00%  (p=0.008 n=5+5)
ResetExecutor/OneCall-128                27.0 ± 0%      23.0 ± 0%  -14.81%  (p=0.008 n=5+5)
Executions/NoCallsNoGen-128              33.0 ± 0%      33.0 ± 0%     ~     (all equal)
Executions/NoCalls-128                   43.0 ± 0%      39.0 ± 0%   -9.30%  (p=0.008 n=5+5)
Executions/OneCall-128                   77.0 ± 0%      73.0 ± 0%   -5.19%  (p=0.008 n=5+5)
ParallelExecutions/NoCallsNoGen-128      33.0 ± 0%      33.0 ± 0%     ~     (all equal)
ParallelExecutions/NoCalls-128           43.0 ± 0%      39.0 ± 0%   -9.30%  (p=0.008 n=5+5)
ParallelExecutions/OneCall-128           77.0 ± 0%      73.0 ± 0%   -5.19%  (p=0.008 n=5+5)
```