### PR TITLE
Add context propagation support

### DIFF
--- a/godeps.txt
+++ b/godeps.txt
@@ -332,6 +332,7 @@ github.com/ServiceWeaver/weaver/internal/net/call
     errors
     fmt
     github.com/ServiceWeaver/weaver/internal/traceio
+    github.com/ServiceWeaver/weaver/metadata
     github.com/ServiceWeaver/weaver/runtime/codegen
     github.com/ServiceWeaver/weaver/runtime/logging
     github.com/ServiceWeaver/weaver/runtime/retry
@@ -695,6 +696,9 @@ github.com/ServiceWeaver/weaver/internal/weaver
     sync/atomic
     syscall
     time
+github.com/ServiceWeaver/weaver/metadata
+    context
+    maps
 github.com/ServiceWeaver/weaver/metrics
     github.com/ServiceWeaver/weaver/runtime/metrics
     github.com/ServiceWeaver/weaver/runtime/protos
@@ -1063,9 +1067,11 @@ github.com/ServiceWeaver/weaver/weavertest/internal/simple
     errors
     fmt
     github.com/ServiceWeaver/weaver
+    github.com/ServiceWeaver/weaver/metadata
     github.com/ServiceWeaver/weaver/runtime/codegen
     go.opentelemetry.io/otel/codes
     go.opentelemetry.io/otel/trace
+    maps
     net/http
     os
     reflect

