### PR TITLE
Fix the website URL for the online boutique example.

### DIFF
--- a/website/examples.html
+++ b/website/examples.html
@@ -31,7 +31,7 @@
 <div class="example">
   <h1>Online Boutique</h1>
   <a class="examples-link" href="https://onlineboutique.serviceweaver.dev/">Live Demo</a>
-  <a class="examples-link" href="https://github.com/ServiceWeaver/weaver/tree/main/examples/onlineboutique">Source Code</a>
+  <a class="examples-link" href="https://github.com/ServiceWeaver/onlineboutique">Source Code</a>
 
   <p>
   This application is an online e-commerce site. You can browse items, add them


### PR DESCRIPTION
We moved the Online Boutique code to a different repo, and the link has been broken ever since.