### PR TITLE
Fix MTLS handling.

### DIFF
--- a/examples/collatz/weaver_mtls.toml
+++ b/examples/collatz/weaver_mtls.toml
@@ -1,0 +1,7 @@
+[serviceweaver]
+binary = "./collatz"
+rollout = "5m"
+
+[multi]
+listeners.collatz = {address = "localhost:9000"}
+mtls = true  # For extra testing of MTLS handling

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -125,7 +125,7 @@ func TestExamples(t *testing.T) {
 }
 
 func run(t *testing.T, test test) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
 
 	// Send a GET request to the endpoint, retrying on error.

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -114,6 +114,9 @@ func TestExamples(t *testing.T) {
 
 			// "weaver multi deploy" the application with MTLS.
 			t.Run("weaver-multi-mtls", func(t *testing.T) {
+				if os.Getenv("GITHUB_RUN_ID") != "" {
+					t.Skip("test takes too long (over 30s) on github")
+				}
 				cmd := startCmd(ctx, t, nil, "../../cmd/weaver/weaver", "multi", "deploy", "weaver_mtls.toml")
 				t.Cleanup(terminateCmdAndWait(t, cmd))
 				run(t, test)
@@ -125,7 +128,7 @@ func TestExamples(t *testing.T) {
 }
 
 func run(t *testing.T, test test) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
 
 	// Send a GET request to the endpoint, retrying on error.

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -106,8 +106,15 @@ func TestExamples(t *testing.T) {
 			})
 
 			// "weaver multi deploy" the application.
-			t.Run("weaver-multi", func(t *testing.T) {
+			t.Run("weaver-multi-nomtls", func(t *testing.T) {
 				cmd := startCmd(ctx, t, nil, "../../cmd/weaver/weaver", "multi", "deploy", "weaver.toml")
+				t.Cleanup(terminateCmdAndWait(t, cmd))
+				run(t, test)
+			})
+
+			// "weaver multi deploy" the application with MTLS.
+			t.Run("weaver-multi-mtls", func(t *testing.T) {
+				cmd := startCmd(ctx, t, nil, "../../cmd/weaver/weaver", "multi", "deploy", "weaver_mtls.toml")
 				t.Cleanup(terminateCmdAndWait(t, cmd))
 				run(t, test)
 			})
@@ -118,7 +125,7 @@ func TestExamples(t *testing.T) {
 }
 
 func run(t *testing.T, test test) {
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
 
 	// Send a GET request to the endpoint, retrying on error.

--- a/internal/weaver/remoteweavelet.go
+++ b/internal/weaver/remoteweavelet.go
@@ -171,6 +171,7 @@ func NewRemoteWeavelet(ctx context.Context, regs []*codegen.Registration, bootst
 
 	// Initialize the component structs.
 	for _, reg := range regs {
+		reg := reg
 		c := &component{reg: reg}
 		w.componentsByName[reg.Name] = c
 		w.componentsByIntf[reg.Iface] = c


### PR DESCRIPTION
We were using the wrong component name when setting up group data structures for MTLS (because of Go's funny loop variable capture semantics). Fixed this.

Added a test that uses multi deployer with MTLS.

Increased timeout for the test from 4s to 10s.