### PR TITLE
Run more than one replica in the simulator.

### DIFF
--- a/internal/sim/executor_test.go
+++ b/internal/sim/executor_test.go
@@ -620,6 +620,34 @@ func BenchmarkExecutions(b *testing.B) {
 	}
 }
 
+func BenchmarkNumReplicas(b *testing.B) {
+	for _, numReplicas := range []int{1, 2, 3} {
+		name := fmt.Sprintf("%d-Replicas", numReplicas)
+		b.Run(name, func(b *testing.B) {
+			s := New(b, &oneCallWorkload{}, Options{})
+			exec := s.newExecutor()
+			params := hyperparameters{
+				NumReplicas: numReplicas,
+				NumOps:      1,
+				FailureRate: 0,
+				YieldRate:   1,
+			}
+			ctx := context.Background()
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				result, err := exec.execute(ctx, params)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if result.err != nil {
+					b.Fatal(result.err)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkParallelExecutions(b *testing.B) {
 	for _, bench := range []struct {
 		name     string

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -404,21 +404,10 @@ func (s *Simulator) run(ctx context.Context, stats *stats) (result, error) {
 		defer done.Done()
 		seed := time.Now().UnixNano()
 		for numOps := 1; ; numOps++ {
-			for numReplicas := 1; numReplicas <= 3; numReplicas++ {
+			for _, numReplicas := range []int{1, 2, 3} {
 				for _, failureRate := range []float64{0.0, 0.01, 0.05, 0.1} {
 					for _, yieldRate := range []float64{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0} {
-						// Run fewer executions with more replicas.
-						var iterations int
-						switch numReplicas {
-						case 1:
-							iterations = 1000
-						case 2:
-							iterations = 100
-						case 3:
-							iterations = 10
-						}
-
-						for i := 0; i < iterations; i++ {
+						for i := 0; i < 1000; i++ {
 							seed++
 							p := hyperparameters{
 								Seed:        seed,

--- a/internal/sim/simulator.go
+++ b/internal/sim/simulator.go
@@ -404,21 +404,34 @@ func (s *Simulator) run(ctx context.Context, stats *stats) (result, error) {
 		defer done.Done()
 		seed := time.Now().UnixNano()
 		for numOps := 1; ; numOps++ {
-			for _, failureRate := range []float64{0.0, 0.01, 0.05, 0.1} {
-				for _, yieldRate := range []float64{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0} {
-					for i := 0; i < 10; i++ {
-						seed++
-						p := hyperparameters{
-							Seed:        seed,
-							NumOps:      numOps,
-							NumReplicas: 1,
-							FailureRate: failureRate,
-							YieldRate:   yieldRate,
+			for numReplicas := 1; numReplicas <= 3; numReplicas++ {
+				for _, failureRate := range []float64{0.0, 0.01, 0.05, 0.1} {
+					for _, yieldRate := range []float64{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0} {
+						// Run fewer executions with more replicas.
+						var iterations int
+						switch numReplicas {
+						case 1:
+							iterations = 1000
+						case 2:
+							iterations = 100
+						case 3:
+							iterations = 10
 						}
-						select {
-						case <-ctx.Done():
-							return
-						case params <- p:
+
+						for i := 0; i < iterations; i++ {
+							seed++
+							p := hyperparameters{
+								Seed:        seed,
+								NumOps:      numOps,
+								NumReplicas: numReplicas,
+								FailureRate: failureRate,
+								YieldRate:   yieldRate,
+							}
+							select {
+							case <-ctx.Done():
+								return
+							case params <- p:
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Executions with more than one replica of each component are harder to reason about, but some bugs may only trigger when there are more than one replica. This PR changes the simulator to sometimes run 2 or 3 replicas of every component.