### PR TITLE
Expose the deployment identifier to the application.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -81,11 +81,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/go/bin/staticcheck
-          key: staticcheck-v0.4.3
+          key: staticcheck-v0.4.6
         if: ${{ matrix.command == 'lint' }}
 
       - name: Install linter
-        run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.6
         if: ${{ matrix.command == 'lint' }}
 
       - name: Build the weaver binary

--- a/dev/build_and_test
+++ b/dev/build_and_test
@@ -54,7 +54,7 @@ function cmd_vet() {
 
 function cmd_lint() {
   if ! exists staticcheck; then
-    printf "staticcheck not found; install via\ngo install honnef.co/go/tools/cmd/staticcheck@v0.4.3\n" >&2
+    printf "staticcheck not found; install via\ngo install honnef.co/go/tools/cmd/staticcheck@v0.4.6\n" >&2
     exit 1
   fi
 

--- a/fill.go
+++ b/fill.go
@@ -27,6 +27,7 @@ import (
 func init() {
 	// See internal/weaver/types.go.
 	weaver.SetLogger = setLogger
+	weaver.SetWeaverInfo = setWeaverInfo
 	weaver.HasRefs = hasRefs
 	weaver.FillRefs = fillRefs
 	weaver.HasListeners = hasListeners
@@ -39,9 +40,19 @@ func init() {
 func setLogger(v any, logger *slog.Logger) error {
 	x, ok := v.(interface{ setLogger(*slog.Logger) })
 	if !ok {
-		return fmt.Errorf("FillLogger: %T does not implement weaver.Implements", v)
+		return fmt.Errorf("setLogger: %T does not implement weaver.Implements", v)
 	}
 	x.setLogger(logger)
+	return nil
+}
+
+// See internal/weaver/types.go.
+func setWeaverInfo(impl any, info *weaver.WeaverInfo) error {
+	x, ok := impl.(interface{ setWeaverInfo(*weaver.WeaverInfo) })
+	if !ok {
+		return fmt.Errorf("setWeaverInfo: %T does not implement weaver.Implements", impl)
+	}
+	x.setWeaverInfo(info)
 	return nil
 }
 

--- a/godeps.txt
+++ b/godeps.txt
@@ -390,6 +390,7 @@ github.com/ServiceWeaver/weaver/internal/sim
     github.com/ServiceWeaver/weaver/runtime/codegen
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/protos
+    github.com/google/uuid
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
     golang.org/x/exp/maps

--- a/internal/testdeployer/components.go
+++ b/internal/testdeployer/components.go
@@ -40,6 +40,10 @@ type c interface {
 	C(context.Context, int) (int, error)
 }
 
+type d interface {
+	D(context.Context) (string, error)
+}
+
 type aimpl struct {
 	weaver.Implements[a]
 	lis weaver.Listener //lint:ignore U1000 used in remoteweavelet_test.go
@@ -53,6 +57,10 @@ type bimpl struct {
 
 type cimpl struct {
 	weaver.Implements[c]
+}
+
+type dimpl struct {
+	weaver.Implements[d]
 }
 
 func (a *aimpl) A(ctx context.Context, x int) (int, error) {
@@ -71,4 +79,8 @@ func (c *cimpl) C(ctx context.Context, x int) (int, error) {
 	c.Logger(ctx).Debug("C")
 	c_calls.Inc()
 	return x, nil
+}
+
+func (d *dimpl) D(ctx context.Context) (string, error) {
+	return d.Weaver().DeploymentID, nil
 }

--- a/internal/testdeployer/weaver_gen.go
+++ b/internal/testdeployer/weaver_gen.go
@@ -69,17 +69,37 @@ func init() {
 		},
 		RefData: "",
 	})
+	codegen.Register(codegen.Registration{
+		Name:  "github.com/ServiceWeaver/weaver/internal/testdeployer/d",
+		Iface: reflect.TypeOf((*d)(nil)).Elem(),
+		Impl:  reflect.TypeOf(dimpl{}),
+		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
+			return d_local_stub{impl: impl.(d), tracer: tracer, dMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/testdeployer/d", Method: "D", Remote: false})}
+		},
+		ClientStubFn: func(stub codegen.Stub, caller string) any {
+			return d_client_stub{stub: stub, dMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/internal/testdeployer/d", Method: "D", Remote: true})}
+		},
+		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
+			return d_server_stub{impl: impl.(d), addLoad: addLoad}
+		},
+		ReflectStubFn: func(caller func(string, context.Context, []any, []any) error) any {
+			return d_reflect_stub{caller: caller}
+		},
+		RefData: "",
+	})
 }
 
 // weaver.InstanceOf checks.
 var _ weaver.InstanceOf[a] = (*aimpl)(nil)
 var _ weaver.InstanceOf[b] = (*bimpl)(nil)
 var _ weaver.InstanceOf[c] = (*cimpl)(nil)
+var _ weaver.InstanceOf[d] = (*dimpl)(nil)
 
 // weaver.Router checks.
 var _ weaver.Unrouted = (*aimpl)(nil)
 var _ weaver.Unrouted = (*bimpl)(nil)
 var _ weaver.Unrouted = (*cimpl)(nil)
+var _ weaver.Unrouted = (*dimpl)(nil)
 
 // Local stub implementations.
 
@@ -168,6 +188,35 @@ func (s c_local_stub) C(ctx context.Context, a0 int) (r0 int, err error) {
 	}
 
 	return s.impl.C(ctx, a0)
+}
+
+type d_local_stub struct {
+	impl     d
+	tracer   trace.Tracer
+	dMetrics *codegen.MethodMetrics
+}
+
+// Check that d_local_stub implements the d interface.
+var _ d = (*d_local_stub)(nil)
+
+func (s d_local_stub) D(ctx context.Context) (r0 string, err error) {
+	// Update metrics.
+	begin := s.dMetrics.Begin()
+	defer func() { s.dMetrics.End(begin, err != nil, 0, 0) }()
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "testdeployer.d.D", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.D(ctx)
 }
 
 // Client stub implementations.
@@ -364,6 +413,61 @@ func (s c_client_stub) C(ctx context.Context, a0 int) (r0 int, err error) {
 	return
 }
 
+type d_client_stub struct {
+	stub     codegen.Stub
+	dMetrics *codegen.MethodMetrics
+}
+
+// Check that d_client_stub implements the d interface.
+var _ d = (*d_client_stub)(nil)
+
+func (s d_client_stub) D(ctx context.Context) (r0 string, err error) {
+	// Update metrics.
+	var requestBytes, replyBytes int
+	begin := s.dMetrics.Begin()
+	defer func() { s.dMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "testdeployer.d.D", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+			if err != nil {
+				err = errors.Join(weaver.RemoteCallError, err)
+			}
+		}
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+
+	}()
+
+	var shardKey uint64
+
+	// Call the remote method.
+	var results []byte
+	results, err = s.stub.Run(ctx, 0, nil, shardKey)
+	replyBytes = len(results)
+	if err != nil {
+		err = errors.Join(weaver.RemoteCallError, err)
+		return
+	}
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	r0 = dec.String()
+	err = dec.Error()
+	return
+}
+
 // Note that "weaver generate" will always generate the error message below.
 // Everything is okay. The error message is only relevant if you see it when
 // you run "go build" or "go run".
@@ -518,6 +622,44 @@ func (s c_server_stub) c(ctx context.Context, args []byte) (res []byte, err erro
 	return enc.Data(), nil
 }
 
+type d_server_stub struct {
+	impl    d
+	addLoad func(key uint64, load float64)
+}
+
+// Check that d_server_stub implements the codegen.Server interface.
+var _ codegen.Server = (*d_server_stub)(nil)
+
+// GetStubFn implements the codegen.Server interface.
+func (s d_server_stub) GetStubFn(method string) func(ctx context.Context, args []byte) ([]byte, error) {
+	switch method {
+	case "D":
+		return s.d
+	default:
+		return nil
+	}
+}
+
+func (s d_server_stub) d(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	r0, appErr := s.impl.D(ctx)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	enc.String(r0)
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
+
 // Reflect stub implementations.
 
 type a_reflect_stub struct {
@@ -553,5 +695,17 @@ var _ c = (*c_reflect_stub)(nil)
 
 func (s c_reflect_stub) C(ctx context.Context, a0 int) (r0 int, err error) {
 	err = s.caller("C", ctx, []any{a0}, []any{&r0})
+	return
+}
+
+type d_reflect_stub struct {
+	caller func(string, context.Context, []any, []any) error
+}
+
+// Check that d_reflect_stub implements the d interface.
+var _ d = (*d_reflect_stub)(nil)
+
+func (s d_reflect_stub) D(ctx context.Context) (r0 string, err error) {
+	err = s.caller("D", ctx, []any{}, []any{&r0})
 	return
 }

--- a/internal/weaver/singleweavelet.go
+++ b/internal/weaver/singleweavelet.go
@@ -71,6 +71,7 @@ type SingleWeavelet struct {
 	config       *single.SingleConfig  // "[single]" section of config file
 	deploymentId string                // globally unique deployment id
 	id           string                // globally unique weavelet id
+	weaverInfo   *WeaverInfo           // application's runtime information
 	createdAt    time.Time             // time at which the weavelet was created
 
 	// Logging, tracing, and metrics.
@@ -141,6 +142,7 @@ func NewSingleWeavelet(ctx context.Context, regs []*codegen.Registration, opts S
 		config:       config,
 		deploymentId: deploymentId,
 		id:           id,
+		weaverInfo:   &WeaverInfo{DeploymentID: id},
 		createdAt:    time.Now(),
 		pp:           logging.NewPrettyPrinter(colors.Enabled()),
 		tracer:       tracer,
@@ -266,6 +268,11 @@ func (w *SingleWeavelet) get(reg *codegen.Registration) (any, error) {
 
 	// Set logger.
 	if err := SetLogger(obj, w.logger(reg.Name)); err != nil {
+		return nil, err
+	}
+
+	// Set application runtime information.
+	if err := SetWeaverInfo(obj, w.weaverInfo); err != nil {
 		return nil, err
 	}
 

--- a/internal/weaver/types.go
+++ b/internal/weaver/types.go
@@ -28,6 +28,9 @@ var (
 	// should be a pointer to the implementation struct.
 	SetLogger func(impl any, logger *slog.Logger) error
 
+	// SetWeaverInfo sets the application's runtime information.
+	SetWeaverInfo func(impl any, info *WeaverInfo) error
+
 	// HasRefs returns whether the provided component implementation has
 	// weaver.Refs fields.
 	HasRefs func(impl any) bool
@@ -57,3 +60,9 @@ var (
 	// implementation, or returns nil if there is no config.
 	GetConfig func(impl any) any
 )
+
+// Copy of the same struct in the main weaver package.
+type WeaverInfo struct {
+	// Unique identifier for the application deployment.
+	DeploymentID string
+}


### PR DESCRIPTION
This was a feature requested by one of our users so that they can distinct between multiple deployments of the same application.

As far as the user is concerned, the string is an opaque identifier they can use to compare different deployments.