### PR TITLE
Fix traffic graph

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/go/bin/staticcheck
-          key: staticcheck-v0.4.6
+          key: staticcheck-v0.5.0
         if: ${{ matrix.command == 'lint' }}
 
       - name: Install linter

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -85,7 +85,7 @@ jobs:
         if: ${{ matrix.command == 'lint' }}
 
       - name: Install linter
-        run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.6
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.5.0
         if: ${{ matrix.command == 'lint' }}
 
       - name: Build the weaver binary

--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -165,7 +165,7 @@ func run(deployer string, args []string) (int, error) {
 	binary := "weaver-" + deployer
 	if _, err := exec.LookPath(binary); err != nil {
 		msg := fmt.Sprintf(`"weaver %s" is not a weaver command. See "weaver --help". If you're trying to invoke a custom deployer, the %q binary was not found. You may need to install the %q binary or add it to your PATH.`, deployer, binary, binary)
-		return 1, fmt.Errorf(wrap(msg, 80))
+		return 1, fmt.Errorf("%s", wrap(msg, 80))
 	}
 	cmd := exec.Command(binary, args...)
 	cmd.Stdin = os.Stdin

--- a/dev/build_and_test
+++ b/dev/build_and_test
@@ -54,7 +54,7 @@ function cmd_vet() {
 
 function cmd_lint() {
   if ! exists staticcheck; then
-    printf "staticcheck not found; install via\ngo install honnef.co/go/tools/cmd/staticcheck@v0.4.6\n" >&2
+    printf "staticcheck not found; install via\ngo install honnef.co/go/tools/cmd/staticcheck@v0.5.0\n" >&2
     exit 1
   fi
 

--- a/godeps.txt
+++ b/godeps.txt
@@ -386,6 +386,7 @@ github.com/ServiceWeaver/weaver/internal/status
     errors
     flag
     fmt
+    github.com/ServiceWeaver/weaver/internal/control
     github.com/ServiceWeaver/weaver/internal/files
     github.com/ServiceWeaver/weaver/internal/metrics
     github.com/ServiceWeaver/weaver/internal/traceio

--- a/internal/net/call/stub_test.go
+++ b/internal/net/call/stub_test.go
@@ -188,7 +188,7 @@ func TestErrorArgsNotEncoded(t *testing.T) {
 	})
 
 	if !strings.Contains(err.Error(), "decoder: unable to read") {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 }
 

--- a/runtime/codegen/encoder_test.go
+++ b/runtime/codegen/encoder_test.go
@@ -144,7 +144,7 @@ func TestErrorDecUnableToRead(t *testing.T) {
 		dec.Bool()
 	})
 	if !strings.Contains(err.Error(), "unable to read #bytes") {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 }
 
@@ -160,7 +160,7 @@ func TestErrorUnableToDecBool(t *testing.T) {
 		dec.Bool()
 	})
 	if !strings.Contains(err.Error(), "unable to decode bool") {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 }
 
@@ -176,7 +176,7 @@ func TestErrorUnableToDecBytes(t *testing.T) {
 		dec.Bytes()
 	})
 	if !strings.Contains(err.Error(), "unable to decode bytes; expected length") {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 }
 


### PR DESCRIPTION
After we introduced system components (weavelet control and deployment control), the traffic graph doesn't display anything in the weaver multi dashboard.

This is because when we display the graph, we look at the components of the application and then we try to match them to the traffic between them. However, the edges show traffic for components that are missing from the status (e.g., the system components). Hence, when we display the graph there is no 1:1 mapping between components and the traffic between them.

This PR fixes this issue by not displaying traffic for system components (in fact the user shouldn't care about that). Maybe a better fix would be to do this in the javascript itself, but we can do that in the future if needed.