### PR TITLE
Add shutdown method per component

### DIFF
--- a/examples/chat/sqlstore.go
+++ b/examples/chat/sqlstore.go
@@ -96,7 +96,7 @@ func (cfg *config) Validate() error {
 	return nil
 }
 
-func (s *sqlStore) Init(ctx context.Context) error {
+func (s *sqlStore) Init(context.Context) error {
 	cfg := s.Config()
 	if cfg.Driver == "" {
 		return fmt.Errorf("missing database driver in config")

--- a/website/docs.md
+++ b/website/docs.md
@@ -636,6 +636,20 @@ func (f *foo) Init(context.Context) error {
 }
 ```
 
+If a component implementation implements an `Shutdown(context.Context) error`
+method, it will be called when an instance of the component is destroyed.
+
+```go
+func (f *foo) Shutdown(context.Context) error {
+    // ...
+}
+```
+
+**Note**: There is no guarantee that the `Shutdown` method will always
+be called. `Shutdown` is called **iff** your application receives a
+`SIGINT` or a `SIGTERM` signal. However, if the machine where your application runs
+crashes unexpectedly or becomes unresponsive, the `Shutdown` method is never called.
+
 ## Semantics
 
 When implementing a component, there are a few semantic details to keep in mind:


### PR DESCRIPTION
In the current implementation, we provide the user the ability to initialize things by implementing an `Init` method. However, they don't have the ability to do a clean shutdown easily.

The user filled multiple github issues (#275 and #765) asking for a `Shutdown` method.

This PR adds a `Shutdown` method to each component. Note that there is no guarantee that this method can run - e.g., the app receives a SIGKILL because the machine suddenly crashes. However, a `Shutdown` method can enable the user to achieve graceful shutdown in normal scenarios.

In tests, if someone wants to test the `Shutdown` method, they can get a pointer to the implementation of the component and explicitly call the `Shutdown` method.