### PR TITLE
Catch panics in simulations.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -298,6 +298,7 @@ github.com/ServiceWeaver/weaver/internal/sim
     path/filepath
     reflect
     runtime
+    runtime/debug
     sort
     strings
     sync

--- a/internal/sim/components.go
+++ b/internal/sim/components.go
@@ -58,15 +58,6 @@ type panicker interface {
 	Panic(context.Context, bool) error
 }
 
-// register is a string-valued register.
-type register interface {
-	// Append appends to the register.
-	Append(context.Context, string) (string, error)
-
-	// Clear clears the contents of the register.
-	Clear(context.Context) error
-}
-
 // Component implementation structs.
 
 type divModImpl struct {
@@ -95,15 +86,6 @@ type blockerImpl struct {
 
 type panickerImpl struct {
 	weaver.Implements[panicker]
-}
-
-type registerImpl struct {
-	weaver.Implements[register]
-
-	// register is always faked, so we embed register and don't implement any
-	// of its methods. A real implementation of register might use something
-	// like a database.
-	register
 }
 
 // Component implementations.

--- a/internal/sim/events.go
+++ b/internal/sim/events.go
@@ -74,6 +74,16 @@ type EventDeliverError struct {
 	SpanID  int // span id
 }
 
+// EventPanic represents a panic.
+type EventPanic struct {
+	TraceID  int    // trace id
+	SpanID   int    // span id
+	Panicker string // panicking component (or "op")
+	Replica  int    // panicking component replica (or op number)
+	Error    string // panic error
+	Stack    string // stack trace
+}
+
 func (EventOpStart) isEvent()       {}
 func (EventOpFinish) isEvent()      {}
 func (EventCall) isEvent()          {}
@@ -81,6 +91,7 @@ func (EventDeliverCall) isEvent()   {}
 func (EventReturn) isEvent()        {}
 func (EventDeliverReturn) isEvent() {}
 func (EventDeliverError) isEvent()  {}
+func (EventPanic) isEvent()         {}
 
 var _ Event = EventOpStart{}
 var _ Event = EventOpFinish{}
@@ -89,3 +100,4 @@ var _ Event = EventDeliverCall{}
 var _ Event = EventReturn{}
 var _ Event = EventDeliverReturn{}
 var _ Event = EventDeliverError{}
+var _ Event = EventPanic{}

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -598,6 +598,9 @@ func (r *Results) Mermaid() string {
 		case EventDeliverError:
 			call := calls[x.SpanID]
 			fmt.Fprintf(&b, "    note right of %s%d: [%d:%d] RemoteCallError\n", call.Caller, call.Replica, x.TraceID, x.SpanID)
+		case EventPanic:
+			// TODO(mwhittaker): Show stack trace?
+			fmt.Fprintf(&b, "    note right of %s%d: [%d:%d] %s\n", x.Panicker, x.Replica, x.TraceID, x.SpanID, x.Error)
 		}
 	}
 	return b.String()

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -599,8 +599,8 @@ func (r *Results) Mermaid() string {
 			call := calls[x.SpanID]
 			fmt.Fprintf(&b, "    note right of %s%d: [%d:%d] RemoteCallError\n", call.Caller, call.Replica, x.TraceID, x.SpanID)
 		case EventPanic:
-			// TODO(mwhittaker): Show stack trace?
-			fmt.Fprintf(&b, "    note right of %s%d: [%d:%d] %s\n", x.Panicker, x.Replica, x.TraceID, x.SpanID, x.Error)
+			stack := strings.ReplaceAll(x.Stack, "\n", "<br>")
+			fmt.Fprintf(&b, "    note right of %s%d: [%d:%d] %s<br>%s\n", x.Panicker, x.Replica, x.TraceID, x.SpanID, x.Error, stack)
 		}
 	}
 	return b.String()

--- a/internal/sim/weaver_gen.go
+++ b/internal/sim/weaver_gen.go
@@ -105,6 +105,42 @@ func init() {
 		},
 		RefData: "⟦1dff5ab5:wEaVeReDgE:github.com/ServiceWeaver/weaver/internal/sim/mod→github.com/ServiceWeaver/weaver/internal/sim/identity⟧\n",
 	})
+	codegen.Register(codegen.Registration{
+		Name:  "github.com/ServiceWeaver/weaver/internal/sim/panicker",
+		Iface: reflect.TypeOf((*panicker)(nil)).Elem(),
+		Impl:  reflect.TypeOf(panickerImpl{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return panicker_local_stub{impl: impl.(panicker), tracer: tracer, panicMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/panicker", Method: "Panic", Remote: false})}
+		},
+		ClientStubFn: func(stub codegen.Stub, caller string) any {
+			return panicker_client_stub{stub: stub, panicMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/panicker", Method: "Panic", Remote: true})}
+		},
+		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
+			return panicker_server_stub{impl: impl.(panicker), addLoad: addLoad}
+		},
+		ReflectStubFn: func(caller func(string, context.Context, []any, []any) error) any {
+			return panicker_reflect_stub{caller: caller}
+		},
+		RefData: "",
+	})
+	codegen.Register(codegen.Registration{
+		Name:  "github.com/ServiceWeaver/weaver/internal/sim/register",
+		Iface: reflect.TypeOf((*register)(nil)).Elem(),
+		Impl:  reflect.TypeOf(registerImpl{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return register_local_stub{impl: impl.(register), tracer: tracer, appendMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/register", Method: "Append", Remote: false}), clearMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/register", Method: "Clear", Remote: false})}
+		},
+		ClientStubFn: func(stub codegen.Stub, caller string) any {
+			return register_client_stub{stub: stub, appendMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/register", Method: "Append", Remote: true}), clearMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/register", Method: "Clear", Remote: true})}
+		},
+		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
+			return register_server_stub{impl: impl.(register), addLoad: addLoad}
+		},
+		ReflectStubFn: func(caller func(string, context.Context, []any, []any) error) any {
+			return register_reflect_stub{caller: caller}
+		},
+		RefData: "",
+	})
 }
 
 // weaver.InstanceOf checks.
@@ -113,6 +149,8 @@ var _ weaver.InstanceOf[div] = (*divImpl)(nil)
 var _ weaver.InstanceOf[divMod] = (*divModImpl)(nil)
 var _ weaver.InstanceOf[identity] = (*identityImpl)(nil)
 var _ weaver.InstanceOf[mod] = (*modImpl)(nil)
+var _ weaver.InstanceOf[panicker] = (*panickerImpl)(nil)
+var _ weaver.InstanceOf[register] = (*registerImpl)(nil)
 
 // weaver.Router checks.
 var _ weaver.Unrouted = (*blockerImpl)(nil)
@@ -120,6 +158,8 @@ var _ weaver.Unrouted = (*divImpl)(nil)
 var _ weaver.Unrouted = (*divModImpl)(nil)
 var _ weaver.Unrouted = (*identityImpl)(nil)
 var _ weaver.Unrouted = (*modImpl)(nil)
+var _ weaver.Unrouted = (*panickerImpl)(nil)
+var _ weaver.Unrouted = (*registerImpl)(nil)
 
 // Local stub implementations.
 
@@ -266,6 +306,85 @@ func (s mod_local_stub) Mod(ctx context.Context, a0 int, a1 int) (r0 int, err er
 	}
 
 	return s.impl.Mod(ctx, a0, a1)
+}
+
+type panicker_local_stub struct {
+	impl         panicker
+	tracer       trace.Tracer
+	panicMetrics *codegen.MethodMetrics
+}
+
+// Check that panicker_local_stub implements the panicker interface.
+var _ panicker = (*panicker_local_stub)(nil)
+
+func (s panicker_local_stub) Panic(ctx context.Context, a0 bool) (err error) {
+	// Update metrics.
+	begin := s.panicMetrics.Begin()
+	defer func() { s.panicMetrics.End(begin, err != nil, 0, 0) }()
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "sim.panicker.Panic", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.Panic(ctx, a0)
+}
+
+type register_local_stub struct {
+	impl          register
+	tracer        trace.Tracer
+	appendMetrics *codegen.MethodMetrics
+	clearMetrics  *codegen.MethodMetrics
+}
+
+// Check that register_local_stub implements the register interface.
+var _ register = (*register_local_stub)(nil)
+
+func (s register_local_stub) Append(ctx context.Context, a0 string) (r0 string, err error) {
+	// Update metrics.
+	begin := s.appendMetrics.Begin()
+	defer func() { s.appendMetrics.End(begin, err != nil, 0, 0) }()
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "sim.register.Append", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.Append(ctx, a0)
+}
+
+func (s register_local_stub) Clear(ctx context.Context) (err error) {
+	// Update metrics.
+	begin := s.clearMetrics.Begin()
+	defer func() { s.clearMetrics.End(begin, err != nil, 0, 0) }()
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "sim.register.Clear", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.Clear(ctx)
 }
 
 // Client stub implementations.
