### PR TITLE
Make tests use NewEnvelope instead of NewEnvelopeConn.

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -991,12 +991,10 @@ github.com/ServiceWeaver/weaver/weavertest
     errors
     fmt
     github.com/ServiceWeaver/weaver/internal/control
-    github.com/ServiceWeaver/weaver/internal/envelope/conn
     github.com/ServiceWeaver/weaver/internal/reflection
     github.com/ServiceWeaver/weaver/internal/weaver
     github.com/ServiceWeaver/weaver/runtime
     github.com/ServiceWeaver/weaver/runtime/codegen
-    github.com/ServiceWeaver/weaver/runtime/deployers
     github.com/ServiceWeaver/weaver/runtime/envelope
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/protos
@@ -1004,7 +1002,6 @@ github.com/ServiceWeaver/weaver/weavertest
     golang.org/x/exp/maps
     golang.org/x/sync/errgroup
     log/slog
-    net
     os
     reflect
     regexp

--- a/internal/tool/multi/deployer.go
+++ b/internal/tool/multi/deployer.go
@@ -353,10 +353,12 @@ func (d *deployer) startColocationGroup(g *group) error {
 			d.stop(err)
 			return err
 		})
-		if pid, ok := e.Pid(); ok {
-			if err := d.registerReplica(g, wlet, pid); err != nil {
-				return err
-			}
+		pid, ok := e.Pid()
+		if !ok {
+			panic("multi deployer child must be a real process")
+		}
+		if err := d.registerReplica(g, wlet, pid); err != nil {
+			return err
 		}
 		if err := e.UpdateComponents(components); err != nil {
 			return err

--- a/internal/tool/multi/deployer.go
+++ b/internal/tool/multi/deployer.go
@@ -353,8 +353,10 @@ func (d *deployer) startColocationGroup(g *group) error {
 			d.stop(err)
 			return err
 		})
-		if err := d.registerReplica(g, wlet, e.Pid()); err != nil {
-			return err
+		if pid, ok := e.Pid(); ok {
+			if err := d.registerReplica(g, wlet, pid); err != nil {
+				return err
+			}
 		}
 		if err := e.UpdateComponents(components); err != nil {
 			return err

--- a/internal/tool/ssh/impl/babysitter.go
+++ b/internal/tool/ssh/impl/babysitter.go
@@ -109,10 +109,12 @@ func RunBabysitter(ctx context.Context) error {
 	// compiled binary.
 	winfo := e.WeaveletInfo()
 
-	if pid, ok := e.Pid(); ok {
-		if err := b.registerReplica(winfo, pid); err != nil {
-			return err
-		}
+	pid, ok := e.Pid()
+	if !ok {
+		panic("ssh deployer child must be a real process")
+	}
+	if err := b.registerReplica(winfo, pid); err != nil {
+		return err
 	}
 	c := metricsCollector{logger: b.logger, envelope: e, info: info}
 	go c.run(ctx)

--- a/internal/tool/ssh/impl/babysitter.go
+++ b/internal/tool/ssh/impl/babysitter.go
@@ -109,8 +109,10 @@ func RunBabysitter(ctx context.Context) error {
 	// compiled binary.
 	winfo := e.WeaveletInfo()
 
-	if err := b.registerReplica(winfo, e.Pid()); err != nil {
-		return err
+	if pid, ok := e.Pid(); ok {
+		if err := b.registerReplica(winfo, pid); err != nil {
+			return err
+		}
 	}
 	c := metricsCollector{logger: b.logger, envelope: e, info: info}
 	go c.run(ctx)

--- a/runtime/envelope/child.go
+++ b/runtime/envelope/child.go
@@ -1,0 +1,142 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envelope
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/ServiceWeaver/weaver/internal/pipe"
+	"github.com/ServiceWeaver/weaver/runtime"
+	"github.com/ServiceWeaver/weaver/runtime/protos"
+)
+
+// Child manages the child of an envelope. This is typically a child process, but
+// tests may manage some in-process resources.
+type Child interface {
+	// Start starts the child.
+	// REQUIRES: Start, Wait have not been called.
+	Start(context.Context, *protos.AppConfig) error
+
+	// Wait for the child to exit.
+	// REQUIRES: Start has been called.
+	// REQUIRES: Wait has not been called.
+	Wait() error
+
+	// Different IO streams connecting us to the child
+	Reader() io.ReadCloser  // Can be used to receive messages from the Child
+	Writer() io.WriteCloser // Can be used to receive messages from the Child
+	Stdout() io.ReadCloser  // Delivers Child stdout
+	Stderr() io.ReadCloser  // Delivers Child stderr
+
+	// Identifier for child process, if available.
+	Pid() (int, bool)
+}
+
+// ProcessChild is a Child implemented as a process.
+type ProcessChild struct {
+	cmd    *pipe.Cmd // command that started the weavelet
+	reader io.ReadCloser
+	writer io.WriteCloser
+	stdout io.ReadCloser
+	stderr io.ReadCloser
+}
+
+var _ Child = &ProcessChild{}
+
+func (p *ProcessChild) Reader() io.ReadCloser  { return p.reader }
+func (p *ProcessChild) Writer() io.WriteCloser { return p.writer }
+func (p *ProcessChild) Stdout() io.ReadCloser  { return p.stdout }
+func (p *ProcessChild) Stderr() io.ReadCloser  { return p.stderr }
+func (p *ProcessChild) Pid() (int, bool)       { return p.cmd.Process.Pid, true }
+
+func (p *ProcessChild) Start(ctx context.Context, config *protos.AppConfig) error {
+	cmd := pipe.CommandContext(ctx, config.Binary, config.Args...)
+
+	// Create the request/response pipes first, so we can fill cmd.Env and detect
+	// any errors early.
+	pipePair, err := cmd.MakePipePair()
+	if err != nil {
+		return fmt.Errorf("create request/response pipes: %w", err)
+	}
+
+	// Create pipes that capture child outputs.
+	outpipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("create stdout pipe: %w", err)
+	}
+	errpipe, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("create stderr pipe: %w", err)
+	}
+
+	// Setup environment for child process.
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", runtime.ToWeaveletKey, strconv.FormatUint(uint64(pipePair.ChildReader), 10)))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", runtime.ToEnvelopeKey, strconv.FormatUint(uint64(pipePair.ChildWriter), 10)))
+	cmd.Env = append(cmd.Env, config.Env...)
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	p.cmd = cmd
+	p.reader = pipePair.ParentReader
+	p.writer = pipePair.ParentWriter
+	p.stdout = outpipe
+	p.stderr = errpipe
+	return nil
+}
+
+func (p *ProcessChild) Wait() error {
+	err := p.cmd.Wait()
+	p.cmd.Cleanup()
+	return err
+}
+
+// inProcessChild is a fake envelope.Child that represents the in-process weavelet.
+type inProcessChild struct {
+	ctx    context.Context
+	reader io.ReadCloser
+	writer io.WriteCloser
+}
+
+var _ Child = &inProcessChild{}
+
+func NewInProcessChild(reader io.ReadCloser, writer io.WriteCloser) Child {
+	return &inProcessChild{
+		reader: reader,
+		writer: writer,
+	}
+}
+
+func (p *inProcessChild) Reader() io.ReadCloser  { return p.reader }
+func (p *inProcessChild) Writer() io.WriteCloser { return p.writer }
+func (p *inProcessChild) Stdout() io.ReadCloser  { return nil }
+func (p *inProcessChild) Stderr() io.ReadCloser  { return nil }
+func (p *inProcessChild) Pid() (int, bool)       { return 0, false }
+
+func (p *inProcessChild) Start(ctx context.Context, config *protos.AppConfig) error {
+	p.ctx = ctx
+	return nil
+}
+
+func (p *inProcessChild) Wait() error {
+	<-p.ctx.Done()
+	return nil
+}

--- a/runtime/envelope/child.go
+++ b/runtime/envelope/child.go
@@ -40,7 +40,7 @@ type Child interface {
 
 	// Different IO streams connecting us to the child
 	Reader() io.ReadCloser  // Can be used to receive messages from the Child
-	Writer() io.WriteCloser // Can be used to receive messages from the Child
+	Writer() io.WriteCloser // Can be used to send messages to the Child
 	Stdout() io.ReadCloser  // Delivers Child stdout
 	Stderr() io.ReadCloser  // Delivers Child stderr
 

--- a/runtime/envelope/envelope.go
+++ b/runtime/envelope/envelope.go
@@ -25,13 +25,11 @@ import (
 	"log/slog"
 	"net"
 	"os"
-	"strconv"
 	"sync"
 
 	"github.com/ServiceWeaver/weaver/internal/control"
 	"github.com/ServiceWeaver/weaver/internal/envelope/conn"
 	"github.com/ServiceWeaver/weaver/internal/net/call"
-	"github.com/ServiceWeaver/weaver/internal/pipe"
 	"github.com/ServiceWeaver/weaver/runtime"
 	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"github.com/ServiceWeaver/weaver/runtime/deployers"
@@ -119,9 +117,7 @@ type Envelope struct {
 	weavelet   *protos.EnvelopeInfo
 	config     *protos.AppConfig
 	conn       *conn.EnvelopeConn      // conn to weavelet
-	cmd        *pipe.Cmd               // command that started the weavelet
-	stdoutPipe io.ReadCloser           // stdout pipe from the weavelet
-	stderrPipe io.ReadCloser           // stderr pipe from the weavelet
+	child      Child                   // weavelet process handle
 	controller control.WeaveletControl // Stub that talks to the weavelet controller
 
 	// State needed to process metric updates.
@@ -131,14 +127,20 @@ type Envelope struct {
 
 // Options contains optional arguments for the envelope.
 type Options struct {
+	// Override for temporary directory.
+	TmpDir string
+
 	// Logger is used for logging internal messages. If nil, a default logger is used.
 	Logger *slog.Logger
 
 	// Tracer is used for tracing internal calls. If nil, internal calls are not traced.
 	Tracer trace.Tracer
+
+	// Child is used to run the weavelet. If nil, a sub-process is created.
+	Child Child
 }
 
-// NewEnvelope creates a new envelope, starting a weavelet subprocess and
+// NewEnvelope creates a new envelope, starting a weavelet subprocess (via child.Start) and
 // establishing a bidirectional connection with it. The weavelet process can be
 // stopped at any time by canceling the passed-in context.
 //
@@ -153,19 +155,24 @@ func NewEnvelope(ctx context.Context, wlet *protos.EnvelopeInfo, config *protos.
 	}
 
 	// Make a temporary directory for unix domain sockets.
-	tmpDir, err := runtime.NewTempDir()
-	if err != nil {
-		return nil, err
-	}
-	runtime.OnExitSignal(func() { os.RemoveAll(tmpDir) }) // Cleanup when process exits
-
-	// Arrange to delete tmpDir if this function returns an error.
-	removeDir := true // Cleared on a successful return
-	defer func() {
-		if removeDir {
-			os.RemoveAll(tmpDir)
+	var removeDir bool
+	tmpDir := options.TmpDir
+	if options.TmpDir == "" {
+		var err error
+		tmpDir, err = runtime.NewTempDir()
+		if err != nil {
+			return nil, err
 		}
-	}()
+		runtime.OnExitSignal(func() { os.RemoveAll(tmpDir) }) // Cleanup when process exits
+
+		// Arrange to delete tmpDir if this function returns an error.
+		removeDir = true // Cleared on a successful return
+		defer func() {
+			if removeDir {
+				os.RemoveAll(tmpDir)
+			}
+		}()
+	}
 
 	myUds := deployers.NewUnixSocketPath(tmpDir)
 
@@ -194,39 +201,16 @@ func NewEnvelope(ctx context.Context, wlet *protos.EnvelopeInfo, config *protos.
 		controller: controller,
 	}
 
-	// Form the weavelet command.
-	cmd := pipe.CommandContext(e.ctx, e.config.Binary, e.config.Args...)
-
-	// Create the request/response pipes first, so we can fill cmd.Env and detect any errors early.
-	pipePair, err := cmd.MakePipePair()
-	if err != nil {
-		return nil, fmt.Errorf("NewEnvelope: create weavelet request/response pipes: %w", err)
+	child := options.Child
+	if child == nil {
+		child = &ProcessChild{}
 	}
-
-	// Create pipes that capture child outputs.
-	outpipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("NewEnvelope: create stdout pipe: %w", err)
-	}
-	errpipe, err := cmd.StderrPipe()
-	if err != nil {
-		return nil, fmt.Errorf("NewEnvelope: create stderr pipe: %w", err)
-	}
-
-	// Create pair of pipes to use for component method calls from weavelet to envelope.
-
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", runtime.ToWeaveletKey, strconv.FormatUint(uint64(pipePair.ChildReader), 10)))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", runtime.ToEnvelopeKey, strconv.FormatUint(uint64(pipePair.ChildWriter), 10)))
-	cmd.Env = append(cmd.Env, e.config.Env...)
-
-	// Start the command.
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("NewEnvelope: start subprocess: %w", err)
+	if err := child.Start(ctx, e.config); err != nil {
+		return nil, fmt.Errorf("NewEnvelope: %w", err)
 	}
 
 	// Create the connection, now that the weavelet is running.
-	conn, err := conn.NewEnvelopeConn(e.ctx, pipePair.ParentReader, pipePair.ParentWriter, e.weavelet)
+	conn, err := conn.NewEnvelopeConn(e.ctx, child.Reader(), child.Writer(), e.weavelet)
 	if err != nil {
 		err := fmt.Errorf("NewEnvelope: connect to weavelet: %w", err)
 
@@ -234,25 +218,26 @@ func NewEnvelope(ctx context.Context, wlet *protos.EnvelopeInfo, config *protos.
 		cancel()
 
 		// Include stdout and stderr in the returned error.
-		if bytes, stdoutErr := io.ReadAll(outpipe); stdoutErr == nil && len(bytes) > 0 {
-			err = errors.Join(err, fmt.Errorf("-----BEGIN STDOUT-----\n%s-----END STDOUT-----", string(bytes)))
+		if stdout := child.Stdout(); stdout != nil {
+			if bytes, stdoutErr := io.ReadAll(stdout); stdoutErr == nil && len(bytes) > 0 {
+				err = errors.Join(err, fmt.Errorf("-----BEGIN STDOUT-----\n%s-----END STDOUT-----", string(bytes)))
+			}
 		}
-		if bytes, stderrErr := io.ReadAll(errpipe); stderrErr == nil && len(bytes) > 0 {
-			err = errors.Join(err, fmt.Errorf("-----BEGIN STDERR-----\n%s\n-----END STDERR-----", string(bytes)))
+		if stderr := child.Stderr(); stderr != nil {
+			if bytes, stderrErr := io.ReadAll(stderr); stderrErr == nil && len(bytes) > 0 {
+				err = errors.Join(err, fmt.Errorf("-----BEGIN STDERR-----\n%s\n-----END STDERR-----", string(bytes)))
+			}
 		}
 
 		// Wait for the subprocess to terminate.
-		if waitErr := cmd.Wait(); waitErr != nil {
+		if waitErr := child.Wait(); waitErr != nil {
 			err = errors.Join(err, waitErr)
 		}
-		cmd.Cleanup()
 		return nil, err
 	}
 
-	e.cmd = cmd
+	e.child = child
 	e.conn = conn
-	e.stdoutPipe = outpipe
-	e.stderrPipe = errpipe
 
 	removeDir = false  // Serve() is now responsible for deletion
 	cancel = func() {} // Delay real context cancellation
@@ -288,16 +273,20 @@ func (e *Envelope) Serve(h EnvelopeHandler) error {
 	}
 
 	// Capture stdout and stderr from the weavelet.
-	running.Go(func() error {
-		err := e.logLines("stdout", e.stdoutPipe, h)
-		stop(err)
-		return err
-	})
-	running.Go(func() error {
-		err := e.logLines("stderr", e.stderrPipe, h)
-		stop(err)
-		return err
-	})
+	if stdout := e.child.Stdout(); stdout != nil {
+		running.Go(func() error {
+			err := e.logLines("stdout", stdout, h)
+			stop(err)
+			return err
+		})
+	}
+	if stderr := e.child.Stderr(); stderr != nil {
+		running.Go(func() error {
+			err := e.logLines("stderr", stderr, h)
+			stop(err)
+			return err
+		})
+	}
 
 	// Start the goroutine watching the context for cancelation.
 	running.Go(func() error {
@@ -328,16 +317,14 @@ func (e *Envelope) Serve(h EnvelopeHandler) error {
 	// Wait for the weavelet command to finish. This needs to be done after
 	// we're done reading from stdout/stderr pipes, per comments on
 	// exec.Cmd.StdoutPipe and exec.Cmd.StderrPipe.
-	err = e.cmd.Wait()
-	stop(err)
-	e.cmd.Cleanup()
+	stop(e.child.Wait())
 
 	return stopErr
 }
 
-// Pid returns the process id of the subprocess.
-func (e *Envelope) Pid() int {
-	return e.cmd.Process.Pid
+// Pid returns the process id of the weavelet, if it is running in a separate process.
+func (e *Envelope) Pid() (int, bool) {
+	return e.child.Pid()
 }
 
 // WeaveletInfo returns information about the started weavelet.


### PR DESCRIPTION
Introduce a new Child interface that NewEnvelope uses to run the weavelet. Typically this is a real process, but tests that want to run the weavelet in-process can supply a custom implementation.