### PR TITLE
update: github.com/lightstep/varopt to v1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/pprof v0.0.0-20230705174524-200ffdc848b8
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/golang-lru/v2 v2.0.1
-	github.com/lightstep/varopt v1.3.0
+	github.com/lightstep/varopt v1.4.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/testcontainers/testcontainers-go v0.24.1

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw1HU4=
 github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
-github.com/lightstep/varopt v1.3.0 h1:H7OhtEBhYyDhoMu+wJGl4mTqM9TrYYdThG+xLGU3fZQ=
-github.com/lightstep/varopt v1.3.0/go.mod h1:3GP18zB7pfvbVUAnJ8xfvYjpwp0CF027QRD5FsfXau0=
+github.com/lightstep/varopt v1.4.0 h1:MCpQouffyrj0xGe7pQRP0urgMHG04gHjE9v5FhpODzo=
+github.com/lightstep/varopt v1.4.0/go.mod h1:8XCrfUxO78WYWeFHSFD1j1ePNhRsGXd44YTfn+l3kjs=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -151,7 +151,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/weaver/load.go
+++ b/internal/weaver/load.go
@@ -66,7 +66,7 @@ type sliceSummary struct {
 	slice  slice                    // the slice
 	load   float64                  // total load
 	count  *hyperloglog.HyperLogLog // counts distinct elements
-	sample *varopt.Varopt           // reservoir sample of keys
+	sample *varopt.Varopt[uint64]   // reservoir sample of keys
 }
 
 // newLoadCollector returns a new load collector. Note that load is collected
@@ -224,7 +224,7 @@ func newSliceSummary(slice slice) (*sliceSummary, error) {
 	// TODO(mwhittaker): When we switch to range sharding, keys might be large
 	// and 1000 keys might be too big.
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	sample := varopt.New(1000, r)
+	sample := varopt.New[uint64](1000, r)
 
 	return &sliceSummary{slice: slice, count: count, sample: sample}, nil
 }
@@ -242,7 +242,7 @@ func (s *sliceSummary) splits(delta time.Duration) []*protos.LoadReport_Subslice
 	xs := make([]uint64, k)
 	for i := 0; i < k; i++ {
 		x, _ := s.sample.Get(i)
-		xs[i] = x.(uint64)
+		xs[i] = x
 	}
 	sort.Slice(xs, func(i, j int) bool { return xs[i] < xs[j] })
 


### PR DESCRIPTION
I often run `get -u ./...` which updates this package all the time, but it has a breaking change introducing generics. quite straightforward to fix, so, it seems better to update it.

it would remove 1 cast. :smile: 