@@ -587,6 +706,180 @@ func (s mod_client_stub) Mod(ctx context.Context, a0 int, a1 int) (r0 int, err e
 	return
 }
 
+type panicker_client_stub struct {
+	stub         codegen.Stub
+	panicMetrics *codegen.MethodMetrics
+}
+
+// Check that panicker_client_stub implements the panicker interface.
+var _ panicker = (*panicker_client_stub)(nil)
+
+func (s panicker_client_stub) Panic(ctx context.Context, a0 bool) (err error) {
+	// Update metrics.
+	var requestBytes, replyBytes int
+	begin := s.panicMetrics.Begin()
+	defer func() { s.panicMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "sim.panicker.Panic", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+			if err != nil {
+				err = errors.Join(weaver.RemoteCallError, err)
+			}
+		}
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+
+	}()
+
+	// Preallocate a buffer of the right size.
+	size := 0
+	size += 1
+	enc := codegen.NewEncoder()
+	enc.Reset(size)
+
+	// Encode arguments.
+	enc.Bool(a0)
+	var shardKey uint64
+
+	// Call the remote method.
+	requestBytes = len(enc.Data())
+	var results []byte
+	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
+	if err != nil {
+		err = errors.Join(weaver.RemoteCallError, err)
+		return
+	}
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	err = dec.Error()
+	return
+}
+
+type register_client_stub struct {
+	stub          codegen.Stub
+	appendMetrics *codegen.MethodMetrics
+	clearMetrics  *codegen.MethodMetrics
+}
+
+// Check that register_client_stub implements the register interface.
+var _ register = (*register_client_stub)(nil)
+
+func (s register_client_stub) Append(ctx context.Context, a0 string) (r0 string, err error) {
+	// Update metrics.
+	var requestBytes, replyBytes int
+	begin := s.appendMetrics.Begin()
+	defer func() { s.appendMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "sim.register.Append", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+			if err != nil {
+				err = errors.Join(weaver.RemoteCallError, err)
+			}
+		}
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+
+	}()
+
+	// Preallocate a buffer of the right size.
+	size := 0
+	size += (4 + len(a0))
+	enc := codegen.NewEncoder()
+	enc.Reset(size)
+
+	// Encode arguments.
+	enc.String(a0)
+	var shardKey uint64
+
+	// Call the remote method.
+	requestBytes = len(enc.Data())
+	var results []byte
+	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
+	replyBytes = len(results)
+	if err != nil {
+		err = errors.Join(weaver.RemoteCallError, err)
+		return
+	}
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	r0 = dec.String()
+	err = dec.Error()
+	return
+}
+
+func (s register_client_stub) Clear(ctx context.Context) (err error) {
+	// Update metrics.
+	var requestBytes, replyBytes int
+	begin := s.clearMetrics.Begin()
+	defer func() { s.clearMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "sim.register.Clear", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+			if err != nil {
+				err = errors.Join(weaver.RemoteCallError, err)
+			}
+		}
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+
+	}()
+
+	var shardKey uint64
+
+	// Call the remote method.
+	var results []byte
+	results, err = s.stub.Run(ctx, 1, nil, shardKey)
+	replyBytes = len(results)
+	if err != nil {
+		err = errors.Join(weaver.RemoteCallError, err)
+		return
+	}
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	err = dec.Error()
+	return
+}
+
 // Note that "weaver generate" will always generate the error message below.
 // Everything is okay. The error message is only relevant if you see it when
 // you run "go build" or "go run".
@@ -828,6 +1121,112 @@ func (s mod_server_stub) mod(ctx context.Context, args []byte) (res []byte, err 
 	return enc.Data(), nil
 }
 
