### PR TITLE
feat: removing the fixed tracing sampler (parent based, always on)

### DIFF
--- a/internal/weaver/tracing.go
+++ b/internal/weaver/tracing.go
@@ -50,9 +50,7 @@ func tracer(exporter sdktrace.SpanExporter, app, deploymentId, weaveletId string
 			traceio.DeploymentIdTraceKey.String(deploymentId),
 			traceio.WeaveletIdTraceKey.String(weaveletId),
 		)),
-		// TODO(spetrovic): Allow the user to create new TracerProviders where
-		// they can control trace sampling and other options.
-		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.AlwaysSample())))
+	)
 	tracer := tracerProvider.Tracer(instrumentationLibrary, trace.WithInstrumentationVersion(instrumentationVersion))
 
 	// Set global tracing defaults.


### PR DESCRIPTION
Removing the FIXED sampler, would still use the ParentBased(Always On) by default, but without it we can now use OTEL environment variables to choose other options.

more info: https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler