### PR TITLE
Fix how graveyard entries are written, replayed.

### DIFF
--- a/internal/sim/simulator_test.go
+++ b/internal/sim/simulator_test.go
@@ -86,7 +86,6 @@ func TestPassingSimulations(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			s := New(t, test.workload, Options{})
 			r := s.Run(1 * time.Second)
-			t.Log(r.Summary())
 			if r.Err != nil {
 				t.Fatal(r.Err)
 			}
@@ -171,7 +170,6 @@ func (d *divideByZeroWorkload) DivMod(ctx context.Context, x, y int) error {
 func TestFailingSimulation(t *testing.T) {
 	s := New(t, &divideByZeroWorkload{}, Options{})
 	r := s.Run(2 * time.Second)
-	t.Log(r.Summary())
 	if r.Err == nil {
 		t.Fatal("Unexpected success")
 	}


### PR DESCRIPTION
Before this PR, the hyperparameters of every failing execution were written to the graveyard. Moreover, a simulator would re-run these graveyard entries in parallel, alongside new executions. This lead to a poor user experience where two things would happen:

1. You would sometimes generate hundreds of graveyard entries from a single test. At first, I thought it was best to capture every single failing input. Later, I realized that if hundreds of tests are failing at once, it's not hard to fail the test, so saving every failing input isn't needed.
2. Every time you ran `go test`, you'd get a different failing execution. This is very frustrating, borderline unusable.

This PR fixes how graveyard entries are written and replayed. First, only the failing execution reported to the user is saved to the graveyard. Second, graveyard entries are replayed serially. This means that the user sees the same error every time they run `go test`.

Alongside these fixes, I also did some refactoring to reduce some duplicated code that got even more duplicated when adding the new graveyard logic.