+type panicker_server_stub struct {
+	impl    panicker
+	addLoad func(key uint64, load float64)
+}
+
+// Check that panicker_server_stub implements the codegen.Server interface.
+var _ codegen.Server = (*panicker_server_stub)(nil)
+
+// GetStubFn implements the codegen.Server interface.
+func (s panicker_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
+	switch method {
+	case "Panic":
+		return s.panic
+	default:
+		return nil
+	}
+}
+
+func (s panicker_server_stub) panic(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// Decode arguments.
+	dec := codegen.NewDecoder(args)
+	var a0 bool
+	a0 = dec.Bool()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	appErr := s.impl.Panic(ctx, a0)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
+
+type register_server_stub struct {
+	impl    register
+	addLoad func(key uint64, load float64)
+}
+
+// Check that register_server_stub implements the codegen.Server interface.
+var _ codegen.Server = (*register_server_stub)(nil)
+
+// GetStubFn implements the codegen.Server interface.
+func (s register_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
+	switch method {
+	case "Append":
+		return s.append
+	case "Clear":
+		return s.clear
+	default:
+		return nil
+	}
+}
+
+func (s register_server_stub) append(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// Decode arguments.
+	dec := codegen.NewDecoder(args)
+	var a0 string
+	a0 = dec.String()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	r0, appErr := s.impl.Append(ctx, a0)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	enc.String(r0)
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
+
+func (s register_server_stub) clear(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	appErr := s.impl.Clear(ctx)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
+
 // Reflect stub implementations.
 
 type blocker_reflect_stub struct {
@@ -887,6 +1286,35 @@ var _ mod = (*mod_reflect_stub)(nil)
 
 func (s mod_reflect_stub) Mod(ctx context.Context, a0 int, a1 int) (r0 int, err error) {
 	err = s.caller("Mod", ctx, []any{a0, a1}, []any{&r0})
+	return
+}
+
+type panicker_reflect_stub struct {
+	caller func(string, context.Context, []any, []any) error
+}
+
+// Check that panicker_reflect_stub implements the panicker interface.
+var _ panicker = (*panicker_reflect_stub)(nil)
+
+func (s panicker_reflect_stub) Panic(ctx context.Context, a0 bool) (err error) {
+	err = s.caller("Panic", ctx, []any{a0}, []any{})
+	return
+}
+
+type register_reflect_stub struct {
+	caller func(string, context.Context, []any, []any) error
+}
+
+// Check that register_reflect_stub implements the register interface.
+var _ register = (*register_reflect_stub)(nil)
+
+func (s register_reflect_stub) Append(ctx context.Context, a0 string) (r0 string, err error) {
+	err = s.caller("Append", ctx, []any{a0}, []any{&r0})
+	return
+}
+
+func (s register_reflect_stub) Clear(ctx context.Context) (err error) {
+	err = s.caller("Clear", ctx, []any{}, []any{})
 	return
 }
 

--- a/internal/sim/weaver_gen.go
+++ b/internal/sim/weaver_gen.go
@@ -123,24 +123,6 @@ func init() {
 		},
 		RefData: "",
 	})
-	codegen.Register(codegen.Registration{
-		Name:  "github.com/ServiceWeaver/weaver/internal/sim/register",
-		Iface: reflect.TypeOf((*register)(nil)).Elem(),
-		Impl:  reflect.TypeOf(registerImpl{}),
-		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
-			return register_local_stub{impl: impl.(register), tracer: tracer, appendMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/register", Method: "Append", Remote: false}), clearMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/register", Method: "Clear", Remote: false})}
-		},
-		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return register_client_stub{stub: stub, appendMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/register", Method: "Append", Remote: true}), clearMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/sim/register", Method: "Clear", Remote: true})}
-		},
-		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
-			return register_server_stub{impl: impl.(register), addLoad: addLoad}
-		},
-		ReflectStubFn: func(caller func(string, context.Context, []any, []any) error) any {
-			return register_reflect_stub{caller: caller}
-		},
-		RefData: "",
-	})
 }
 
 // weaver.InstanceOf checks.
@@ -150,7 +132,6 @@ var _ weaver.InstanceOf[divMod] = (*divModImpl)(nil)
 var _ weaver.InstanceOf[identity] = (*identityImpl)(nil)
 var _ weaver.InstanceOf[mod] = (*modImpl)(nil)
 var _ weaver.InstanceOf[panicker] = (*panickerImpl)(nil)
-var _ weaver.InstanceOf[register] = (*registerImpl)(nil)
 
 // weaver.Router checks.
 var _ weaver.Unrouted = (*blockerImpl)(nil)
