### PR TITLE
Detect bad context propagation in simulations.

### DIFF
--- a/internal/sim/executor.go
+++ b/internal/sim/executor.go
@@ -384,10 +384,17 @@ func (e *executor) call(caller string, replica int, reg *codegen.Registration, m
 		strings[i] = fmt.Sprint(arg)
 	}
 
+	// Extract the trace id.
+	traceID, _ := extractIDs(ctx)
+	if traceID == 0 {
+		// TODO(mwhittaker): Link to online documentation with better
+		// explanation of this error.
+		panic(fmt.Errorf("missing simulation trace context. Make sure you are correctly propagating contexts through your workload."))
+	}
+
 	// Record the call.
 	reply := make(chan *reply, 1)
 	e.mu.Lock()
-	traceID, _ := extractIDs(ctx)
 	spanID := e.nextSpanID
 	e.nextSpanID++
 

--- a/internal/sim/executor.go
+++ b/internal/sim/executor.go
@@ -389,7 +389,7 @@ func (e *executor) call(caller string, replica int, reg *codegen.Registration, m
 	if traceID == 0 {
 		// TODO(mwhittaker): Link to online documentation with better
 		// explanation of this error.
-		panic(fmt.Errorf("missing simulation trace context. Make sure you are correctly propagating contexts through your workload."))
+		panic(fmt.Errorf("missing simulation trace context. Make sure that every component method call is performed with the context the caller was invoked with."))
 	}
 
 	// Record the call.


### PR DESCRIPTION
An executor embeds trace and span ids in the contexts passed to a workload. The workload is responsible for propagating these contexts throughout the workload. If a context is not propagated, then an executor cannot tell which op a given call is part of. This makes it impossible for the executor to schedule things correctly. Plus, the reported history will be missing tracing information, making it much harder to understand what happened.

This PR detects and panics when contexts are not being propagated properly. I think with enough effort, we could modify the executor to gracefully handle missing trace information, but I'll leave that for future work.