### PR TITLE
Add DFS utilities to the graph library.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -712,6 +712,8 @@ github.com/ServiceWeaver/weaver/runtime/envelope
 github.com/ServiceWeaver/weaver/runtime/graph
     fmt
     golang.org/x/exp/slices
+    slices
+    strings
 github.com/ServiceWeaver/weaver/runtime/logging
     bufio
     context

--- a/runtime/graph/dfs.go
+++ b/runtime/graph/dfs.go
@@ -1,0 +1,75 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import "slices"
+
+// DFSAll performs a depth first search of all nodes in g.
+// If enter is non-nil, it is called on entry to a node.
+// If exit is non-nil, it is called on exit from a node.
+func DFSAll(g Graph, enter, exit func(Node)) {
+	var all []Node
+	g.PerNode(func(n Node) {
+		all = append(all, n)
+	})
+	dfs(g, all, enter, exit)
+}
+
+// PostOrder returns nodes in g in post-order.
+func PostOrder(g Graph) []Node {
+	var result []Node
+	DFSAll(g, nil, func(n Node) {
+		result = append(result, n)
+	})
+	return result
+}
+
+// ReversePostOrder returns nodes in g in reverse-post-order.
+func ReversePostOrder(g Graph) []Node {
+	result := PostOrder(g)
+	slices.Reverse(result)
+	return result
+}
+
+func dfs(g Graph, roots []Node, enter, exit func(Node)) {
+	// Stack holds nodes to traverse.  If we need to call exit, we
+	// leave a negative marker at the appropriate place in the stack.
+	var stack []Node
+	visited := make([]bool, g.NodeLimit())
+	for _, r := range roots {
+		stack = append(stack, r)
+		for len(stack) > 0 {
+			n := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if n < 0 {
+				exit(-n - 1)
+				continue
+			}
+			if visited[n] {
+				continue
+			}
+			visited[n] = true
+			if exit != nil {
+				stack = append(stack, -n-1) // Exit marker
+			}
+			if enter != nil {
+				enter(n)
+			}
+			g.PerOutEdge(n, func(e Edge) {
+				stack = append(stack, e.Dst)
+			})
+		}
+	}
+}

--- a/runtime/graph/dfs_test.go
+++ b/runtime/graph/dfs_test.go
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDFSAll(t *testing.T) {
+	g := NewAdjacencyGraph(
+		[]Node{1, 2, 3, 4},
+		[]Edge{
+			{2, 1},
+			{2, 3},
+			{3, 2},
+			{3, 4},
+		},
+	)
+	var got []string
+	DFSAll(g,
+		func(n Node) { got = append(got, fmt.Sprint("enter ", n)) },
+		func(n Node) { got = append(got, fmt.Sprint("leave ", n)) })
+	want := []string{
+		"enter 1",
+		"leave 1",
+		"enter 2",
+		"enter 3",
+		"enter 4",
+		"leave 4",
+		"leave 3",
+		"leave 2",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("DFSAll for:\n%s\nDiff (-want +got):\n%s",
+			DebugString(g), diff)
+	}
+}

--- a/runtime/graph/graph.go
+++ b/runtime/graph/graph.go
@@ -14,6 +14,11 @@
 
 package graph
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Node is a small non-negative number that identifies a node in
 // a directed graph.  Node numbers should be kept proportional to
 // the size of the graph (i.e., mostly densely packed) since different
@@ -57,4 +62,23 @@ func OutDegree(g Graph, n Node) int {
 	g.PerOutEdge(n, func(Edge) { result++ })
 	return result
 
+}
+
+// DebugString returns a human readable string representation of g.
+//
+// Sample output for a graph with nodes 1,2,3:
+//
+//	1:
+//	2: 1
+//	3: 1 2
+func DebugString(g Graph) string {
+	var b strings.Builder
+	g.PerNode(func(src Node) {
+		b.WriteString(fmt.Sprint(src, ":"))
+		g.PerOutEdge(src, func(edge Edge) {
+			fmt.Fprintf(&b, " %d", edge.Dst)
+		})
+		b.WriteRune('\n')
+	})
+	return b.String()
 }


### PR DESCRIPTION
Taken from an internal library written by ghemawat@.

These utilities will be used by various Service Weaver deployers.