@@ -159,7 +140,6 @@ var _ weaver.Unrouted = (*divModImpl)(nil)
 var _ weaver.Unrouted = (*identityImpl)(nil)
 var _ weaver.Unrouted = (*modImpl)(nil)
 var _ weaver.Unrouted = (*panickerImpl)(nil)
-var _ weaver.Unrouted = (*registerImpl)(nil)
 
 // Local stub implementations.
 
@@ -335,56 +315,6 @@ func (s panicker_local_stub) Panic(ctx context.Context, a0 bool) (err error) {
 	}
 
 	return s.impl.Panic(ctx, a0)
-}
-
-type register_local_stub struct {
-	impl          register
-	tracer        trace.Tracer
-	appendMetrics *codegen.MethodMetrics
-	clearMetrics  *codegen.MethodMetrics
-}
-
-// Check that register_local_stub implements the register interface.
-var _ register = (*register_local_stub)(nil)
-
-func (s register_local_stub) Append(ctx context.Context, a0 string) (r0 string, err error) {
-	// Update metrics.
-	begin := s.appendMetrics.Begin()
-	defer func() { s.appendMetrics.End(begin, err != nil, 0, 0) }()
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a child span for this method.
-		ctx, span = s.tracer.Start(ctx, "sim.register.Append", trace.WithSpanKind(trace.SpanKindInternal))
-		defer func() {
-			if err != nil {
-				span.RecordError(err)
-				span.SetStatus(codes.Error, err.Error())
-			}
-			span.End()
-		}()
-	}
-
-	return s.impl.Append(ctx, a0)
-}
-
-func (s register_local_stub) Clear(ctx context.Context) (err error) {
-	// Update metrics.
-	begin := s.clearMetrics.Begin()
-	defer func() { s.clearMetrics.End(begin, err != nil, 0, 0) }()
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a child span for this method.
-		ctx, span = s.tracer.Start(ctx, "sim.register.Clear", trace.WithSpanKind(trace.SpanKindInternal))
-		defer func() {
-			if err != nil {
-				span.RecordError(err)
-				span.SetStatus(codes.Error, err.Error())
-			}
-			span.End()
-		}()
-	}
-
-	return s.impl.Clear(ctx)
 }
 
 // Client stub implementations.
@@ -769,117 +699,6 @@ func (s panicker_client_stub) Panic(ctx context.Context, a0 bool) (err error) {
 	return
 }
 
-type register_client_stub struct {
-	stub          codegen.Stub
-	appendMetrics *codegen.MethodMetrics
-	clearMetrics  *codegen.MethodMetrics
-}
-
-// Check that register_client_stub implements the register interface.
-var _ register = (*register_client_stub)(nil)
-
-func (s register_client_stub) Append(ctx context.Context, a0 string) (r0 string, err error) {
-	// Update metrics.
-	var requestBytes, replyBytes int
-	begin := s.appendMetrics.Begin()
-	defer func() { s.appendMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
-
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a child span for this method.
-		ctx, span = s.stub.Tracer().Start(ctx, "sim.register.Append", trace.WithSpanKind(trace.SpanKindClient))
-	}
-
-	defer func() {
-		// Catch and return any panics detected during encoding/decoding/rpc.
-		if err == nil {
-			err = codegen.CatchPanics(recover())
-			if err != nil {
-				err = errors.Join(weaver.RemoteCallError, err)
-			}
-		}
-
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-		}
-		span.End()
-
-	}()
-
-	// Preallocate a buffer of the right size.
-	size := 0
-	size += (4 + len(a0))
-	enc := codegen.NewEncoder()
-	enc.Reset(size)
-
-	// Encode arguments.
-	enc.String(a0)
-	var shardKey uint64
-
-	// Call the remote method.
-	requestBytes = len(enc.Data())
-	var results []byte
-	results, err = s.stub.Run(ctx, 0, enc.Data(), shardKey)
-	replyBytes = len(results)
-	if err != nil {
-		err = errors.Join(weaver.RemoteCallError, err)
-		return
-	}
-
-	// Decode the results.
-	dec := codegen.NewDecoder(results)
-	r0 = dec.String()
-	err = dec.Error()
-	return
-}
-
-func (s register_client_stub) Clear(ctx context.Context) (err error) {
-	// Update metrics.
-	var requestBytes, replyBytes int
-	begin := s.clearMetrics.Begin()
-	defer func() { s.clearMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
-
-	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a child span for this method.
-		ctx, span = s.stub.Tracer().Start(ctx, "sim.register.Clear", trace.WithSpanKind(trace.SpanKindClient))
-	}
-
-	defer func() {
-		// Catch and return any panics detected during encoding/decoding/rpc.
-		if err == nil {
-			err = codegen.CatchPanics(recover())
-			if err != nil {
-				err = errors.Join(weaver.RemoteCallError, err)
-			}
-		}
-
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-		}
-		span.End()
-
-	}()
-
-	var shardKey uint64
-
-	// Call the remote method.
-	var results []byte
-	results, err = s.stub.Run(ctx, 1, nil, shardKey)
-	replyBytes = len(results)
-	if err != nil {
-		err = errors.Join(weaver.RemoteCallError, err)
-		return
-	}
-
-	// Decode the results.
-	dec := codegen.NewDecoder(results)
-	err = dec.Error()
-	return
-}
-
 // Note that "weaver generate" will always generate the error message below.
 // Everything is okay. The error message is only relevant if you see it when
 // you run "go build" or "go run".
