### PR TITLE
Periodically print simulator progress.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	golang.org/x/image v0.5.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/term v0.10.0
+	golang.org/x/text v0.9.0
 	golang.org/x/tools v0.11.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20230717213848-3f92550aa753
 	google.golang.org/protobuf v1.31.0
@@ -48,7 +49,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	lukechampine.com/uint128 v1.2.0 // indirect
 	modernc.org/cc/v3 v3.40.0 // indirect

--- a/godeps.txt
+++ b/godeps.txt
@@ -283,6 +283,8 @@ github.com/ServiceWeaver/weaver/internal/sim
     go.opentelemetry.io/otel/trace
     golang.org/x/exp/maps
     golang.org/x/sync/errgroup
+    golang.org/x/text/language
+    golang.org/x/text/message
     log/slog
     math/bits
     math/rand


### PR DESCRIPTION
With this PR, a simulator periodically prints out its progress, just like with Go's fuzz testing. This is important to make sure the user knows the simulation isn't stuck.

```
$ go test -run=Passing/NoCallsNoGen -v
=== RUN   TestPassingSimulations
=== RUN   TestPassingSimulations/NoCallsNoGen
    simulator.go:390: Simulating *sim.noCallsNoGenWorkload for 10s with 1280 executors...
    simulator.go:405: [1s] 60,520 execs (60,064 execs/s), 4,207,853 ops (4,176,166 ops/s)
    simulator.go:405: [2s] 91,122 execs (45,390 execs/s), 9,494,404 ops (4,729,368 ops/s)
    simulator.go:405: [3s] 116,070 execs (38,594 execs/s), 15,377,846 ops (5,113,218 ops/s)
    simulator.go:405: [4s] 136,944 execs (34,175 execs/s), 21,386,940 ops (5,337,185 ops/s)
    simulator.go:405: [5s] 155,343 execs (31,024 execs/s), 27,506,001 ops (5,493,331 ops/s)
    simulator.go:405: [6s] 172,306 execs (28,681 execs/s), 33,831,171 ops (5,631,418 ops/s)
    simulator.go:405: [7s] 187,752 execs (26,794 execs/s), 40,157,529 ops (5,730,931 ops/s)
    simulator.go:405: [8s] 201,803 execs (25,203 execs/s), 46,384,348 ops (5,792,803 ops/s)
    simulator.go:405: [9s] 215,544 execs (23,930 execs/s), 52,909,102 ops (5,874,082 ops/s)
```