### PR TITLE
Added instructions to run chat app on Kubernetes.

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -34,11 +34,12 @@ $ docker run \
       --publish 127.0.0.1:3306:3306 \
       mysql
 
-# Initialize the MySQL database.
+# Wait about ten seconds for the MySQL instance to start. Then, initialize the
+# chat database with chat.sql.
 $ docker exec mysql sh -c "mysql --password=password < /app/chat.sql"
 ```
 
-Then, update the `db_uri` field in `weaver.toml` to point to your MySQL
+Next, update the `db_uri` field in `weaver.toml` to point to your MySQL
 instance. If you used the Docker commands above, the default value of `db_uri`
 should already point to your database. You don't have to change anything.
 
@@ -54,7 +55,33 @@ $ weaver single deploy weaver.toml
 $ weaver multi deploy weaver.toml
 ```
 
-## How to run on GKE
+## How to Run on Kubernetes
+
+First, run a MySQL instance in your Kubernetes cluster and initialize it with
+[`chat.sql`](chat.sql). We recommend using [`mysql.yaml`](mysql.yaml) for this:
+
+```shell
+$ kubectl apply -f mysql.yaml
+```
+
+Next, update the `db_uri` field in `weaver.toml` to point to your MySQL
+instance. If you're using `mysql.yaml`, then you should update the `SQLStore`
+section of `weaver.toml` to have the following contents:
+
+```toml
+["github.com/ServiceWeaver/weaver/examples/chat/SQLStore"]
+db_driver = "mysql"
+db_uri = "root:password@tcp(mysql:3306)/chat"
+```
+
+Finally, deploy the application using `weaver kube`.
+
+```shell
+$ go build .
+$ kubectl apply -f $(weaver kube deploy weaver.toml)
+```
+
+## How to Run on GKE
 
 Create a new MySQL instance on [Cloud SQL][cloud_sql]. During creation, ensure
 the `"No password"` and `"Private IP"` options are checked and the latter is

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -74,6 +74,19 @@ db_driver = "mysql"
 db_uri = "root:password@tcp(mysql:3306)/chat"
 ```
 
+Then, update the `repo` field in `weaver.toml` with the Docker repository where
+the chat application will be uploaded. For example, if your Docker Hub username
+is `myusername`, you can update the `[kube]` section of `weaver.toml` to the
+following:
+
+```toml
+[kube]
+listeners.chat = {public = true}
+repo = "docker.io/myusername/"
+```
+
+See `weaver kube deploy --help` for more information on the `repo` field.
+
 Finally, deploy the application using `weaver kube`.
 
 ```shell

--- a/examples/chat/mysql.yaml
+++ b/examples/chat/mysql.yaml
@@ -1,0 +1,107 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chat-config
+data:
+  chat.sql: |
+    USE chat;
+
+    CREATE TABLE IF NOT EXISTS threads (
+        thread  INTEGER AUTO_INCREMENT PRIMARY KEY,
+        creator VARCHAR(256) NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS userthreads (
+        user   VARCHAR(256) NOT NULL,
+        thread INTEGER NOT NULL,
+        CONSTRAINT uthread FOREIGN KEY(thread) REFERENCES threads(thread)
+    );
+
+    CREATE TABLE IF NOT EXISTS images (
+        id    INTEGER AUTO_INCREMENT PRIMARY KEY,
+        image BLOB NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS posts (
+        post    INTEGER AUTO_INCREMENT PRIMARY KEY,
+        thread  INTEGER NOT NULL,
+        creator VARCHAR(256) NOT NULL,
+        time    INTEGER NOT NULL,
+        text    TEXT NOT NULL,
+        imageid INTEGER,
+        CONSTRAINT pthread FOREIGN KEY (thread) REFERENCES threads(thread),
+        CONSTRAINT pimageid FOREIGN KEY (imageid) REFERENCES images(id)
+    );
+
+    CREATE INDEX thread ON threads (thread);
+    CREATE INDEX uthread ON userthreads (thread);
+    CREATE INDEX image ON images (id);
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: mysql
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - image: mysql
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: password
+        - name: MYSQL_DATABASE
+          value: chat
+        ports:
+        - containerPort: 3306
+        volumeMounts:
+        - name: config
+          # As described in https://hub.docker.com/_/mysql, the MySQL instance
+          # will automatically run all .sql files stored in
+          # /docker-entrypoint-initdb.d.
+          mountPath: /docker-entrypoint-initdb.d/chat.sql
+          subPath: chat.sql
+        lifecycle:
+          postStart:
+            exec:
+              # chat.sql is mounted as the root user, but the MySQL instance
+              # runs as the mysql user and needs access to this file.
+              command: ["/bin/sh", "chown", "mysql:mysql", "/docker-entrypoint-initdb.d/chat.sql"]
+      volumes:
+      - name: config
+        configMap:
+          name: chat-config

--- a/examples/chat/weaver.toml
+++ b/examples/chat/weaver.toml
@@ -12,6 +12,11 @@ listeners.chat = {address = "localhost:9000"}
 regions = ["us-west1", "us-east1"]
 listeners.chat = {public_hostname = "chat.example.com"}
 
+[kube]
+listeners.chat = {public = true}
+# To upload the image to another repository, check `weaver kube deploy -h`.
+repo = "docker.io/my_docker_hub_username/"
+
 ["github.com/ServiceWeaver/weaver/examples/chat/SQLStore"]
 db_driver = "mysql"
 db_uri = "root:password@tcp(localhost:3306)/chat"


### PR DESCRIPTION
This PR adds instructions on how to run the chat app on a Kubernetes cluster using the `weaver kube` deployer. The main challenge is running MySQL in the Kubernetes cluster. It is quite a bit more involved than running MySQL locally using Docker. You have to write about 100 lines of Kubernetes YAML, which isn't rocket science, but it also isn't the most pleasant experience.