@@ -1163,70 +982,6 @@ func (s panicker_server_stub) panic(ctx context.Context, args []byte) (res []byt
 	return enc.Data(), nil
 }
 
-type register_server_stub struct {
-	impl    register
-	addLoad func(key uint64, load float64)
-}
-
-// Check that register_server_stub implements the codegen.Server interface.
-var _ codegen.Server = (*register_server_stub)(nil)
-
-// GetStubFn implements the codegen.Server interface.
-func (s register_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
-	switch method {
-	case "Append":
-		return s.append
-	case "Clear":
-		return s.clear
-	default:
-		return nil
-	}
-}
-
-func (s register_server_stub) append(ctx context.Context, args []byte) (res []byte, err error) {
-	// Catch and return any panics detected during encoding/decoding/rpc.
-	defer func() {
-		if err == nil {
-			err = codegen.CatchPanics(recover())
-		}
-	}()
-
-	// Decode arguments.
-	dec := codegen.NewDecoder(args)
-	var a0 string
-	a0 = dec.String()
-
-	// TODO(rgrandl): The deferred function above will recover from panics in the
-	// user code: fix this.
-	// Call the local method.
-	r0, appErr := s.impl.Append(ctx, a0)
-
-	// Encode the results.
-	enc := codegen.NewEncoder()
-	enc.String(r0)
-	enc.Error(appErr)
-	return enc.Data(), nil
-}
-
-func (s register_server_stub) clear(ctx context.Context, args []byte) (res []byte, err error) {
-	// Catch and return any panics detected during encoding/decoding/rpc.
-	defer func() {
-		if err == nil {
-			err = codegen.CatchPanics(recover())
-		}
-	}()
-
-	// TODO(rgrandl): The deferred function above will recover from panics in the
-	// user code: fix this.
-	// Call the local method.
-	appErr := s.impl.Clear(ctx)
-
-	// Encode the results.
-	enc := codegen.NewEncoder()
-	enc.Error(appErr)
-	return enc.Data(), nil
-}
-
 // Reflect stub implementations.
 
 type blocker_reflect_stub struct {
@@ -1298,23 +1053,6 @@ var _ panicker = (*panicker_reflect_stub)(nil)
 
 func (s panicker_reflect_stub) Panic(ctx context.Context, a0 bool) (err error) {
 	err = s.caller("Panic", ctx, []any{a0}, []any{})
-	return
-}
-
-type register_reflect_stub struct {
-	caller func(string, context.Context, []any, []any) error
-}
-
-// Check that register_reflect_stub implements the register interface.
-var _ register = (*register_reflect_stub)(nil)
-
-func (s register_reflect_stub) Append(ctx context.Context, a0 string) (r0 string, err error) {
-	err = s.caller("Append", ctx, []any{a0}, []any{&r0})
-	return
-}
-
-func (s register_reflect_stub) Clear(ctx context.Context) (err error) {
-	err = s.caller("Clear", ctx, []any{}, []any{})
 	return
 }
 


### PR DESCRIPTION
This PR extends the simulator to catch any panics that happen during an execution and abort the execution. By catching panics, the simulator is able to show the user the history of events that led to the panic.

This PR also fixes a minor bug. Previously, we recorded the history for aborted events. With this PR, once an execution is aborted, no other events are recorded.

I also renamed some unit tests to be more descriptive.