--- a/internal/net/call/call.go
+++ b/internal/net/call/call.go
@@ -148,8 +148,6 @@ const (
 	idle                   // can be used for calls, no calls in-flight
 	active                 // can be used for calls, some calls in-flight
 	draining               // some calls in-flight, no new calls should be added
-
-	hdrLenLen = uint32(4) // size of the header length included in each message
 )
 
 var connStateNames = []string{
@@ -405,8 +403,7 @@ func (rc *reconnectingConnection) callOnce(ctx context.Context, h MethodKey, arg
 	// [header_length][encoded_header][payload]
 	var hdrLen [hdrLenLen]byte
 	binary.LittleEndian.PutUint32(hdrLen[:], uint32(len(hdr)))
-	hdrSlice := hdrLen[:]
-	hdrSlice = append(hdrSlice, hdr...)
+	hdrSlice := append(hdrLen[:], hdr...)
 
 	rpc := &call{}
 	rpc.doneSignal = make(chan struct{})

--- a/internal/net/call/metadata.go
+++ b/internal/net/call/metadata.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package call
+
+import (
+	"context"
+
+	"github.com/ServiceWeaver/weaver/metadata"
+	"github.com/ServiceWeaver/weaver/runtime/codegen"
+)
+
+// writeContextMetadata serializes the context metadata (if any) into enc.
+func writeContextMetadata(ctx context.Context, enc *codegen.Encoder) {
+	m, found := metadata.FromContext(ctx)
+	if !found {
+		enc.Bool(false)
+		return
+	}
+	enc.Bool(true)
+	enc.Len(len(m))
+	for k, v := range m {
+		enc.String(k)
+		enc.String(v)
+	}
+}
+
+// readContextMetadata returns the context metadata (if any) stored in dec.
+func readContextMetadata(ctx context.Context, dec *codegen.Decoder) context.Context {
+	hasMeta := dec.Bool()
+	if !hasMeta {
+		return ctx
+	}
+	n := dec.Len()
+	res := make(map[string]string, n)
+	var k, v string
+	for i := 0; i < n; i++ {
+		k = dec.String()
+		v = dec.String()
+		res[k] = v
+	}
+	return metadata.NewContext(ctx, res)
+}

--- a/internal/net/call/msg.go
+++ b/internal/net/call/msg.go
@@ -46,6 +46,8 @@ const (
 
 const currentVersion = initialVersion
 
+const hdrLenLen = uint32(4) // size of the header length included in each message
+
 // # Message formats
 //
 // All messages have the following format:
@@ -68,10 +70,10 @@ const currentVersion = initialVersion
 // looks like:
 //
 // struct header {
-//  MethodKey [16]byte
-//  Deadline  int64
-//  TraceContext [25]byte
-//  MetadataContext map[string]string
+//   MethodKey       [16]byte
+//   Deadline        int64
+//   TraceContext    [25]byte
+//   MetadataContext map[string]string
 // }
 //
 // responseMessage:

--- a/internal/net/call/msg.go
+++ b/internal/net/call/msg.go
@@ -60,13 +60,19 @@ const currentVersion = initialVersion
 //    version  [4]byte
 //
 // requestMessage:
-//    headerLen         [4]byte       -- length of the encoded header
-//    header            [length]byte  -- encoded header information
-//      headerKey       [16]byte      -- fingerprint of method name
-//      deadline        [8]byte       -- zero, or deadline in microseconds
-//      traceContext    [25]byte      -- zero, or trace context
-//      metadataContext [length]byte  -- encoded map[string]string
-//    remainder                       -- call argument serialization
+//    headerLen         [4]byte         -- length of the encoded header
+//    header            [headerLen]byte -- encoded header information
+//    payload                           -- call argument serialization
+//
+// The header is encoded using Service Weaver's encoding format for a type that
+// looks like:
+//
+// struct header {
+//  MethodKey [16]byte
+//  Deadline  int64
+//  TraceContext [25]byte
+//  MetadataContext map[string]string
+// }
 //
 // responseMessage:
 //    payload holds call result serialization

--- a/internal/net/call/msg.go
+++ b/internal/net/call/msg.go
@@ -60,10 +60,13 @@ const currentVersion = initialVersion
 //    version  [4]byte
 //
 // requestMessage:
-//    headerKey    [16]byte   -- fingerprint of method name
-//    deadline      [8]byte   -- zero, or deadline in microseconds
-//    traceContext [25]byte   -- zero, or trace context
-//    remainder               -- call argument serialization
+//    headerLen         [4]byte       -- length of the encoded header
+//    header            [length]byte  -- encoded header information
+//      headerKey       [16]byte      -- fingerprint of method name
+//      deadline        [8]byte       -- zero, or deadline in microseconds
+//      traceContext    [25]byte      -- zero, or trace context
+//      metadataContext [length]byte  -- encoded map[string]string
+//    remainder                       -- call argument serialization
 //
 // responseMessage:
 //    payload holds call result serialization

--- a/internal/net/call/trace_test.go
+++ b/internal/net/call/trace_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/ServiceWeaver/weaver/runtime/codegen"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -36,14 +37,14 @@ func TestTraceSerialization(t *testing.T) {
 	})
 
 	// Serialize the trace context.
-	var b [25]byte
-	writeTraceContext(
-		trace.ContextWithSpanContext(context.Background(), span), b[:])
+	enc := codegen.NewEncoder()
+	writeTraceContext(trace.ContextWithSpanContext(context.Background(), span), enc)
 
 	// Deserialize the trace context.
-	actual := readTraceContext(b[:])
+	dec := codegen.NewDecoder(enc.Data())
+	actual := readTraceContext(dec)
 	expect := span.WithRemote(true)
-	if !expect.Equal(actual) {
+	if !expect.Equal(*actual) {
 		want, _ := json.Marshal(expect)
 		got, _ := json.Marshal(actual)
 		t.Errorf("span context diff, want %q, got %q", want, got)

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,0 +1,58 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metadata provides support for the propagation of metadata information
+// from a component method caller to the callee. The metadata is propagated to
+// the callee even if the caller and callee are not colocated in the same process.
+//
+// The metadata is a map from string to string stored in context.Context. The map
+// can be added to a context by calling NewContext.
+//
+// Example:
+//
+// To attach metadata with key "foo" and value "bar" to the context:
+//
+//	ctx := context.Background()
+//	ctx = metadata.NewContext(ctx, map[string]string{"foo": "bar"})
+//
+// To read the metadata value associated with a key "foo" in the context:
+//
+//	meta, found := metadata.FromContext(ctx)
+//	if found {
+//		  value := meta["foo"]
+//	}
+package metadata
+
+import (
+	"context"
+	"maps"
+)
+
+// metaKey is an unexported type for the key that stores the metadata.
+type metaKey struct{}
+
+// NewContext returns a new context that carries metadata meta.
+func NewContext(ctx context.Context, meta map[string]string) context.Context {
+	return context.WithValue(ctx, metaKey{}, meta)
+}
+
+// FromContext returns the metadata value stored in ctx, if any.
+func FromContext(ctx context.Context) (map[string]string, bool) {
+	meta, ok := ctx.Value(metaKey{}).(map[string]string)
+	if !ok {
+		return nil, false
+	}
+	out := maps.Clone(meta)
+	return out, true
+}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestContextMetadata(t *testing.T) {
+	type testCase struct {
+		name           string
+		meta           map[string]string
+		isMetaExpected bool
+		want           map[string]string
+	}
+	for _, test := range []testCase{
+		{
+			name: "no metadata",
+		},
+		{
+			name:           "with empty metadata",
+			meta:           map[string]string{},
+			isMetaExpected: false,
+		},
+		{
+			name: "with valid metadata",
+			meta: map[string]string{
+				"foo": "bar",
+				"baz": "waldo",
+			},
+			isMetaExpected: true,
+			want: map[string]string{
+				"foo": "bar",
+				"baz": "waldo",
+			},
+		},
+		{
+			name: "with valid metadata and uppercase keys",
+			meta: map[string]string{
+				"Foo": "bar",
+				"Baz": "waldo",
+			},
+			isMetaExpected: true,
+			want: map[string]string{
+				"Foo": "bar",
+				"Baz": "waldo",
+			},
+		},
+		{
+			name: "with valid metadata and uppercase values",
+			meta: map[string]string{
+				"Foo": "Bar",
+				"Baz": "Waldo",
+			},
+			isMetaExpected: true,
+			want: map[string]string{
+				"Foo": "Bar",
+				"Baz": "Waldo",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			if len(test.meta) > 0 {
+				ctx = NewContext(ctx, test.meta)
+			}
+
+			got, found := FromContext(ctx)
+			if !reflect.DeepEqual(found, test.isMetaExpected) {
+				t.Errorf("ExtractMetadata: expecting %v, got %v", test.isMetaExpected, found)
+			}
+			if !found {
+				return
+			}
+			if !reflect.DeepEqual(test.want, got) {
+				t.Errorf("ExtractMetadata: expecting %v, got %v", test.want, got)
+			}
+		})
+	}
+}

--- a/weavertest/internal/simple/simple.go
+++ b/weavertest/internal/simple/simple.go
@@ -22,12 +22,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"strings"
 	"sync"
 
 	"github.com/ServiceWeaver/weaver"
+	"github.com/ServiceWeaver/weaver/metadata"
 )
 
 //go:generate ../../../cmd/weaver/weaver generate
@@ -50,6 +52,8 @@ type Destination interface {
 	Record(_ context.Context, file, msg string) error
 	GetAll(_ context.Context, file string) ([]string, error)
 	RoutedRecord(_ context.Context, file, msg string) error
+	UpdateMetadata(_ context.Context) error
+	GetMetadata(_ context.Context) (map[string]string, error)
 }
 
 var (
@@ -67,7 +71,8 @@ func (r destRouter) RoutedRecord(_ context.Context, file, msg string) string {
 type destination struct {
 	weaver.Implements[Destination]
 	weaver.WithRouter[destRouter]
-	mu sync.Mutex
+	mu       sync.Mutex
+	metadata map[string]string
 }
 
 var pid = os.Getpid()
@@ -77,7 +82,7 @@ func (d *destination) Init(ctx context.Context) error {
 	return nil
 }
 
-func (d *destination) Getpid(_ context.Context) (int, error) {
+func (d *destination) Getpid(context.Context) (int, error) {
 	return pid, nil
 }
 
@@ -111,6 +116,22 @@ func (d *destination) GetAll(_ context.Context, file string) ([]string, error) {
 	}
 	str := strings.TrimSpace(string(data))
 	return strings.Split(str, "\n"), nil
+}
+
+func (d *destination) UpdateMetadata(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	meta, found := metadata.FromContext(ctx)
+	if found {
+		d.metadata = maps.Clone(meta)
+	}
+	return nil
+}
+
+func (d *destination) GetMetadata(_ context.Context) (map[string]string, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.metadata, nil
 }
 
 // Server is a component used to test Service Weaver listener handling.

--- a/weavertest/internal/simple/simple.go
+++ b/weavertest/internal/simple/simple.go
@@ -121,8 +121,7 @@ func (d *destination) GetAll(_ context.Context, file string) ([]string, error) {
 func (d *destination) UpdateMetadata(ctx context.Context) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	meta, found := metadata.FromContext(ctx)
-	if found {
+	if meta, found := metadata.FromContext(ctx); found {
 		d.metadata = maps.Clone(meta)
 	}
 	return nil

--- a/weavertest/internal/simple/weaver_gen.go
+++ b/weavertest/internal/simple/weaver_gen.go
@@ -19,12 +19,12 @@ func init() {
 		Iface:   reflect.TypeOf((*Destination)(nil)).Elem(),
 		Impl:    reflect.TypeOf(destination{}),
 		Routed:  true,
-		NoRetry: []int{2, 3},
+		NoRetry: []int{3, 4},
 		LocalStubFn: func(impl any, caller string, tracer trace.Tracer) any {
-			return destination_local_stub{impl: impl.(Destination), tracer: tracer, getAllMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "GetAll", Remote: false, Generated: true}), getpidMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Getpid", Remote: false, Generated: true}), recordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Record", Remote: false, Generated: true}), routedRecordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "RoutedRecord", Remote: false, Generated: true})}
+			return destination_local_stub{impl: impl.(Destination), tracer: tracer, getAllMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "GetAll", Remote: false, Generated: true}), getMetadataMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "GetMetadata", Remote: false, Generated: true}), getpidMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Getpid", Remote: false, Generated: true}), recordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Record", Remote: false, Generated: true}), routedRecordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "RoutedRecord", Remote: false, Generated: true}), updateMetadataMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "UpdateMetadata", Remote: false, Generated: true})}
 		},
 		ClientStubFn: func(stub codegen.Stub, caller string) any {
-			return destination_client_stub{stub: stub, getAllMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "GetAll", Remote: true, Generated: true}), getpidMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Getpid", Remote: true, Generated: true}), recordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Record", Remote: true, Generated: true}), routedRecordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "RoutedRecord", Remote: true, Generated: true})}
+			return destination_client_stub{stub: stub, getAllMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "GetAll", Remote: true, Generated: true}), getMetadataMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "GetMetadata", Remote: true, Generated: true}), getpidMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Getpid", Remote: true, Generated: true}), recordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "Record", Remote: true, Generated: true}), routedRecordMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "RoutedRecord", Remote: true, Generated: true}), updateMetadataMetrics: codegen.MethodMetricsFor(codegen.MethodLabels{Caller: caller, Component: "github.com/ServiceWeaver/weaver/weavertest/internal/simple/Destination", Method: "UpdateMetadata", Remote: true, Generated: true})}
 		},
 		ServerStubFn: func(impl any, addLoad func(uint64, float64)) codegen.Server {
 			return destination_server_stub{impl: impl.(Destination), addLoad: addLoad}
@@ -92,24 +92,30 @@ type __destination_destRouter_if_youre_seeing_this_you_probably_forgot_to_run_we
 
 type __destination_destRouter_embedding struct{}
 
-func (__destination_destRouter_embedding) GetAll() {}
-func (__destination_destRouter_embedding) Getpid() {}
-func (__destination_destRouter_embedding) Record() {}
+func (__destination_destRouter_embedding) GetAll()         {}
+func (__destination_destRouter_embedding) GetMetadata()    {}
+func (__destination_destRouter_embedding) Getpid()         {}
+func (__destination_destRouter_embedding) Record()         {}
+func (__destination_destRouter_embedding) UpdateMetadata() {}
 
-var _ func(_ context.Context, file string, msg string) string = (&destRouter{}).RoutedRecord                 // routed
-var _ = (&__destination_destRouter_if_youre_seeing_this_you_probably_forgot_to_run_weaver_generate{}).GetAll // unrouted
-var _ = (&__destination_destRouter_if_youre_seeing_this_you_probably_forgot_to_run_weaver_generate{}).Getpid // unrouted
-var _ = (&__destination_destRouter_if_youre_seeing_this_you_probably_forgot_to_run_weaver_generate{}).Record // unrouted
+var _ func(_ context.Context, file string, msg string) string = (&destRouter{}).RoutedRecord                         // routed
+var _ = (&__destination_destRouter_if_youre_seeing_this_you_probably_forgot_to_run_weaver_generate{}).GetAll         // unrouted
+var _ = (&__destination_destRouter_if_youre_seeing_this_you_probably_forgot_to_run_weaver_generate{}).GetMetadata    // unrouted
+var _ = (&__destination_destRouter_if_youre_seeing_this_you_probably_forgot_to_run_weaver_generate{}).Getpid         // unrouted
+var _ = (&__destination_destRouter_if_youre_seeing_this_you_probably_forgot_to_run_weaver_generate{}).Record         // unrouted
+var _ = (&__destination_destRouter_if_youre_seeing_this_you_probably_forgot_to_run_weaver_generate{}).UpdateMetadata // unrouted
 
 // Local stub implementations.
 
 type destination_local_stub struct {
-	impl                Destination
-	tracer              trace.Tracer
-	getAllMetrics       *codegen.MethodMetrics
-	getpidMetrics       *codegen.MethodMetrics
-	recordMetrics       *codegen.MethodMetrics
-	routedRecordMetrics *codegen.MethodMetrics
+	impl                  Destination
+	tracer                trace.Tracer
+	getAllMetrics         *codegen.MethodMetrics
+	getMetadataMetrics    *codegen.MethodMetrics
+	getpidMetrics         *codegen.MethodMetrics
+	recordMetrics         *codegen.MethodMetrics
+	routedRecordMetrics   *codegen.MethodMetrics
+	updateMetadataMetrics *codegen.MethodMetrics
 }
 
 // Check that destination_local_stub implements the Destination interface.
@@ -133,6 +139,26 @@ func (s destination_local_stub) GetAll(ctx context.Context, a0 string) (r0 []str
 	}
 
 	return s.impl.GetAll(ctx, a0)
+}
+
+func (s destination_local_stub) GetMetadata(ctx context.Context) (r0 map[string]string, err error) {
+	// Update metrics.
+	begin := s.getMetadataMetrics.Begin()
+	defer func() { s.getMetadataMetrics.End(begin, err != nil, 0, 0) }()
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "simple.Destination.GetMetadata", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.GetMetadata(ctx)
 }
 
 func (s destination_local_stub) Getpid(ctx context.Context) (r0 int, err error) {
@@ -193,6 +219,26 @@ func (s destination_local_stub) RoutedRecord(ctx context.Context, a0 string, a1 
 	}
 
 	return s.impl.RoutedRecord(ctx, a0, a1)
+}
+
+func (s destination_local_stub) UpdateMetadata(ctx context.Context) (err error) {
+	// Update metrics.
+	begin := s.updateMetadataMetrics.Begin()
+	defer func() { s.updateMetadataMetrics.End(begin, err != nil, 0, 0) }()
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.tracer.Start(ctx, "simple.Destination.UpdateMetadata", trace.WithSpanKind(trace.SpanKindInternal))
+		defer func() {
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+			span.End()
+		}()
+	}
+
+	return s.impl.UpdateMetadata(ctx)
 }
 
 type server_local_stub struct {
@@ -298,11 +344,13 @@ func (s source_local_stub) Emit(ctx context.Context, a0 string, a1 string) (err 
 // Client stub implementations.
 
 type destination_client_stub struct {
-	stub                codegen.Stub
-	getAllMetrics       *codegen.MethodMetrics
-	getpidMetrics       *codegen.MethodMetrics
-	recordMetrics       *codegen.MethodMetrics
-	routedRecordMetrics *codegen.MethodMetrics
+	stub                  codegen.Stub
+	getAllMetrics         *codegen.MethodMetrics
+	getMetadataMetrics    *codegen.MethodMetrics
+	getpidMetrics         *codegen.MethodMetrics
+	recordMetrics         *codegen.MethodMetrics
+	routedRecordMetrics   *codegen.MethodMetrics
+	updateMetadataMetrics *codegen.MethodMetrics
 }
 
 // Check that destination_client_stub implements the Destination interface.
@@ -364,6 +412,53 @@ func (s destination_client_stub) GetAll(ctx context.Context, a0 string) (r0 []st
 	return
 }
 
+func (s destination_client_stub) GetMetadata(ctx context.Context) (r0 map[string]string, err error) {
+	// Update metrics.
+	var requestBytes, replyBytes int
+	begin := s.getMetadataMetrics.Begin()
+	defer func() { s.getMetadataMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "simple.Destination.GetMetadata", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+			if err != nil {
+				err = errors.Join(weaver.RemoteCallError, err)
+			}
+		}
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+
+	}()
+
+	var shardKey uint64
+
+	// Call the remote method.
+	var results []byte
+	results, err = s.stub.Run(ctx, 1, nil, shardKey)
+	replyBytes = len(results)
+	if err != nil {
+		err = errors.Join(weaver.RemoteCallError, err)
+		return
+	}
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	r0 = serviceweaver_dec_map_string_string_219dd46d(dec)
+	err = dec.Error()
+	return
+}
+
 func (s destination_client_stub) Getpid(ctx context.Context) (r0 int, err error) {
 	// Update metrics.
 	var requestBytes, replyBytes int
@@ -397,7 +492,7 @@ func (s destination_client_stub) Getpid(ctx context.Context) (r0 int, err error)
 
 	// Call the remote method.
 	var results []byte
-	results, err = s.stub.Run(ctx, 1, nil, shardKey)
+	results, err = s.stub.Run(ctx, 2, nil, shardKey)
 	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
@@ -455,7 +550,7 @@ func (s destination_client_stub) Record(ctx context.Context, a0 string, a1 strin
 	// Call the remote method.
 	requestBytes = len(enc.Data())
 	var results []byte
-	results, err = s.stub.Run(ctx, 2, enc.Data(), shardKey)
+	results, err = s.stub.Run(ctx, 3, enc.Data(), shardKey)
 	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
@@ -515,7 +610,53 @@ func (s destination_client_stub) RoutedRecord(ctx context.Context, a0 string, a1
 	// Call the remote method.
 	requestBytes = len(enc.Data())
 	var results []byte
-	results, err = s.stub.Run(ctx, 3, enc.Data(), shardKey)
+	results, err = s.stub.Run(ctx, 4, enc.Data(), shardKey)
+	replyBytes = len(results)
+	if err != nil {
+		err = errors.Join(weaver.RemoteCallError, err)
+		return
+	}
+
+	// Decode the results.
+	dec := codegen.NewDecoder(results)
+	err = dec.Error()
+	return
+}
+
+func (s destination_client_stub) UpdateMetadata(ctx context.Context) (err error) {
+	// Update metrics.
+	var requestBytes, replyBytes int
+	begin := s.updateMetadataMetrics.Begin()
+	defer func() { s.updateMetadataMetrics.End(begin, err != nil, requestBytes, replyBytes) }()
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		// Create a child span for this method.
+		ctx, span = s.stub.Tracer().Start(ctx, "simple.Destination.UpdateMetadata", trace.WithSpanKind(trace.SpanKindClient))
+	}
+
+	defer func() {
+		// Catch and return any panics detected during encoding/decoding/rpc.
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+			if err != nil {
+				err = errors.Join(weaver.RemoteCallError, err)
+			}
+		}
+
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+
+	}()
+
+	var shardKey uint64
+
+	// Call the remote method.
+	var results []byte
+	results, err = s.stub.Run(ctx, 5, nil, shardKey)
 	replyBytes = len(results)
 	if err != nil {
 		err = errors.Join(weaver.RemoteCallError, err)
@@ -781,12 +922,16 @@ func (s destination_server_stub) GetStubFn(method string) func(ctx context.Conte
 	switch method {
 	case "GetAll":
 		return s.getAll
+	case "GetMetadata":
+		return s.getMetadata
 	case "Getpid":
 		return s.getpid
 	case "Record":
 		return s.record
 	case "RoutedRecord":
 		return s.routedRecord
+	case "UpdateMetadata":
+		return s.updateMetadata
 	default:
 		return nil
 	}
@@ -813,6 +958,26 @@ func (s destination_server_stub) getAll(ctx context.Context, args []byte) (res [
 	// Encode the results.
 	enc := codegen.NewEncoder()
 	serviceweaver_enc_slice_string_4af10117(enc, r0)
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
+
+func (s destination_server_stub) getMetadata(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	r0, appErr := s.impl.GetMetadata(ctx)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	serviceweaver_enc_map_string_string_219dd46d(enc, r0)
 	enc.Error(appErr)
 	return enc.Data(), nil
 }
@@ -884,6 +1049,25 @@ func (s destination_server_stub) routedRecord(ctx context.Context, args []byte) 
 	// user code: fix this.
 	// Call the local method.
 	appErr := s.impl.RoutedRecord(ctx, a0, a1)
+
+	// Encode the results.
+	enc := codegen.NewEncoder()
+	enc.Error(appErr)
+	return enc.Data(), nil
+}
+
+func (s destination_server_stub) updateMetadata(ctx context.Context, args []byte) (res []byte, err error) {
+	// Catch and return any panics detected during encoding/decoding/rpc.
+	defer func() {
+		if err == nil {
+			err = codegen.CatchPanics(recover())
+		}
+	}()
+
+	// TODO(rgrandl): The deferred function above will recover from panics in the
+	// user code: fix this.
+	// Call the local method.
+	appErr := s.impl.UpdateMetadata(ctx)
 
 	// Encode the results.
 	enc := codegen.NewEncoder()
@@ -1030,6 +1214,11 @@ func (s destination_reflect_stub) GetAll(ctx context.Context, a0 string) (r0 []s
 	return
 }
 
+func (s destination_reflect_stub) GetMetadata(ctx context.Context) (r0 map[string]string, err error) {
+	err = s.caller("GetMetadata", ctx, []any{}, []any{&r0})
+	return
+}
+
 func (s destination_reflect_stub) Getpid(ctx context.Context) (r0 int, err error) {
 	err = s.caller("Getpid", ctx, []any{}, []any{&r0})
 	return
@@ -1042,6 +1231,11 @@ func (s destination_reflect_stub) Record(ctx context.Context, a0 string, a1 stri
 
 func (s destination_reflect_stub) RoutedRecord(ctx context.Context, a0 string, a1 string) (err error) {
 	err = s.caller("RoutedRecord", ctx, []any{a0, a1}, []any{})
+	return
+}
+
+func (s destination_reflect_stub) UpdateMetadata(ctx context.Context) (err error) {
+	err = s.caller("UpdateMetadata", ctx, []any{}, []any{})
 	return
 }
 
@@ -1116,6 +1310,34 @@ func serviceweaver_dec_slice_string_4af10117(dec *codegen.Decoder) []string {
 	res := make([]string, n)
 	for i := 0; i < n; i++ {
 		res[i] = dec.String()
+	}
+	return res
+}
+
+func serviceweaver_enc_map_string_string_219dd46d(enc *codegen.Encoder, arg map[string]string) {
+	if arg == nil {
+		enc.Len(-1)
+		return
+	}
+	enc.Len(len(arg))
+	for k, v := range arg {
+		enc.String(k)
+		enc.String(v)
+	}
+}
+
+func serviceweaver_dec_map_string_string_219dd46d(dec *codegen.Decoder) map[string]string {
+	n := dec.Len()
+	if n == -1 {
+		return nil
+	}
+	res := make(map[string]string, n)
+	var k string
+	var v string
+	for i := 0; i < n; i++ {
+		k = dec.String()
+		v = dec.String()
+		res[k] = v
 	}
 	return res
 }


### PR DESCRIPTION
In the current implementation, weaver doesn't allow the user to propagate context information. We recommend users to define a struct that encapsulates the metadata information and add it as an argument to the method. However, more and more users are asking for an option to propagate metadata information using the context. This request comes especially from users that are using gRPC to communicate between their services, and gRPC provides a way to propagate metadata information using the context.

This PR implements a similar approach to gRPC [1] to propagate metadata information. We allow users to create a context where they can pass metadata as a `map[string][]string`.

E.g.,
```main.go
...
ctx := context.Background()
meta := metadata.New(map[string][]string{"name":{"foo", "bar"}})
ctx = metadata.NewContext(ctx, meta)

dst.Get().Update(ctx, ....)
```

```destination.go
...
func( d *destination) Update(ctx, ...) (error) {
  meta := metadata.FromContext(ctx)
  vals := meta.Get("name")

  // Can call another component method with an updated context
  meta.Set("account", "x", "y")
  ctx = metadata.NewContext(ctx, meta)
  acct.Get().UpdateAccount(ctx, ...)
}
```

The user APIs are as follows:
```api.go
// New creates a Metadata object that has operations
// to manipulate the metadata (e.g., Get, Set, Append, Delete.
func New(m map[string][]string) Metadata

// NewContext creates a new context that contains metadata meta, with
// parent context ctx.
func NewContext(ctx context.Context, meta Metadata) context.Context

// FromContext returns the metadata from the context. If the context
// doesn't have any metata, it returns an empty metadata.
func FromContext(ctx context.Context) Metadata
```

Note that similar to the gRPC metadata, we make sure the metadata keys are lowercased, because the user can create metadata w/o using our New() metadata constructor, hence they can set the keys however they want.

[1] https://pkg.go.dev/google.golang.org/grpc/metadata