### PR TITLE
Made simulator parallelism adjustable.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -290,6 +290,7 @@ github.com/ServiceWeaver/weaver/internal/sim
     os
     path/filepath
     reflect
+    runtime
     sort
     strings
     sync

--- a/internal/sim/simulator_test.go
+++ b/internal/sim/simulator_test.go
@@ -85,7 +85,7 @@ func TestPassingSimulations(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			s := New(t, test.workload, Options{})
-			r := s.Run(2 * time.Second)
+			r := s.Run(1 * time.Second)
 			t.Log(r.Summary())
 			if r.Err != nil {
 				t.Fatal(r.Err)


### PR DESCRIPTION
This PR adds a `Parallelism` option to the simulator that allows someone to tweak the number of parallel executions. This value has a big impact on simulation throughput, and there's not a universally good value. In the future, we could adjust the degree of parallelism as the simulation runs, but that's complicated.

I also settled on a default parallelism of `10 * runtime.NumCPU`. My intuition was that `runtime.NumCPU` would have led to max throughput, but running some benchmarks, it seems like simulations benefit from much higher parallelism. I don't fully understand why that is.

Here are benchmark numbers on my machine where `runtime.NumCPU` is 128.

| Parallelism | NoCallsNoGens ops/s | NoCalls ops/s | OneCall ops/s |
| ----------- | ------------------- | ------------- | ------------- |
| 1           | 166k ± 1%           | 156k ± 1%     | 57.5k ± 1%    |
| 2           | 303k ± 3%           | 296k ± 0%     | 107k ± 1%     |
| 5           | 649k ± 2%           | 623k ± 1%     | 223k ± 4%     |
| 10          | 1.14M ± 0%          | 1.09M ± 1%    | 438k ± 0%     |
| 32          | 1.63M ± 9%          | 2.22M ± 0%    | 602k ± 2%     |
| 64          | 1.78M ±27%          | 2.01M ± 1%    | 523k ± 2%     |
| 128         | 1.88M ± 1%          | 1.68M ± 3%    | 565k ± 7%     |
| 256         | 1.99M ± 4%          | 1.76M ± 4%    | 686k ± 4%     |
| 384         | 2.07M ± 4%          | 1.92M ± 1%    | 798k ± 3%     |
| 512         | 2.41M ± 1%          | 2.09M ± 1%    | 887k ± 1%     |
| 640         | 2.73M ± 1%          | 2.51M ± 5%    | 938k ± 3%     |
| 768         | 3.26M ± 6%          | 2.81M ± 3%    | 951k ± 2%     |
| 896         | 3.40M ± 1%          | 3.05M ± 5%    | 973k ± 1%     |
| 1024        | 3.78M ± 5%          | 3.39M ± 8%    | 1.00M ± 2%    |
| 1152        | 3.84M ± 2%          | 3.43M ± 3%    | 1.00M ± 4%    |
| 1280        | 4.06M ± 2%          | 3.60M ± 5%    | 1.03M ± 2%    |
| 1408        | 4.02M ± 3%          | 3.47M ± 1%    | 1.02M ± 5%    |
| 1536        | 4.27M ± 8%          | 3.71M ± 7%    | 1.04M ± 7%    |
| 1664        | 4.26M ± 7%          | 3.84M ±11%    | 1.06M ± 3%    |
| 1792        | 4.40M ± 2%          | 3.80M ± 2%    | 1.06M ± 1%    |
| 1920        | 4.47M ± 6%          | 3.77M ± 6%    | 1.09M ± 5%    |
| 2048        | 4.60M ± 3%          | 3.84M ± 5%    | 1.10M ± 5%    |
| 2176        | 4.49M ± 4%          | 4.05M ± 6%    | 1.10M ± 1%    |
| 2304        | 4.40M ± 4%          | 3.77M ± 2%    | 1.14M ± 3%    |
| 2432        | 4.38M ± 6%          | 3.94M ± 4%    | 1.14M ± 2%    |
| 2560        | 4.68M ± 4%          | 3.99M ± 5%    | 1.17M ± 4%    |