### PR TITLE
Add a graph library and use it to represent the component call-graph.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -363,11 +363,9 @@ github.com/ServiceWeaver/weaver/internal/tool
     runtime/debug
 github.com/ServiceWeaver/weaver/internal/tool/callgraph
     fmt
-    github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/bin
+    github.com/ServiceWeaver/weaver/runtime/graph
     github.com/ServiceWeaver/weaver/runtime/logging
-    golang.org/x/exp/maps
-    sort
     strings
 github.com/ServiceWeaver/weaver/internal/tool/certs
     bytes
@@ -446,6 +444,7 @@ github.com/ServiceWeaver/weaver/internal/tool/multi
     github.com/ServiceWeaver/weaver/runtime/colors
     github.com/ServiceWeaver/weaver/runtime/deployers
     github.com/ServiceWeaver/weaver/runtime/envelope
+    github.com/ServiceWeaver/weaver/runtime/graph
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/metrics
     github.com/ServiceWeaver/weaver/runtime/profiling
@@ -648,7 +647,10 @@ github.com/ServiceWeaver/weaver/runtime/bin
     debug/pe
     fmt
     github.com/ServiceWeaver/weaver/runtime/codegen
+    github.com/ServiceWeaver/weaver/runtime/graph
     github.com/ServiceWeaver/weaver/runtime/version
+    golang.org/x/exp/maps
+    golang.org/x/exp/slices
     os
     regexp
     strconv
@@ -706,6 +708,9 @@ github.com/ServiceWeaver/weaver/runtime/envelope
     os
     strconv
     sync
+github.com/ServiceWeaver/weaver/runtime/graph
+    fmt
+    golang.org/x/exp/slices
 github.com/ServiceWeaver/weaver/runtime/logging
     bufio
     context

--- a/internal/tool/callgraph/callgraph.go
+++ b/internal/tool/callgraph/callgraph.go
@@ -18,67 +18,25 @@ package callgraph
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
-	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/bin"
+	"github.com/ServiceWeaver/weaver/runtime/graph"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
-	"golang.org/x/exp/maps"
 )
 
 // Mermaid returns a Mermaid diagram, https://mermaid.js.org/, of the component
 // call graph embedded in the provided Service Weaver binary.
 func Mermaid(binary string) (string, error) {
-	g, err := readGraph(binary)
+	components, g, err := bin.ReadComponentGraph(binary)
 	if err != nil {
 		return "", err
 	}
-	return g.mermaid(), nil
+	return mermaid(components, g), nil
 }
 
