### PR TITLE
Added local MySQL instructions for chat app.

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -19,8 +19,39 @@ graph TD
 
 ## How to Run Locally
 
-```sh
-$ go run .
+First, run a local MySQL instance and initialize it with [`chat.sql`](chat.sql).
+We recommend using Docker for this:
+
+```shell
+# Run the MySQL instance.
+$ docker run \
+      --rm \
+      --detach \
+      --name mysql \
+      --env MYSQL_ROOT_PASSWORD="password" \
+      --env MYSQL_DATABASE="serviceweaver_chat_example" \
+      --volume="$(realpath chat.sql):/app/chat.sql" \
+      --publish 127.0.0.1:3306:3306 \
+      mysql
+
+# Initialize the MySQL database.
+$ docker exec mysql sh -c "mysql --password=password < /app/chat.sql"
+```
+
+Then, update the `db_uri` field in `weaver.toml` to point to your MySQL
+instance. If you used the Docker commands above, the default value of `db_uri`
+should already point to your database. You don't have to change anything.
+
+Finally, run the application.
+
+```shell
+$ go build .
+
+# Run the application in a single process.
+$ weaver single deploy weaver.toml
+
+# Run the application in multiple processes.
+$ weaver multi deploy weaver.toml
 ```
 
 ## How to run on GKE

--- a/examples/chat/chat.sql
+++ b/examples/chat/chat.sql
@@ -1,0 +1,46 @@
+-- Copyright 2023 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+USE serviceweaver_chat_example;
+
+CREATE TABLE IF NOT EXISTS threads (
+    thread  INTEGER AUTO_INCREMENT PRIMARY KEY,
+    creator VARCHAR(256) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS userthreads (
+    user   VARCHAR(256) NOT NULL,
+    thread INTEGER NOT NULL,
+    CONSTRAINT uthread FOREIGN KEY(thread) REFERENCES threads(thread)
+);
+
+CREATE TABLE IF NOT EXISTS images (
+    id    INTEGER AUTO_INCREMENT PRIMARY KEY,
+    image BLOB NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS posts (
+    post    INTEGER AUTO_INCREMENT PRIMARY KEY,
+    thread  INTEGER NOT NULL,
+    creator VARCHAR(256) NOT NULL,
+    time    INTEGER NOT NULL,
+    text    TEXT NOT NULL,
+    imageid INTEGER,
+    CONSTRAINT pthread FOREIGN KEY (thread) REFERENCES threads(thread),
+    CONSTRAINT pimageid FOREIGN KEY (imageid) REFERENCES images(id)
+);
+
+CREATE INDEX thread ON threads (thread);
+CREATE INDEX uthread ON userthreads (thread);
+CREATE INDEX image ON images (id);

--- a/examples/chat/sqlstore.go
+++ b/examples/chat/sqlstore.go
@@ -100,6 +100,8 @@ func (cfg *config) Validate() error {
 }
 
 func (s *sqlStore) Init(ctx context.Context) error {
+	// TODO(mwhittaker): Don't use sqlite, and don't initialize the database
+	// within Init. Just connect to the database listed in the config.
 	cfg := s.Config()
 
 	var db *sql.DB

--- a/examples/chat/weaver.toml
+++ b/examples/chat/weaver.toml
@@ -14,4 +14,4 @@ listeners.chat = {public_hostname = "chat.example.com"}
 
 ["github.com/ServiceWeaver/weaver/examples/chat/SQLStore"]
 db_driver = "mysql"
-db_uri = "root:@tcp(localhost:3306)/"
+db_uri = "root:password@tcp(localhost:3306)/"


### PR DESCRIPTION
This PR adds some instructions on how to run a MySQL instance locally using Docker for the example `chat` application. This is part of a larger effort to understand how hard it is for people to run their own databases locally.

In a future PR, I will explore how we can run MySQL instances for unit tests. [dockertest][] and [testcontainers] seem to be popular choices. After that, I will likely remove our use of sqlite entirely.

[dockertest]: https://github.com/ory/dockertest
[testcontainers]: https://testcontainers.com/