### PR TITLE
Add build tags support

### DIFF
--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -74,25 +74,19 @@ func main() {
 	switch flag.Arg(0) {
 	case "generate":
 		generateFlags := flag.NewFlagSet("generate", flag.ExitOnError)
-		tags := generateFlags.String("tags", "not specified", "Optional tags for the generate command")
+		tags := generateFlags.String("tags", "", "Optional tags for the generate command")
 		generateFlags.Usage = func() {
 			fmt.Fprintln(os.Stderr, generate.Usage)
 		}
 		generateFlags.Parse(flag.Args()[1:])
-		buildTags := "--tags=ignoreWeaverGen"
-		if *tags != "not specified" { // tags flag was specified
-			if *tags == "" || *tags == "." {
-				// User specified the tags flag but didn't provide any tags.
-				fmt.Fprintln(os.Stderr, "No tags provided.")
-				os.Exit(1)
-			}
+		buildTags := "ignoreWeaverGen"
+		if *tags != "" { // tags flag was specified
 			// TODO(rgrandl): we assume that the user specify the tags properly. I.e.,
 			// a single tag, or a list of tags separated by comma. We may want to do
 			// extra validation at some point.
 			buildTags = buildTags + "," + *tags
 		}
-		idx := len(flag.Args()) - len(generateFlags.Args())
-		if err := generate.Generate(".", flag.Args()[idx:], generate.Options{BuildTags: buildTags}); err != nil {
+		if err := generate.Generate(".", generateFlags.Args(), generate.Options{BuildTags: buildTags}); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}

--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -74,11 +74,25 @@ func main() {
 	switch flag.Arg(0) {
 	case "generate":
 		generateFlags := flag.NewFlagSet("generate", flag.ExitOnError)
+		tags := generateFlags.String("tags", "not specified", "Optional tags for the generate command")
 		generateFlags.Usage = func() {
 			fmt.Fprintln(os.Stderr, generate.Usage)
 		}
 		generateFlags.Parse(flag.Args()[1:])
-		if err := generate.Generate(".", flag.Args()[1:], generate.Options{}); err != nil {
+		buildTags := "--tags=ignoreWeaverGen"
+		if *tags != "not specified" { // tags flag was specified
+			if *tags == "" || *tags == "." {
+				// User specified the tags flag but didn't provide any tags.
+				fmt.Fprintln(os.Stderr, "No tags provided.")
+				os.Exit(1)
+			}
+			// TODO(rgrandl): we assume that the user specify the tags properly. I.e.,
+			// a single tag, or a list of tags separated by comma. We may want to do
+			// extra validation at some point.
+			buildTags = buildTags + "," + *tags
+		}
+		idx := len(flag.Args()) - len(generateFlags.Args())
+		if err := generate.Generate(".", flag.Args()[idx:], generate.Options{BuildTags: buildTags}); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}

--- a/internal/tool/generate/generator.go
+++ b/internal/tool/generate/generator.go
@@ -54,7 +54,7 @@ const (
 	Usage = `Generate code for a Service Weaver application.
 
 Usage:
-  weaver generate [tags] [packages]
+  weaver generate [-tags taglist] [packages]
 
 Description:
   "weaver generate" generates code for the Service Weaver applications in the
@@ -121,7 +121,7 @@ func Generate(dir string, pkgs []string, opt Options) error {
 		ParseFile: parseNonWeaverGenFile,
 	}
 	if len(opt.BuildTags) > 0 {
-		cfg.BuildFlags = []string{opt.BuildTags}
+		cfg.BuildFlags = []string{"-tags", opt.BuildTags}
 	}
 	pkgList, err := packages.Load(cfg, pkgs...)
 	if err != nil {

--- a/internal/tool/generate/generator_test.go
+++ b/internal/tool/generate/generator_test.go
@@ -136,12 +136,7 @@ func runGenerator(t *testing.T, directory, filename, contents string, subdirs []
 	if err := tidy.Run(); err != nil {
 		t.Fatalf("go mod tidy: %v", err)
 	}
-
-	var buildTagsArg string
-	if len(buildTags) > 0 {
-		buildTagsArg = "-tags=" + strings.Join(buildTags, ",")
-	}
-	gobuild := exec.Command("go", "build", buildTagsArg)
+	gobuild := exec.Command("go", "build", "-tags="+opt.BuildTags)
 	gobuild.Dir = tmp
 	gobuild.Stdout = os.Stdout
 	gobuild.Stderr = os.Stderr
@@ -225,7 +220,7 @@ func TestGenerator(t *testing.T) {
 			}
 
 			// Run "weaver generate".
-			output, err := runGenerator(t, dir, filename, contents, []string{"sub1", "sub2"}, []string{})
+			output, err := runGenerator(t, dir, filename, contents, []string{"sub1", "sub2"}, nil)
 			if err != nil {
 				t.Fatalf("error running generator: %v", err)
 			}
@@ -268,7 +263,7 @@ func TestGeneratorBuildWithTags(t *testing.T) {
 			}
 			contents := string(bits)
 			// Run "weaver generate".
-			output, err := runGenerator(t, dir, filename, contents, []string{}, []string{"good"})
+			output, err := runGenerator(t, dir, filename, contents, nil, []string{"good"})
 
 			if filename == "good.go" {
 				// Verify that the error is nil and the weaver_gen.go contains generated code for the good service.
@@ -334,7 +329,7 @@ func TestGeneratorErrors(t *testing.T) {
 			}
 
 			// Run "weaver generate".
-			output, err := runGenerator(t, dir, filename, contents, []string{}, []string{})
+			output, err := runGenerator(t, dir, filename, contents, nil, nil)
 			errfile := strings.TrimSuffix(filename, ".go") + "_error.txt"
 			if err == nil {
 				os.Remove(filepath.Join(dir, errfile))

--- a/internal/tool/generate/generator_test.go
+++ b/internal/tool/generate/generator_test.go
@@ -103,7 +103,7 @@ func runGenerator(t *testing.T, directory, filename, contents string, subdirs []
 	// Run "weaver generate".
 	opt := Options{
 		Warn:      func(err error) { t.Log(err) },
-		BuildTags: "--tags=ignoreWeaverGen",
+		BuildTags: "ignoreWeaverGen",
 	}
 	if err := Generate(tmp, []string{tmp}, opt); err != nil {
 		return "", err
@@ -295,7 +295,7 @@ func TestGeneratorBuildWithTags(t *testing.T) {
 	// Run the "weaver generate" command with the build tag "good". Verify that the
 	// command succeeds because the bad.go file is ignored, and the weaver_gen.go
 	// contains only generated code for the good.go.
-	err = Generate(tmp, []string{tmp}, Options{Warn: func(err error) { t.Log(err) }, BuildTags: "--tags=good"})
+	err = Generate(tmp, []string{tmp}, Options{Warn: func(err error) { t.Log(err) }, BuildTags: "good"})
 	if err != nil {
 		t.Fatalf("unexpected generator error: %v", err)
 	}

--- a/internal/tool/generate/testdata/tags/bad.go
+++ b/internal/tool/generate/testdata/tags/bad.go
@@ -1,0 +1,36 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !good
+
+package tags
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ServiceWeaver/weaver"
+)
+
+type BadService interface {
+	DoSomething(context.Context) error
+}
+
+type badServiceImpl struct {
+	weaver.Implements[BadService]
+}
+
+func (b *badServiceImpl) DoSomething(context.Context) error {
+	Some code that does not compile
+}

--- a/internal/tool/generate/testdata/tags/good.go
+++ b/internal/tool/generate/testdata/tags/good.go
@@ -1,0 +1,37 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build good
+
+package tags
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ServiceWeaver/weaver"
+)
+
+type GoodService interface {
+	DoSomething(context.Context) error
+}
+
+type goodServiceImpl struct {
+	weaver.Implements[GoodService]
+}
+
+func (g *goodServiceImpl) DoSomething(context.Context) error {
+	fmt.Println("Hello world!")
+	return nil
+}


### PR DESCRIPTION
`go build` allows the user to specify build tags. These tags enable the user to discard files based on various tags when they build the application binary.

`weaver generate` which is a wrapper around `go build` doesn't allow the user to specify build tags.

This PR adds built tags support for the `weaver generate` command.

The syntax of passing build tags to the `weaver generate` command is similar to how build tags are specified when using `go build`.

E.g.,

weaver generate -tags good,prod
weaver generate --tags=good