-// graph is a (potentially cyclic) call graph.
-type graph struct {
-	edges []edge
-}
-
-// An edge from src to dst exists when component src has a weaver.Ref on dst.
-type edge struct {
-	src, dst string
-}
-
-// readGraph reads a graph from the provided Service Weaver binary.
-func readGraph(binary string) (*graph, error) {
-	edges, err := bin.ReadComponentGraph(binary)
-	if err != nil {
-		return nil, fmt.Errorf("read graph %q: %w", binary, err)
-	}
-
-	g := graph{}
-	for _, e := range edges {
-		g.edges = append(g.edges, edge{e[0], e[1]})
-	}
-	return &g, nil
-}
-
-// nodes returns the nodes (aka components) in a graph.
-func (g *graph) nodes() []string {
-	components := map[string]struct{}{}
-	for _, edge := range g.edges {
-		components[edge.src] = struct{}{}
-		components[edge.dst] = struct{}{}
-	}
-
-	// Ensure we have a node for the main component.
-	components[runtime.Main] = struct{}{}
-
-	keys := maps.Keys(components)
-	sort.Strings(keys)
-	return keys
-}
-
-// mermaid returns a Mermaid diagram of the graph.
-func (g *graph) mermaid() string {
+// mermaid returns a Mermaid diagram of the given component graph.
+func mermaid(components []string, g graph.Graph) string {
 	// See https://mermaid.js.org/syntax/flowchart.html for details.
 	var b strings.Builder
 	fmt.Fprintln(&b, `%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%`)
@@ -86,16 +44,16 @@ func (g *graph) mermaid() string {
 
 	// Nodes.
 	fmt.Fprintln(&b, `    %% Nodes.`)
-	for _, node := range g.nodes() {
-		fmt.Fprintf(&b, "    %s(%s)\n", node, logging.ShortenComponent(node))
-	}
+	g.PerNode(func(n graph.Node) {
+		fmt.Fprintf(&b, "    %d(%s)\n", n, logging.ShortenComponent(components[n]))
+	})
 	fmt.Fprintln(&b, "")
 
 	// Edges.
 	fmt.Fprintln(&b, `    %% Edges.`)
-	for _, edge := range g.edges {
-		fmt.Fprintf(&b, "    %s --> %s\n", edge.src, edge.dst)
-	}
+	graph.PerEdge(g, func(e graph.Edge) {
+		fmt.Fprintf(&b, "    %d --> %d\n", e.Src, e.Dst)
+	})
 	return b.String()
 }
 

--- a/runtime/graph/adjacency.go
+++ b/runtime/graph/adjacency.go
@@ -1,0 +1,94 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/slices"
+)
+
+type adjacencyGraph struct {
+	// out[n] stores a list of nodes that n has an outgoing edge to.
+	// out[n] == nil means that n is not a node in the graph.
+	// out[n] == []Node{} means that node n exists but has no outgoing edges.
+	out [][]Node
+}
+
+var _ Graph = &adjacencyGraph{}
+
+// NewAdjacencyGraph returns a Graph represented using adjacency lists.
+//
+// It panics if it specified edge nodes aren't in nodes.
+func NewAdjacencyGraph(nodes []Node, edges []Edge) Graph {
+	// Find the maximum node value.
+	var max Node
+	for _, n := range nodes {
+		if n > max {
+			max = n
+		}
+	}
+
+	// Build an internal representation.
+	out := make([][]Node, max+1)
+	for _, n := range nodes {
+		out[n] = make([]Node, 0, 1) // provision one outgoing edge by default
+	}
+	for _, e := range edges {
+		if !isNode(e.Src, out) {
+			panic(fmt.Sprintf("edge source %d is not a node", e.Src))
+		}
+		if !isNode(e.Dst, out) {
+			panic(fmt.Sprintf("edge destination %d is not a node", e.Src))
+		}
+		out[e.Src] = append(out[e.Src], e.Dst)
+	}
+
+	for _, dsts := range out {
+		slices.Sort(dsts)
+	}
+	return &adjacencyGraph{out: out}
+}
+
+var _ Graph = &adjacencyGraph{}
+
+// PerNode implements the Graph interface.
+func (g *adjacencyGraph) PerNode(fn func(n Node)) {
+	for n, dsts := range g.out {
+		if dsts == nil { // not a node
+			continue
+		}
+		fn(Node(n))
+	}
+}
+
+// PerOutEdge implements the Graph interface.
+func (g *adjacencyGraph) PerOutEdge(src Node, fn func(e Edge)) {
+	if !isNode(src, g.out) {
+		panic(fmt.Sprintf("src %d is not a node", src))
+	}
+	for _, dst := range g.out[src] {
+		fn(Edge{Src: src, Dst: dst})
+	}
+}
+
+// NodeLimit implements the Graph interface.
+func (g *adjacencyGraph) NodeLimit() int {
+	return len(g.out)
+}
+
+func isNode(n Node, out [][]Node) bool {
+	return n >= 0 && int(n) < len(out) && out[n] != nil
+}

--- a/runtime/graph/adjacency_test.go
+++ b/runtime/graph/adjacency_test.go
@@ -1,0 +1,75 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ServiceWeaver/weaver/runtime/graph"
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/exp/slices"
+)
+
+func TestAdjacencyGraph(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		nodes []graph.Node
+		edges []graph.Edge
+	}{
+		{name: "empty"},
+		{
+			name:  "nodes_without_edges",
+			nodes: []graph.Node{0, 1, 2, 3},
+		},
+		{
+			name:  "nodes_with_edges",
+			nodes: []graph.Node{0, 1, 2, 3},
+			edges: []graph.Edge{{0, 0}, {0, 1}, {1, 2}, {2, 3}, {3, 0}},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := graph.NewAdjacencyGraph(tc.nodes, tc.edges)
+
+			// Collect nodes from the graph and compare.
+			var nodes []graph.Node
+			g.PerNode(func(n graph.Node) {
+				nodes = append(nodes, n)
+			})
+			slices.Sort(nodes)
+			if diff := cmp.Diff(tc.nodes, nodes); diff != "" {
+				t.Fatalf("unexpected nodes: (-want +got): %s", diff)
+			}
+
+			// Collect edges from the graph and compare.
+			var edges []graph.Edge
+			graph.PerEdge(g, func(e graph.Edge) {
+				edges = append(edges, e)
+			})
+			sort.Slice(edges, func(i, j int) bool {
+				x, y := edges[i], edges[j]
+				if x.Src == y.Src {
+					return x.Dst < y.Dst
+				}
+				return x.Src < y.Src
+			})
+			if diff := cmp.Diff(tc.edges, edges); diff != "" {
+				t.Fatalf("unexpected edges: (-want +got): %s", diff)
+			}
+
+		})
+	}
+}

--- a/runtime/graph/graph.go
+++ b/runtime/graph/graph.go
@@ -1,0 +1,60 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+// Node is a small non-negative number that identifies a node in
+// a directed graph.  Node numbers should be kept proportional to
+// the size of the graph (i.e., mostly densely packed) since different
+// algorithms may allocate arrays indexed by the node number.
+type Node int
+
+// Edge is a directed graph edge.
+type Edge struct {
+	Src, Dst Node
+}
+
+// Graph is an interface that represents a directed graph.  Most users will
+// want to use the `AdjacencyGraph` implementation of `Graph`, but it is
+// easy to provide and use a custom `Graph` implementation if necessary.
+type Graph interface {
+	// PerNode executes the supplied function exactly once per node.
+	PerNode(func(n Node))
+
+	// PerOutEdge executes the supplied function exactly once per edge from src.
+	PerOutEdge(src Node, fn func(e Edge))
+
+	// NodeLimit returns a number guaranteed to be larger than any
+	// Node in the graph.  Many algorithms assume that NodeLimit
+	// is not much larger than the number of Nodes in the graph,
+	// so Graph implementations should use a relatively dense numeric
+	// assignment for nodes.
+	NodeLimit() int
+}
+
+// PerEdge calls fn(edge) for every edge in g.
+func PerEdge(g Graph, fn func(e Edge)) {
+	g.PerNode(func(n Node) {
+		g.PerOutEdge(n, fn)
+	})
+
+}
+
+// OutDegree returns the out-degree for node n in g.
+func OutDegree(g Graph, n Node) int {
+	var result int
+	g.PerOutEdge(n, func(Edge) { result++ })
+	return result
+
+}


### PR DESCRIPTION
This graph library is based on an earlier C++ implementation by ghemawat@.

The binary package now returns a component call-graph, as opposed to returning a set of component edges. This fixes the following bug we ran into multiple times:
  * The program contains only the `weaver.Main` component.
  * The set of component edges is therefore empty.
  * The deployer iterates over the edges, and ends up ignoring `weaver.Main` component.

The graph package will be handy in the future, as we plan to perform a Topo-sort traversal of the graph when generating Kubernetes YAML files. Also, the package may be useful for detecting component-graph cycles.