### PR TITLE
Added test that shows importance of minimization.

### DIFF
--- a/internal/sim/components.go
+++ b/internal/sim/components.go
@@ -52,6 +52,15 @@ type blocker interface {
 	Block(context.Context) error
 }
 
+// register is a string-valued register.
+type register interface {
+	// Append appends to the register.
+	Append(context.Context, string) (string, error)
+
+	// Clear clears the contents of the register.
+	Clear(context.Context) error
+}
+
 // Component implementation structs.
 
 type divModImpl struct {
@@ -129,6 +138,15 @@ func (i *identityImpl) Identity(ctx context.Context, x int) (int, error) {
 func (*blockerImpl) Block(ctx context.Context) error {
 	<-ctx.Done()
 	return ctx.Err()
+}
+
+type registerImpl struct {
+	weaver.Implements[register]
+
+	// register is always faked, so we embed register and don't implement any
+	// of its methods. A real implementation of register might use something
+	// like a database.
+	register
 }
 
 // Errors.

--- a/internal/sim/generators.go
+++ b/internal/sim/generators.go
@@ -1,0 +1,65 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sim
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+// TODO(mwhittaker): Add other generators.
+
+// OneOf returns a [Generator] that returns one of the provided values
+// equiprobably. OneOf panics if no values are provided.
+func OneOf[T any](xs ...T) Generator[T] {
+	if len(xs) == 0 {
+		panic(fmt.Errorf("OneOf: empty slice"))
+	}
+	return generatorFunc[T](func(r *rand.Rand) T {
+		return xs[r.Intn(len(xs))]
+	})
+}
+
+// Flip returns a [Generator] that returns true with probability p. Flip
+// panics if p is not in the range [0, 1].
+func Flip(p float64) Generator[bool] {
+	if p < 0 || p > 1 {
+		panic(fmt.Errorf("Flip: probability p = %f not in range [0, 1]", p))
+	}
+	return generatorFunc[bool](func(r *rand.Rand) bool {
+		return r.Float64() <= p
+	})
+}
+
+// Range returns a [Generator] that returns integers equiprobably in the range
+// [low, high). Range panics if low >= high.
+func Range(low, high int) Generator[int] {
+	if low >= high {
+		panic(fmt.Errorf("Range: low (%d) >= high (%d)", low, high))
+	}
+	return generatorFunc[int](func(r *rand.Rand) int {
+		delta := high - low
+		return low + r.Intn(delta)
+	})
+}
+
+// generatorFunc[T] is an instance of Generator[T] that uses the provided
+// function to generate values.
+type generatorFunc[T any] func(r *rand.Rand) T
+
+// Generate implements the Generator interface.
+func (g generatorFunc[T]) Generate(r *rand.Rand) T {
+	return g(r)
+}

--- a/internal/sim/minimization_test.go
+++ b/internal/sim/minimization_test.go
@@ -1,0 +1,100 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sim
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ServiceWeaver/weaver"
+)
+
+// fakeRegister is a fake implementation of the register component.
+type fakeRegister struct {
+	mu sync.Mutex
+	s  string
+}
+
+func (f *fakeRegister) Append(_ context.Context, s string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.s = f.s + s
+	return f.s, nil
+}
+
+func (f *fakeRegister) Clear(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.s = ""
+	return nil
+}
+
+// See TestRegisterWorkload.
+type registerWorkload struct {
+	reg  weaver.Ref[register]
+	fake fakeRegister
+}
+
+func (w *registerWorkload) Init(r Registrar) error {
+	alphabet := strings.Split("abcdefghijklmnopqrstuvwxyz", "")
+	r.RegisterFake(Fake[register](&w.fake))
+	r.RegisterGenerators("Append", OneOf(alphabet...))
+	r.RegisterGenerators("Clear")
+	return nil
+}
+
+func (w *registerWorkload) Append(ctx context.Context, s string) error {
+	s, err := w.reg.Get().Append(ctx, s)
+	if err != nil {
+		return nil
+	}
+	if s == "hello" {
+		return fmt.Errorf("hello")
+	}
+	return nil
+}
+
+func (w *registerWorkload) Clear(ctx context.Context) error {
+	w.reg.Get().Clear(ctx)
+	return nil
+}
+
+func TestRegisterWorkload(t *testing.T) {
+	// TestRegisterWorkload showcases the importance of test case minimization.
+	// The workload randomly appends letters to a string, failing if the string
+	// "hello" is ever formed. The odds of picking five random letters and
+	// forming the string "hello" is (1/26)^5, quite unlikely. The odds of
+	// picking 100 random letters and having a subsequence of them form "hello"
+	// is much more likely.
+	//
+	// Thus, when we do find an execution that forms "hello", it is probably a
+	// long execution that appends a lot of garbage letters, eventually clears
+	// the string, and then appends "hello". These long executions can benefit
+	// from minimization.
+	//
+	// TODO(mwhittaker): Consider what happens when we don't have a Clear
+	// method. In this case, the simulator may run forever without finding a
+	// "hello" sequence. We want to make sure our search algorithm is smart
+	// enough to eventually find "hello".
+	s := New(t, &registerWorkload{}, Options{})
+	if results := s.Run(1 * time.Second); results.Err != nil {
+		t.Log(results.Mermaid())
+		t.Log(results.Err)
+	}
+}

--- a/internal/sim/weaver_gen.go
+++ b/internal/sim/weaver_gen.go
@@ -105,6 +105,24 @@ func init() {
 		},
 		RefData: "⟦1dff5ab5:wEaVeReDgE:github.com/ServiceWeaver/weaver/internal/sim/mod→github.com/ServiceWeaver/weaver/internal/sim/identity⟧\n",
 	})
