### PR TITLE
net/call now picks appropriate default for options.

### DIFF
--- a/internal/net/benchmarks/net_test.go
+++ b/internal/net/benchmarks/net_test.go
@@ -39,8 +39,8 @@ var (
 	subproccess           = flag.Bool("subprocess", false, "Is this a subprocess?")
 	network               = flag.String("network", "", "Network (e.g., tcp, unix, mtls)")
 	address               = flag.String("address", "", "Server address")
-	inlineHandlerDuration = flag.Duration("inline_handler_duration", 0, "ServerOptions.InlineHandlerDuration")
-	writeFlattenLimit     = flag.Int("write_flatten_limit", 0, "ServerOptions.WriteFlattenLimit")
+	inlineHandlerDuration = flag.Duration("inline_handler_duration", -1, "ServerOptions.InlineHandlerDuration")
+	writeFlattenLimit     = flag.Int("write_flatten_limit", -1, "ServerOptions.WriteFlattenLimit")
 
 	echoKey   = call.MakeMethodKey("component", "echo")
 	handlers  call.HandlerMap
@@ -214,8 +214,8 @@ func configs(b testing.TB) []config {
 	var configs []config
 	for _, network := range []string{"tcp", "unix", "mtls"} {
 		for _, spin := range []time.Duration{0, 20 * time.Microsecond} {
-			for _, inline := range []time.Duration{0, 20 * time.Microsecond} {
-				for _, flatten := range []int{0, 1 << 10, 4 << 10} {
+			for _, inline := range []time.Duration{-1, 20 * time.Microsecond} {
+				for _, flatten := range []int{-1, 1 << 10, 4 << 10} {
 					addr := "localhost:12345"
 					if network == "unix" {
 						addr = filepath.Join(b.TempDir(), "socket")

--- a/internal/net/call/options.go
+++ b/internal/net/call/options.go
@@ -23,6 +23,11 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const (
+	defaultWriteFlattenLimit     = 4 << 10
+	defaultInlineHandlerDuration = 20 * time.Microsecond
+)
+
 // ClientOptions are the options to configure an RPC client.
 type ClientOptions struct {
 	// Load balancer. Defaults to RoundRobin() if nil.
@@ -35,8 +40,9 @@ type ClientOptions struct {
 	// before blocking, waiting for the results.
 	OptimisticSpinDuration time.Duration
 
-	// If non-zero, all writes smaller than this limit are flattened into
-	// a single buffer before being written on the connection.
+	// All writes smaller than this limit are flattened into a single
+	// buffer before being written on the connection. If zero, an appropriate
+	// value is picked automatically.
 	WriteFlattenLimit int
 }
 
@@ -48,12 +54,15 @@ type ServerOptions struct {
 	// Tracer. Defaults to a discarding tracer.
 	Tracer trace.Tracer
 
-	// If non-zero, calls on the server are inlined and a new goroutine is
+	// If positive, calls on the server are inlined and a new goroutine is
 	// launched only if the call takes longer than the provided duration.
+	// If zero, the system inlines call execution and automatically picks a
+	// reasonable delay before the new goroutine is launched.
 	InlineHandlerDuration time.Duration
 
-	// If non-zero, all writes smaller than this limit are flattened into
-	// a single buffer before being written on the connection.
+	// All writes smaller than this limit are flattened into a single
+	// buffer before being written on the connection. If zero, an appropriate
+	// value is picked automatically.
 	WriteFlattenLimit int
 }
 
@@ -80,6 +89,9 @@ func (c ClientOptions) withDefaults() ClientOptions {
 	if c.Balancer == nil {
 		c.Balancer = RoundRobin()
 	}
+	if c.WriteFlattenLimit == 0 {
+		c.WriteFlattenLimit = defaultWriteFlattenLimit
+	}
 	return c
 }
 
@@ -91,6 +103,12 @@ func (s ServerOptions) withDefaults() ServerOptions {
 	}
 	if s.Tracer == nil {
 		s.Tracer = traceio.TestTracer()
+	}
+	if s.InlineHandlerDuration == 0 {
+		s.InlineHandlerDuration = defaultInlineHandlerDuration
+	}
+	if s.WriteFlattenLimit == 0 {
+		s.WriteFlattenLimit = defaultWriteFlattenLimit
 	}
 	return s
 }

--- a/internal/net/call/options.go
+++ b/internal/net/call/options.go
@@ -42,7 +42,7 @@ type ClientOptions struct {
 
 	// All writes smaller than this limit are flattened into a single
 	// buffer before being written on the connection. If zero, an appropriate
-	// value is picked automatically.
+	// value is picked automatically. If negative, no flattening is done.
 	WriteFlattenLimit int
 }
 
@@ -58,11 +58,12 @@ type ServerOptions struct {
 	// launched only if the call takes longer than the provided duration.
 	// If zero, the system inlines call execution and automatically picks a
 	// reasonable delay before the new goroutine is launched.
+	// If negative, handlers are always started in a new goroutine.
 	InlineHandlerDuration time.Duration
 
 	// All writes smaller than this limit are flattened into a single
 	// buffer before being written on the connection. If zero, an appropriate
-	// value is picked automatically.
+	// value is picked automatically. If negative, no flattening is done.
 	WriteFlattenLimit int
 }
 

--- a/internal/weaver/remoteweavelet.go
+++ b/internal/weaver/remoteweavelet.go
@@ -25,7 +25,6 @@ import (
 	"reflect"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/ServiceWeaver/weaver/internal/config"
 	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
@@ -189,10 +188,8 @@ func NewRemoteWeavelet(ctx context.Context, regs []*codegen.Registration, bootst
 	servers.Go(func() error {
 		server := &server{Listener: w.conn.Listener(), wlet: w}
 		opts := call.ServerOptions{
-			Logger:                w.syslogger,
-			Tracer:                w.tracer,
-			InlineHandlerDuration: 20 * time.Microsecond,
-			WriteFlattenLimit:     4 << 10,
+			Logger: w.syslogger,
+			Tracer: w.tracer,
 		}
 		if err := call.Serve(w.ctx, server, opts); err != nil {
 			w.syslogger.Error("RPC server failed", "err", err)
@@ -359,9 +356,8 @@ func (w *RemoteWeavelet) makeStub(reg *codegen.Registration, resolver *routingRe
 	name := logging.ShortenComponent(reg.Name)
 	w.syslogger.Debug("Connecting to remote", "component", name)
 	opts := call.ClientOptions{
-		Balancer:          balancer,
-		Logger:            w.syslogger,
-		WriteFlattenLimit: 4 << 10,
+		Balancer: balancer,
+		Logger:   w.syslogger,
 	}
 	conn, err := call.Connect(w.ctx, resolver, opts)
 	if err != nil {


### PR DESCRIPTION
Previously callers of call.Serve and call.Connect were responsible for picking appropriate tuning parameter values. We now let the callers provide zero values and let the call implementation pick the right value.