### PR TITLE
Use the Go BuildInfo to read the tool and application module versions.

### DIFF
--- a/examples/chat/weaver_gen.go
+++ b/examples/chat/weaver_gen.go
@@ -720,7 +720,7 @@ func (s sQLStore_client_stub) GetImage(ctx context.Context, a0 string, a1 ImageI
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/examples/collatz/weaver_gen.go
+++ b/examples/collatz/weaver_gen.go
@@ -289,7 +289,7 @@ func (s odd_client_stub) Do(ctx context.Context, a0 int) (r0 int, err error) {
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/examples/factors/weaver_gen.go
+++ b/examples/factors/weaver_gen.go
@@ -183,7 +183,7 @@ var _ weaver.Main = (*main_client_stub)(nil)
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/examples/fakes/weaver_gen.go
+++ b/examples/fakes/weaver_gen.go
@@ -133,7 +133,7 @@ func (s clock_client_stub) UnixMicro(ctx context.Context) (r0 int64, err error) 
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/examples/hello/weaver_gen.go
+++ b/examples/hello/weaver_gen.go
@@ -176,7 +176,7 @@ func (s reverser_client_stub) Reverse(ctx context.Context, a0 string) (r0 string
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/examples/helloworld/weaver_gen.go
+++ b/examples/helloworld/weaver_gen.go
@@ -60,7 +60,7 @@ var _ weaver.Main = (*main_client_stub)(nil)
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/examples/reverser/weaver_gen.go
+++ b/examples/reverser/weaver_gen.go
@@ -176,7 +176,7 @@ func (s reverser_client_stub) Reverse(ctx context.Context, a0 string) (r0 string
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/godeps.txt
+++ b/godeps.txt
@@ -351,8 +351,8 @@ github.com/ServiceWeaver/weaver/internal/tool
     flag
     fmt
     github.com/ServiceWeaver/weaver/runtime/tool
-    github.com/ServiceWeaver/weaver/runtime/version
     runtime
+    runtime/debug
 github.com/ServiceWeaver/weaver/internal/tool/callgraph
     fmt
     github.com/ServiceWeaver/weaver/runtime
@@ -385,6 +385,7 @@ github.com/ServiceWeaver/weaver/internal/tool/generate
     errors
     fmt
     github.com/ServiceWeaver/weaver/internal/files
+    github.com/ServiceWeaver/weaver/internal/tool
     github.com/ServiceWeaver/weaver/runtime/codegen
     github.com/ServiceWeaver/weaver/runtime/colors
     github.com/ServiceWeaver/weaver/runtime/version
@@ -628,6 +629,7 @@ github.com/ServiceWeaver/weaver/runtime
     time
 github.com/ServiceWeaver/weaver/runtime/bin
     bytes
+    debug/buildinfo
     debug/elf
     debug/macho
     debug/pe

--- a/internal/benchmarks/weaver_gen.go
+++ b/internal/benchmarks/weaver_gen.go
@@ -1920,7 +1920,7 @@ func (s ping9_client_stub) PingS(ctx context.Context, a0 payloadS, a1 int) (r0 p
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/internal/sim/weaver_gen.go
+++ b/internal/sim/weaver_gen.go
@@ -592,7 +592,7 @@ func (s mod_client_stub) Mod(ctx context.Context, a0 int, a1 int) (r0 int, err e
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/internal/testdeployer/weaver_gen.go
+++ b/internal/testdeployer/weaver_gen.go
@@ -369,7 +369,7 @@ func (s c_client_stub) C(ctx context.Context, a0 int) (r0 int, err error) {
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/internal/tool/generate/example/weaver_gen.go
+++ b/internal/tool/generate/example/weaver_gen.go
@@ -439,7 +439,7 @@ func (s b_client_stub) M2(ctx context.Context, a0 int, a1 string, a2 bool, a3 [1
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/internal/tool/generate/generator_test.go
+++ b/internal/tool/generate/generator_test.go
@@ -459,7 +459,7 @@ func TestExampleVersion(t *testing.T) {
 	got := fmt.Sprintf("%x", h.Sum(nil))
 
 	// If weaver_gen.go has changed, the codegen version may need updating.
-	const want = "554bb0acc152b1d5b7a3dc5aa1cf17c67befbded53a05cbd59c809c71983735d"
+	const want = "872c34c2f9a62ebcb5085494bbdc92e127d1188b5e171e4f95a8d2f87518c5d6"
 	if got != want {
 		t.Fatalf(`Unexpected SHA-256 hash of examples/weaver_gen.go: got %s, want %s. If this change is meaningful, REMEMBER TO UPDATE THE CODEGEN VERSION in runtime/version/version.go.`, got, want)
 	}

--- a/internal/tool/multi/deploy.go
+++ b/internal/tool/multi/deploy.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 
 	"github.com/ServiceWeaver/weaver/internal/status"
+	itool "github.com/ServiceWeaver/weaver/internal/tool"
 	"github.com/ServiceWeaver/weaver/internal/tool/config"
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/bin"
@@ -101,6 +102,10 @@ func deploy(ctx context.Context, args []string) error {
 				binary = rel
 			}
 		}
+		selfVersion, err := itool.SelfVersion()
+		if err != nil {
+			return fmt.Errorf("read self version: %w", err)
+		}
 		return fmt.Errorf(`
 ERROR: The binary you're trying to deploy (%q) was built with
 github.com/ServiceWeaver/weaver module version %s. However, the 'weaver
@@ -115,7 +120,7 @@ updating the 'weaver multi' command by running the following.
 
 Then, re-build your code and re-run 'weaver multi deploy'. If the problem
 persists, please file an issue at https://github.com/ServiceWeaver/weaver/issues.`,
-			binary, versions.ModuleVersion, version.ModuleVersion)
+			binary, versions.ModuleVersion, selfVersion)
 	}
 
 	// Create the deployer.

--- a/internal/tool/ssh/deploy.go
+++ b/internal/tool/ssh/deploy.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/exp/maps"
 
+	itool "github.com/ServiceWeaver/weaver/internal/tool"
 	"github.com/ServiceWeaver/weaver/internal/tool/config"
 	"github.com/ServiceWeaver/weaver/internal/tool/ssh/impl"
 	"github.com/ServiceWeaver/weaver/runtime"
@@ -108,6 +109,10 @@ func deploy(ctx context.Context, args []string) error {
 				binary = rel
 			}
 		}
+		selfVersion, err := itool.SelfVersion()
+		if err != nil {
+			return fmt.Errorf("read self version: %w", err)
+		}
 		return fmt.Errorf(`
 ERROR: The binary you're trying to deploy (%q) was built with
 github.com/ServiceWeaver/weaver module version %s. However, the 'weaver
@@ -122,7 +127,7 @@ updating the 'weaver ssh' command by running the following.
 
 Then, re-build your code and re-run 'weaver ssh deploy'. If the problem
 persists, please file an issue at https://github.com/ServiceWeaver/weaver/issues.`,
-			binary, versions.ModuleVersion, version.ModuleVersion)
+			binary, versions.ModuleVersion, selfVersion)
 	}
 
 	// Retrieve the list of locations to deploy.

--- a/internal/tool/version.go
+++ b/internal/tool/version.go
@@ -19,9 +19,9 @@ import (
 	"flag"
 	"fmt"
 	"runtime"
+	"runtime/debug"
 
 	"github.com/ServiceWeaver/weaver/runtime/tool"
-	"github.com/ServiceWeaver/weaver/runtime/version"
 )
 
 // VersionCmd returns a command to show a deployer's version.
@@ -32,8 +32,22 @@ func VersionCmd(toolname string) *tool.Command {
 		Description: fmt.Sprintf("Show %q version", toolname),
 		Help:        fmt.Sprintf("Usage:\n  %s version", toolname),
 		Fn: func(context.Context, []string) error {
-			fmt.Printf("%s %s %s/%s\n", toolname, version.ModuleVersion, runtime.GOOS, runtime.GOARCH)
+			v, err := SelfVersion()
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%s %s %s/%s\n", toolname, v, runtime.GOOS, runtime.GOARCH)
 			return nil
 		},
 	}
+}
+
+// SelfVersion returns the version of the running tool binary.
+func SelfVersion() (string, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		// Should never happen.
+		return "", fmt.Errorf("tool binary must be built from a module")
+	}
+	return info.Main.Version, nil
 }

--- a/runtime/bin/testprogram/weaver_gen.go
+++ b/runtime/bin/testprogram/weaver_gen.go
@@ -163,7 +163,7 @@ var _ weaver.Main = (*main_client_stub)(nil)
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/runtime/version/version.go
+++ b/runtime/version/version.go
@@ -24,19 +24,6 @@ import (
 // Srdjan's comments in PR #219.
 
 const (
-	// The weaver module semantic version [1].
-	//
-	// [1]: https://go.dev/doc/modules/version-numbers
-	ModuleMajor = 0
-	ModuleMinor = 21
-	ModulePatch = 2
-
-	// Note that there is currently no way to programmatically get the version
-	// of the current module [1], so we have to manually update the module
-	// version here whenever we release a new version.
-	//
-	// [1]: https://github.com/golang/go/issues/29228
-
 	// The version of the deployer API.
 	//
 	// Every time we make a change to the deployer API, we assign it a new
@@ -50,7 +37,7 @@ const (
 	// the deployer API in v0.13.0 of Service Weaver, then we leave the
 	// deployer API at v0.12.0.
 	DeployerMajor = 0
-	DeployerMinor = 20
+	DeployerMinor = 22
 
 	// The version of the codegen API. As with the deployer API, we assign a
 	// new version every time we change how code is generated, and we use
@@ -60,9 +47,6 @@ const (
 )
 
 var (
-	// The weaver module version.
-	ModuleVersion = SemVer{ModuleMajor, ModuleMinor, ModulePatch}
-
 	// The deployer API version.
 	DeployerVersion = SemVer{DeployerMajor, DeployerMinor, 0}
 

--- a/weavertest/internal/chain/weaver_gen.go
+++ b/weavertest/internal/chain/weaver_gen.go
@@ -365,7 +365,7 @@ func (s c_client_stub) Propagate(ctx context.Context, a0 int) (err error) {
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/weavertest/internal/deploy/weaver_gen.go
+++ b/weavertest/internal/deploy/weaver_gen.go
@@ -253,7 +253,7 @@ func (s widget_client_stub) Use(ctx context.Context, a0 string) (err error) {
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/weavertest/internal/diverge/weaver_gen.go
+++ b/weavertest/internal/diverge/weaver_gen.go
@@ -246,7 +246,7 @@ func (s pointer_client_stub) Get(ctx context.Context) (r0 Pair, err error) {
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/weavertest/internal/generate/weaver_gen.go
+++ b/weavertest/internal/generate/weaver_gen.go
@@ -304,7 +304,7 @@ func (s testApp_client_stub) IncPointer(ctx context.Context, a0 *int) (r0 *int, 
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/weavertest/internal/protos/weaver_gen.go
+++ b/weavertest/internal/protos/weaver_gen.go
@@ -137,7 +137,7 @@ func (s pingPonger_client_stub) Ping(ctx context.Context, a0 *Ping) (r0 *Pong, e
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/weavertest/internal/simple/weaver_gen.go
+++ b/weavertest/internal/simple/weaver_gen.go
@@ -748,7 +748,7 @@ func (s source_client_stub) Emit(ctx context.Context, a0 string, a1 string) (err
 // you run "go build" or "go run".
 var _ codegen.LatestVersion = codegen.Version[[0][20]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.21.2 (codegen
+ERROR: You generated this file with 'weaver generate' (devel) (codegen
 version v0.20.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.


### PR DESCRIPTION
This remove the manual module version tracking (in the version.go file), which will hopefully lead to fewer versioning errors and allow us to track the version information at a finer granularity.

Note that the tool and the application module versions aren't ever directly compared: their values are only used for nicer error-message generation.