+	codegen.Register(codegen.Registration{
+		Name:  "github.com/ServiceWeaver/weaver/internal/sim/register",
+		Iface: reflect.TypeOf((*register)(nil)).Elem(),
+		Impl:  reflect.TypeOf(registerImpl{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return register_local_stub{impl: impl.(register), tracer: tracer, appendMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/register", Method: "Append", Remote: false}), clearMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/register", Method: "Clear", Remote: false})}
+		},
+		ClientStubFn: func(stub codegen.Stub, caller string) any {
+			return register_client_stub{stub: stub, appendMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/register", Method: "Append", Remote: true}), clearMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/register", Method: "Clear", Remote: true})}
+		},
+		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
+			return register_server_stub{impl: impl.(register), addLoad: addLoad}
+		},
+		ReflectStubFn: func(caller func(string, context.Context, []any, []any) error) any {
+			return register_reflect_stub{caller: caller}
+		},
+		RefData: "",
+	})
 }
 
 // weaver.InstanceOf checks.
@@ -113,6 +131,7 @@ var _ weaver.InstanceOf[div] = (*divImpl)(nil)
 var _ weaver.InstanceOf[divMod] = (*divModImpl)(nil)
 var _ weaver.InstanceOf[identity] = (*identityImpl)(nil)
 var _ weaver.InstanceOf[mod] = (*modImpl)(nil)
+var _ weaver.InstanceOf[register] = (*registerImpl)(nil)
 
 // weaver.Router checks.
 var _ weaver.Unrouted = (*blockerImpl)(nil)
@@ -120,6 +139,7 @@ var _ weaver.Unrouted = (*divImpl)(nil)
 var _ weaver.Unrouted = (*divModImpl)(nil)
 var _ weaver.Unrouted = (*identityImpl)(nil)
 var _ weaver.Unrouted = (*modImpl)(nil)
+var _ weaver.Unrouted = (*registerImpl)(nil)
 
 // Local stub implementations.
 
@@ -266,6 +286,56 @@ func (s mod_local_stub) Mod(ctx context.Context, a0 int, a1 int) (r0 int, err er
 	}
 
 	return s.impl.Mod(ctx, a0, a1)
+}
+
+type register_local_stub struct {
+	impl          register
+	tracer        trace.Tracer
+	appendMetrics *codegen.MethodMetrics
+	clearMetrics  *codegen.MethodMetrics
+}
+
+// Check that register_local_stub implements the register interface.
+var _ register = (*register_local_stub)(nil)
+
+func (s register_local_stub) Append(ctx context.Context, a0 string) (r0 string, err error) {
+	// Update metrics.
+	begin := s.appendMetrics.Begin()
+	defer func() { s.appendMetrics.End(begin, err != nil, 0, 0) }()
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "sim.register.Append", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.Append(ctx, a0)
+}
+
+func (s register_local_stub) Clear(ctx context.Context) (err error) {
+	// Update metrics.
+	begin := s.clearMetrics.Begin()
+	defer func() { s.clearMetrics.End(begin, err != nil, 0, 0) }()
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "sim.register.Clear", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.Clear(ctx)
 }
 
 // Client stub implementations.
@@ -587,6 +657,117 @@ func (s mod_client_stub) Mod(ctx context.Context, a0 int, a1 int) (r0 int, err e
 	return
 }
 
+type register_client_stub struct {
+	stub          codegen.Stub
+	appendMetrics *codegen.MethodMetrics
+	clearMetrics  *codegen.MethodMetrics
+}
+
+// Check that register_client_stub implements the register interface.
+var _ register = (*register_client_stub)(nil)
+
+func (s register_client_stub) Append(ctx context.Context, a0 string) (r0 string, err error) {
+	// Update metrics.
+	var requestBytes, replyBytes int
+	begin := s.appendMetrics.Begin()
+	defer func() { s.appendMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "sim.register.Append", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+			if err != nil {
+				err = errors.Join(weaver.RemoteCallError, err)
+			}
+		}
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+
+	}()
+
+	// Preallocate a buffer of the right size.
+	size := 0
+	size += (4 + len(a0))
+	enc := codegen.NewEncoder()
+	enc.Reset(size)
+
+	// Encode arguments.
+	enc.String(a0)
+	var shardKey uint64
+
+	// Call the remote method.
+	requestBytes = len(enc.Data())
+	var results []byte
+	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
+	if err != nil {
+		err = errors.Join(weaver.RemoteCallError, err)
+		return
+	}
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	r0 = dec.String()
+	err = dec.Error()
+	return
+}
+
+func (s register_client_stub) Clear(ctx context.Context) (err error) {
+	// Update metrics.
+	var requestBytes, replyBytes int
+	begin := s.clearMetrics.Begin()
+	defer func() { s.clearMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "sim.register.Clear", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+			if err != nil {
+				err = errors.Join(weaver.RemoteCallError, err)
+			}
+		}
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+
+	}()
+
+	var shardKey uint64
+
+	// Call the remote method.
+	var results []byte
+	results, err = s.stub.Run(ctx, 1, nil, shardKey)
+	replyBytes = len(results)
+	if err != nil {
+		err = errors.Join(weaver.RemoteCallError, err)
+		return
+	}
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	err = dec.Error()
+	return
+}
+
 // Note that "weaver generate" will always generate the error message below.
 // Everything is okay. The error message is only relevant if you see it when
 // you run "go build" or "go run".
@@ -828,6 +1009,70 @@ func (s mod_server_stub) mod(ctx context.Context, args []byte) (res []byte, err 
 	return enc.Data(), nil
 }
 
+type register_server_stub struct {
+	impl    register
+	addLoad func(key uint64, load float64)
+}
+
+// Check that register_server_stub implements the codegen.Server interface.
+var _ codegen.Server = (*register_server_stub)(nil)
+
+// GetStubFn implements the codegen.Server interface.
+func (s register_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
+	switch method {
+	case "Append":
+		return s.append
+	case "Clear":
+		return s.clear
+	default:
+		return nil
+	}
+}
+
+func (s register_server_stub) append(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// Decode arguments.
+	dec := codegen.NewDecoder(args)
+	var a0 string
+	a0 = dec.String()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	r0, appErr := s.impl.Append(ctx, a0)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	enc.String(r0)
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
+
+func (s register_server_stub) clear(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	appErr := s.impl.Clear(ctx)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
+
 // Reflect stub implementations.
 
 type blocker_reflect_stub struct {
@@ -887,6 +1132,23 @@ var _ mod = (*mod_reflect_stub)(nil)
 
 func (s mod_reflect_stub) Mod(ctx context.Context, a0 int, a1 int) (r0 int, err error) {
 	err = s.caller("Mod", ctx, []any{a0, a1}, []any{&r0})
+	return
+}
+
+type register_reflect_stub struct {
+	caller func(string, context.Context, []any, []any) error
+}
+
+// Check that register_reflect_stub implements the register interface.
+var _ register = (*register_reflect_stub)(nil)
+
+func (s register_reflect_stub) Append(ctx context.Context, a0 string) (r0 string, err error) {
+	err = s.caller("Append", ctx, []any{a0}, []any{&r0})
+	return
+}
+
+func (s register_reflect_stub) Clear(ctx context.Context) (err error) {
+	err = s.caller("Clear", ctx, []any{}, []any{})
 	return
 }
 


### PR DESCRIPTION
I've been playing around with various workloads and found an append-only string workload to be quite interesting. It emphasizes the importance of the following things:

1. Simulator speed is important. For rarely occurring bugs, the simulator being 100x slower can mean the difference between finding the bug overnight and not finding the bug in a month.
2. Test case minimization is more important for rarer bugs, as they are likely to arise in longer executions with irrelevant ops.
3. At any point in time, the search algorithm should give every possible execution a non-zero change of being run. Currently, we increase the number of ops per execution over time, but this means that if a bug only arises from an execution with few ops, we may never find it.